### PR TITLE
Adopt jiff, improve MS-PSRP CLI XML parsing, and align rustfmt rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+This file is guidance for AI/code agents working in this repository.
+
+## Scope
+
+- Make minimal, targeted changes.
+- Prefer root-cause fixes over superficial edits.
+- Avoid unrelated refactors.
+
+## Baseline
+
+- .NET SDK pinned in `global.json` (currently `8.0.418`).
+- .NET target framework is `net8.0` in `dotnet/Bindings.csproj`.
+- Rust crate uses edition 2018.
+
+## Required verification
+
+Run these after meaningful code changes:
+
+```powershell
+cargo build --all-targets
+cargo test --all-targets
+dotnet build pwsh-host-rs.sln
+dotnet test pwsh-host-rs.sln --no-build
+```
+
+If dependency changes are made in `dotnet/Bindings.csproj`, also run:
+
+```powershell
+dotnet list dotnet/Bindings.csproj package --vulnerable --include-transitive
+```
+
+## Project map
+
+- `src/bindings.rs`: Rust FFI surface over .NET unmanaged entry points.
+- `dotnet/Bindings.cs`: Unmanaged-callable C# methods around `System.Management.Automation.PowerShell`.
+- `src/cli_xml.rs`: CLIXML parsing helpers.
+- `src/tests.rs`: behavior and integration tests used as usage references.
+
+## Editing conventions
+
+- Preserve existing style and naming.
+- Do not introduce new dependencies unless needed.
+- Keep patches small and cohesive.
+- Update docs if behavior or baseline changes.
+
+## Operational notes
+
+- Tests and runtime behavior expect `pwsh` to be resolvable from `PATH`.
+- For .NET 8 compatibility with current PowerShell SDK dependency chain, `UseRidGraph` is intentionally enabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ quick-error = "2.0"
 quick-xml = "0.26"
 decimal = { version = "2.1", default-features = false }
 which = { version = "3.0", default-features = false, features = [] }
-time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
-iso8601-duration = "0.1"
+jiff = "0.2"
 base64 = "0.13"
 uuid = "1.2"
 url = "2.3"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# pwsh-host-rs
+
+Rust PowerShell hosting library that loads .NET delegates and drives `System.Management.Automation.PowerShell` through unmanaged entry points.
+
+## What this repository contains
+
+- A Rust crate (`pwsh-host`) that loads and invokes PowerShell hosting delegates.
+- A .NET bindings project (`dotnet/Bindings.csproj`) exposing `[UnmanagedCallersOnly]` methods consumed by Rust.
+- Parsing and conversion helpers for PowerShell CLIXML output.
+
+## Baseline and toolchain
+
+- .NET SDK is pinned via `global.json` to **8.0.418**.
+- .NET project target framework: **net8.0**.
+- Rust crate edition: **2018**.
+- Primary OS target in current setup: **Windows**.
+
+## Prerequisites
+
+- Rust toolchain (`cargo`, `rustc`)
+- .NET SDK 8.0.418 (or update `global.json` intentionally)
+- PowerShell 7+ (`pwsh`) available in `PATH`
+
+## Build
+
+```powershell
+cargo build --all-targets
+dotnet build pwsh-host-rs.sln
+```
+
+## Test
+
+```powershell
+cargo test --all-targets
+dotnet test pwsh-host-rs.sln --no-build
+```
+
+## Typical Rust usage (from tests)
+
+```rust
+use pwsh_host::bindings::PowerShell;
+
+let pwsh = PowerShell::new().unwrap();
+pwsh.add_command("Get-Date");
+pwsh.add_parameter_long("-UnixTimeSeconds", 1577836800);
+pwsh.add_command("Set-Variable");
+pwsh.add_parameter_string("-Name", "Date");
+pwsh.add_statement();
+pwsh.invoke(true);
+
+let date_json = pwsh.export_to_json("Date");
+assert_eq!(date_json, "\"2019-12-31T19:00:00-05:00\"");
+```
+
+## Repository layout
+
+- `src/` – Rust host, delegate loading, CLIXML parsing, tests
+- `dotnet/` – .NET unmanaged-callable bindings
+- `global.json` – pinned .NET SDK version
+- `pwsh-host-rs.sln` – .NET solution for bindings
+
+## Notes
+
+- The .NET bindings package currently uses `Microsoft.PowerShell.SDK` `7.2.24` for compatibility with this repository’s interop layer.
+- `dotnet/Bindings.csproj` enables `UseRidGraph` to keep runtime-identifier compatibility under .NET 8.

--- a/dotnet/Bindings.csproj
+++ b/dotnet/Bindings.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
+    <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.0" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.24" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.418",
+    "allowPrerelease": false,
+    "rollForward": "disable"
+  }
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+reorder_imports = true
+imports_granularity = "Module"
+max_width = 120
+group_imports = "StdExternalCrate"

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,11 +1,12 @@
 #![allow(dead_code)]
 
+use std::ffi::{CStr, CString};
+
 use crate::delegate_loader::{AssemblyDelegateLoader, MethodWithUnknownSignature};
 use crate::error::Error;
 use crate::loader::get_assembly_delegate_loader;
 use crate::pdcstr;
 use crate::pdcstring::{PdCStr, PdCString};
-use std::ffi::{CStr, CString};
 
 pub type PowerShellHandle = *mut libc::c_void;
 
@@ -14,11 +15,8 @@ pub type FnPowerShellCreate = unsafe extern "system" fn() -> PowerShellHandle;
 pub type FnPowerShellAddArgumentString =
     unsafe extern "system" fn(handle: PowerShellHandle, argument: *const libc::c_char);
 
-pub type FnPowerShellAddParameterString = unsafe extern "system" fn(
-    handle: PowerShellHandle,
-    name: *const libc::c_char,
-    value: *const libc::c_char,
-);
+pub type FnPowerShellAddParameterString =
+    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: *const libc::c_char);
 
 pub type FnPowerShellAddParameterInt =
     unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: i32);
@@ -26,33 +24,24 @@ pub type FnPowerShellAddParameterInt =
 pub type FnPowerShellAddParameterLong =
     unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: i64);
 
-pub type FnPowerShellAddCommand =
-    unsafe extern "system" fn(handle: PowerShellHandle, command: *const libc::c_char);
+pub type FnPowerShellAddCommand = unsafe extern "system" fn(handle: PowerShellHandle, command: *const libc::c_char);
 
-pub type FnPowerShellAddScript =
-    unsafe extern "system" fn(handle: PowerShellHandle, script: *const libc::c_char);
+pub type FnPowerShellAddScript = unsafe extern "system" fn(handle: PowerShellHandle, script: *const libc::c_char);
 
-pub type FnPowerShellAddStatement =
-    unsafe extern "system" fn(handle: PowerShellHandle) -> PowerShellHandle;
+pub type FnPowerShellAddStatement = unsafe extern "system" fn(handle: PowerShellHandle) -> PowerShellHandle;
 
 pub type FnPowerShellInvoke = unsafe extern "system" fn(handle: PowerShellHandle);
 
 pub type FnPowerShellClear = unsafe extern "system" fn(handle: PowerShellHandle);
 
-pub type FnPowerShellExportToXml = unsafe extern "system" fn(
-    handle: PowerShellHandle,
-    name: *const libc::c_char,
-) -> *const libc::c_char;
+pub type FnPowerShellExportToXml =
+    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnPowerShellExportToJson = unsafe extern "system" fn(
-    handle: PowerShellHandle,
-    name: *const libc::c_char,
-) -> *const libc::c_char;
+pub type FnPowerShellExportToJson =
+    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnPowerShellExportToString = unsafe extern "system" fn(
-    handle: PowerShellHandle,
-    name: *const libc::c_char,
-) -> *const libc::c_char;
+pub type FnPowerShellExportToString =
+    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
 
 pub type FnMarshalFreeCoTaskMem = unsafe extern "system" fn(ptr: *mut libc::c_void);
 
@@ -232,11 +221,7 @@ impl PowerShell {
         let name_cstr = CString::new(name).unwrap();
         let value_cstr = CString::new(value).unwrap();
         unsafe {
-            (self.inner.add_parameter_string_fn)(
-                self.handle,
-                name_cstr.as_ptr(),
-                value_cstr.as_ptr(),
-            );
+            (self.inner.add_parameter_string_fn)(self.handle, name_cstr.as_ptr(), value_cstr.as_ptr());
         }
     }
 

--- a/src/cli_xml.rs
+++ b/src/cli_xml.rs
@@ -6,6 +6,7 @@ use decimal::d128;
 use quick_xml::events;
 use quick_xml::events::Event;
 use quick_xml::reader::Reader;
+use std::collections::HashMap;
 use std::time::Duration;
 use url::Url;
 use uuid::Uuid;
@@ -1032,7 +1033,54 @@ fn try_get_ref_id_attr<B>(reader: &Reader<B>, event: &events::BytesStart) -> Opt
 fn try_get_name_attr<B>(reader: &Reader<B>, event: &events::BytesStart) -> Option<String> {
     let attr = event.try_get_attribute("N").ok().unwrap()?;
     let value = attr.decode_and_unescape_value(&reader).ok()?;
-    Some(value.to_string())
+    Some(decode_psrp_string(&value))
+}
+
+fn push_value(stack: &mut Vec<CliObject>, value: CliValue) {
+    if let Some(current_obj) = stack.last_mut() {
+        current_obj.values.push(value);
+    }
+}
+
+fn push_object(stack: &mut Vec<CliObject>, objs: &mut Vec<CliObject>, obj: CliObject) {
+    if let Some(parent_obj) = stack.last_mut() {
+        parent_obj.values.push(CliValue::CliObject(obj));
+    } else {
+        objs.push(obj);
+    }
+}
+
+fn decode_psrp_string(value: &str) -> String {
+    let mut utf16_units: Vec<u16> = Vec::new();
+    let bytes = value.as_bytes();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        let is_escape = index + 6 < bytes.len()
+            && bytes[index] == b'_'
+            && matches!(bytes[index + 1], b'x' | b'X')
+            && bytes[index + 2].is_ascii_hexdigit()
+            && bytes[index + 3].is_ascii_hexdigit()
+            && bytes[index + 4].is_ascii_hexdigit()
+            && bytes[index + 5].is_ascii_hexdigit()
+            && bytes[index + 6] == b'_';
+
+        if is_escape {
+            if let Ok(hex_value) = u16::from_str_radix(&value[index + 2..index + 6], 16) {
+                utf16_units.push(hex_value);
+                index += 7;
+                continue;
+            }
+        }
+
+        let next_char = value[index..].chars().next().unwrap();
+        let mut units = [0u16; 2];
+        let encoded = next_char.encode_utf16(&mut units);
+        utf16_units.extend_from_slice(encoded);
+        index += next_char.len_utf8();
+    }
+
+    String::from_utf16_lossy(&utf16_units)
 }
 
 pub fn parse_cli_xml(cli_xml: &str) -> Vec<CliObject> {
@@ -1041,7 +1089,10 @@ pub fn parse_cli_xml(cli_xml: &str) -> Vec<CliObject> {
     reader.trim_text(true);
 
     let mut objs: Vec<CliObject> = Vec::new();
-    let mut obj = CliObject::default();
+    let mut object_stack: Vec<CliObject> = Vec::new();
+    let mut object_refs: HashMap<String, CliObject> = HashMap::new();
+    let mut type_refs: HashMap<String, Vec<String>> = HashMap::new();
+    let mut current_type_names: Option<(Option<String>, Vec<String>)> = None;
 
     loop {
         let event = reader.read_event();
@@ -1050,27 +1101,46 @@ pub fn parse_cli_xml(cli_xml: &str) -> Vec<CliObject> {
                 match event.name().as_ref() {
                     b"Objs" => {}
                     b"Obj" => {
+                        let mut obj = CliObject::default();
+                        obj.name = try_get_name_attr(&reader, &event);
+                        obj.ref_id = try_get_ref_id_attr(&reader, &event);
+                        object_stack.push(obj);
+                    }
+                    b"Ref" => {
                         if let Some(ref_id) = try_get_ref_id_attr(&reader, &event) {
-                            obj.ref_id = Some(ref_id);
+                            if let Some(target_obj) = object_refs.get(&ref_id) {
+                                let mut target_obj = target_obj.clone();
+                                if let Some(name) = try_get_name_attr(&reader, &event) {
+                                    target_obj.name = Some(name);
+                                }
+                                push_object(&mut object_stack, &mut objs, target_obj);
+                            }
                         }
                     }
                     b"TN" => {
-                        if let Some(_ref_id) = try_get_ref_id_attr(&reader, &event) {
-                            //println!("TN RefId={}", ref_id);
-                        }
+                        let ref_id = try_get_ref_id_attr(&reader, &event);
+                        current_type_names = Some((ref_id, Vec::new()));
                     }
                     b"T" => {
                         let txt = reader.read_text(event.name()).unwrap();
-                        obj.type_names.push(txt.to_string());
+                        if let Some((_ref_id, names)) = current_type_names.as_mut() {
+                            names.push(decode_psrp_string(&txt));
+                        }
                     }
                     b"TNRef" => {
-                        if let Some(_ref_id) = try_get_ref_id_attr(&reader, &event) {
-                            //println!("TNRef RefId={}", ref_id);
+                        if let Some(ref_id) = try_get_ref_id_attr(&reader, &event) {
+                            if let Some(type_names) = type_refs.get(&ref_id) {
+                                if let Some(current_obj) = object_stack.last_mut() {
+                                    current_obj.type_names = type_names.clone();
+                                }
+                            }
                         }
                     }
                     b"ToString" => {
                         let txt = reader.read_text(event.name()).unwrap();
-                        obj.string_repr = Some(txt.to_string());
+                        if let Some(current_obj) = object_stack.last_mut() {
+                            current_obj.string_repr = Some(decode_psrp_string(&txt));
+                        }
                     }
                     b"Props" => {
                         // Adapted Properties
@@ -1082,142 +1152,146 @@ pub fn parse_cli_xml(cli_xml: &str) -> Vec<CliObject> {
                     }
                     b"LST" => {}
                     b"IE" => {}
+                    b"STK" => {}
+                    b"QUE" => {}
+                    b"DCT" => {}
+                    b"En" => {}
                     b"B" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliBool::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliBool(val));
+                        push_value(&mut object_stack, CliValue::CliBool(val));
                     }
                     b"S" => {
-                        let txt = reader.read_text(event.name()).unwrap();
+                        let txt = decode_psrp_string(&reader.read_text(event.name()).unwrap());
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliString::new(prop_name.as_deref(), &txt);
-                        obj.values.push(CliValue::CliString(val));
+                        push_value(&mut object_stack, CliValue::CliString(val));
                     }
                     b"C" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliChar::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliChar(val));
+                        push_value(&mut object_stack, CliValue::CliChar(val));
                     }
                     b"By" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliUInt8::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliUInt8(val));
+                        push_value(&mut object_stack, CliValue::CliUInt8(val));
                     }
                     b"SB" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliInt8::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliInt8(val));
+                        push_value(&mut object_stack, CliValue::CliInt8(val));
                     }
                     b"U16" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliUInt16::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliUInt16(val));
+                        push_value(&mut object_stack, CliValue::CliUInt16(val));
                     }
                     b"I16" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliInt16::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliInt16(val));
+                        push_value(&mut object_stack, CliValue::CliInt16(val));
                     }
                     b"U32" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliUInt32::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliUInt32(val));
+                        push_value(&mut object_stack, CliValue::CliUInt32(val));
                     }
                     b"I32" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliInt32::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliInt32(val));
+                        push_value(&mut object_stack, CliValue::CliInt32(val));
                     }
                     b"U64" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliUInt64::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliUInt64(val));
+                        push_value(&mut object_stack, CliValue::CliUInt64(val));
                     }
                     b"I64" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliInt64::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliInt64(val));
+                        push_value(&mut object_stack, CliValue::CliInt64(val));
                     }
                     b"DT" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliDateTime::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliDateTime(val));
+                        push_value(&mut object_stack, CliValue::CliDateTime(val));
                     }
                     b"TS" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliDuration::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliDuration(val));
+                        push_value(&mut object_stack, CliValue::CliDuration(val));
                     }
                     b"Sg" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliFloat::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliFloat(val));
+                        push_value(&mut object_stack, CliValue::CliFloat(val));
                     }
                     b"Db" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliDouble::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliDouble(val));
+                        push_value(&mut object_stack, CliValue::CliDouble(val));
                     }
                     b"D" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliDecimal::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliDecimal(val));
+                        push_value(&mut object_stack, CliValue::CliDecimal(val));
                     }
                     b"BA" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliBuffer::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliBuffer(val));
+                        push_value(&mut object_stack, CliValue::CliBuffer(val));
                     }
                     b"G" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliGuid::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliGuid(val));
+                        push_value(&mut object_stack, CliValue::CliGuid(val));
                     }
                     b"URI" => {
-                        let txt = reader.read_text(event.name()).unwrap();
+                        let txt = decode_psrp_string(&reader.read_text(event.name()).unwrap());
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliUri::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliUri(val));
+                        push_value(&mut object_stack, CliValue::CliUri(val));
                     }
                     b"Version" => {
                         let txt = reader.read_text(event.name()).unwrap();
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliVersion::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliVersion(val));
+                        push_value(&mut object_stack, CliValue::CliVersion(val));
                     }
                     b"XD" => {
-                        let txt = reader.read_text(event.name()).unwrap();
+                        let txt = decode_psrp_string(&reader.read_text(event.name()).unwrap());
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliXmlDocument::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliXmlDocument(val));
+                        push_value(&mut object_stack, CliValue::CliXmlDocument(val));
                     }
                     b"SBK" => {
-                        let txt = reader.read_text(event.name()).unwrap();
+                        let txt = decode_psrp_string(&reader.read_text(event.name()).unwrap());
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliScriptBlock::new_from_str(prop_name.as_deref(), &txt).unwrap();
-                        obj.values.push(CliValue::CliScriptBlock(val));
+                        push_value(&mut object_stack, CliValue::CliScriptBlock(val));
                     }
                     b"Nil" => {
                         let prop_name = try_get_name_attr(&reader, &event);
                         let val = CliNull::new(prop_name.as_deref());
-                        obj.values.push(CliValue::CliNull(val));
+                        push_value(&mut object_stack, CliValue::CliNull(val));
                     }
                     _ => {
                         let event_name = event.name();
@@ -1227,9 +1301,23 @@ pub fn parse_cli_xml(cli_xml: &str) -> Vec<CliObject> {
                 }
             }
             Ok(Event::End(event)) => match event.name().as_ref() {
+                b"TN" => {
+                    if let Some((ref_id, type_names)) = current_type_names.take() {
+                        if let Some(current_obj) = object_stack.last_mut() {
+                            current_obj.type_names = type_names.clone();
+                        }
+                        if let Some(ref_id) = ref_id {
+                            type_refs.insert(ref_id, type_names);
+                        }
+                    }
+                }
                 b"Obj" => {
-                    objs.push(obj);
-                    obj = CliObject::default();
+                    if let Some(current_obj) = object_stack.pop() {
+                        if let Some(ref_id) = current_obj.ref_id.clone() {
+                            object_refs.insert(ref_id, current_obj.clone());
+                        }
+                        push_object(&mut object_stack, &mut objs, current_obj);
+                    }
                 }
                 _ => {}
             },

--- a/src/cli_xml.rs
+++ b/src/cli_xml.rs
@@ -1,15 +1,16 @@
 #![allow(dead_code)]
 
-use crate::time::parse_iso8601_duration;
-use crate::time::DateTime;
+use std::collections::HashMap;
+use std::time::Duration;
+
 use decimal::d128;
 use quick_xml::events;
 use quick_xml::events::Event;
 use quick_xml::reader::Reader;
-use std::collections::HashMap;
-use std::time::Duration;
 use url::Url;
 use uuid::Uuid;
+
+use crate::time::{parse_iso8601_duration, DateTime};
 
 // [MS-PSRP]: PowerShell Remoting Protocol
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp
@@ -1323,11 +1324,7 @@ pub fn parse_cli_xml(cli_xml: &str) -> Vec<CliObject> {
             },
             Ok(Event::Text(_event)) => {}
             Ok(Event::Eof) => break,
-            Err(event) => panic!(
-                "Error at position {}: {:?}",
-                reader.buffer_position(),
-                event
-            ),
+            Err(event) => panic!("Error at position {}: {:?}", reader.buffer_position(), event),
             _ => (),
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,14 +1,15 @@
+use core::{mem, ptr};
+use std::borrow::BorrowMut;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
 use crate::delegate_loader::{AssemblyDelegateLoader, DelegateLoader, MethodWithUnknownSignature};
 use crate::error::Error;
 use crate::host_exit_code::HostExitCode;
 use crate::hostfxr::{
-    GetFunctionPointerFn, Hostfxr, HostfxrDelegateType, Hostfxrhandle,
-    LoadAssemblyAndGetFunctionPointerFn,
+    GetFunctionPointerFn, Hostfxr, HostfxrDelegateType, Hostfxrhandle, LoadAssemblyAndGetFunctionPointerFn,
 };
 use crate::pdcstring::PdCStr;
-use core::{mem, ptr};
-use std::borrow::BorrowMut;
-use std::{marker::PhantomData, ptr::NonNull};
 
 /// A marker struct indicating that the context was initialized for the dotnet command line.
 /// This means that it is possible to run the application associated with the context.
@@ -85,8 +86,7 @@ impl<'a, I> HostfxrContext<'a, I> {
     #[allow(dead_code)]
     pub fn get_delegate_loader(&self) -> Result<DelegateLoader, Error> {
         Ok(DelegateLoader {
-            get_load_assembly_and_get_function_pointer: self
-                .get_load_assembly_and_get_function_pointer_delegate()?,
+            get_load_assembly_and_get_function_pointer: self.get_load_assembly_and_get_function_pointer_delegate()?,
             get_function_pointer: self.get_get_function_pointer_delegate()?,
         })
     }

--- a/src/delegate_loader.rs
+++ b/src/delegate_loader.rs
@@ -1,12 +1,12 @@
+use core::ptr;
+use std::borrow::BorrowMut;
+
 use crate::error::Error;
 use crate::host_exit_code::HostExitCode;
 use crate::hostfxr::{
-    char_t, GetFunctionPointerFn, LoadAssemblyAndGetFunctionPointerFn,
-    UNMANAGED_CALLERS_ONLY_METHOD,
+    char_t, GetFunctionPointerFn, LoadAssemblyAndGetFunctionPointerFn, UNMANAGED_CALLERS_ONLY_METHOD,
 };
 use crate::pdcstring::PdCStr;
-use core::ptr;
-use std::borrow::BorrowMut;
 
 #[derive(Copy, Clone)]
 pub struct DelegateLoader {
@@ -132,10 +132,7 @@ pub struct AssemblyDelegateLoader<A: AsRef<PdCStr>> {
 
 impl<A: AsRef<PdCStr>> AssemblyDelegateLoader<A> {
     pub fn new(loader: DelegateLoader, assembly_path: A) -> Self {
-        Self {
-            loader,
-            assembly_path,
-        }
+        Self { loader, assembly_path }
     }
 
     #[allow(dead_code)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
-use crate::host_exit_code::HostExitCode;
 use std::io;
+
+use crate::host_exit_code::HostExitCode;
 
 quick_error! {
     /// An error struct encompassing all possible errors of this crate.

--- a/src/host_detect.rs
+++ b/src/host_detect.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
+
 use thiserror::Error;
 
 #[allow(dead_code)]

--- a/src/host_exit_code.rs
+++ b/src/host_exit_code.rs
@@ -1,9 +1,9 @@
-use crate::error::Error;
+use std::convert::{TryFrom, TryInto};
+use std::num::TryFromIntError;
+
 use num_enum::TryFromPrimitive;
-use std::{
-    convert::{TryFrom, TryInto},
-    num::TryFromIntError,
-};
+
+use crate::error::Error;
 /// The special error or exit codes for hostfxr operations.
 ///
 /// Source: [https://github.com/dotnet/runtime/blob/main/docs/design/features/host-error-codes.md](https://github.com/dotnet/runtime/blob/main/docs/design/features/host-error-codes.md)

--- a/src/hostfxr.rs
+++ b/src/hostfxr.rs
@@ -116,7 +116,7 @@ impl Hostfxr {
     pub fn initialize_for_dotnet_command_line(
         &self,
         pwsh_path: impl AsRef<OsStr>,
-    ) -> Result<HostfxrContext<InitializedForCommandLine>, Box<dyn std::error::Error>> {
+    ) -> Result<HostfxrContext<'_, InitializedForCommandLine>, Box<dyn std::error::Error>> {
         use crate::host_exit_code::HostExitCode;
         use std::ptr;
 

--- a/src/hostfxr.rs
+++ b/src/hostfxr.rs
@@ -1,9 +1,11 @@
+use std::borrow::BorrowMut;
+use std::ffi::OsStr;
+
+use dlopen::wrapper::{Container, WrapperApi};
+
 use crate::context::{HostfxrContext, HostfxrHandle, InitializedForCommandLine};
 use crate::host_detect::pwsh_host_detect;
 use crate::pdcstring::{PdCStr, PdCString};
-use dlopen::wrapper::{Container, WrapperApi};
-use std::borrow::BorrowMut;
-use std::ffi::OsStr;
 
 #[cfg(windows)]
 #[allow(non_camel_case_types)]
@@ -50,16 +52,10 @@ pub struct HostfxrLib {
         parameters: *const HostfxrInitializeParameters,
         host_context_handle: *mut Hostfxrhandle,
     ) -> i32,
-    hostfxr_get_runtime_property_value: unsafe extern "C" fn(
-        host_context_handle: Hostfxrhandle,
-        name: *const char_t,
-        value: *mut *const char_t,
-    ) -> i32,
-    hostfxr_set_runtime_property_value: unsafe extern "C" fn(
-        host_context_handle: Hostfxrhandle,
-        name: *const char_t,
-        value: *const char_t,
-    ) -> i32,
+    hostfxr_get_runtime_property_value:
+        unsafe extern "C" fn(host_context_handle: Hostfxrhandle, name: *const char_t, value: *mut *const char_t) -> i32,
+    hostfxr_set_runtime_property_value:
+        unsafe extern "C" fn(host_context_handle: Hostfxrhandle, name: *const char_t, value: *const char_t) -> i32,
     hostfxr_get_runtime_properties: unsafe extern "C" fn(
         host_context_handle: Hostfxrhandle,
         count: *mut libc::size_t,
@@ -117,8 +113,9 @@ impl Hostfxr {
         &self,
         pwsh_path: impl AsRef<OsStr>,
     ) -> Result<HostfxrContext<'_, InitializedForCommandLine>, Box<dyn std::error::Error>> {
-        use crate::host_exit_code::HostExitCode;
         use std::ptr;
+
+        use crate::host_exit_code::HostExitCode;
 
         let args = &[PdCString::from_os_str(pwsh_path)?];
         let mut host_context_handle = ptr::null::<Hostfxrhandle>() as Hostfxrhandle;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -20,11 +20,7 @@ pub fn get_assembly_delegate_loader() -> AssemblyDelegateLoader<PdCString> {
     assert!(ctx.is_ok());
     let ctx = ctx.unwrap();
 
-    let assembly_path = PdCString::from_os_str(
-        pwsh_path
-            .join("System.Management.Automation.dll")
-            .into_os_string(),
-    );
+    let assembly_path = PdCString::from_os_str(pwsh_path.join("System.Management.Automation.dll").into_os_string());
     assert!(assembly_path.is_ok());
     let assembly_path = assembly_path.unwrap();
 
@@ -34,16 +30,14 @@ pub fn get_assembly_delegate_loader() -> AssemblyDelegateLoader<PdCString> {
 
     let load_assembly_from_native_memory = fn_loader.get_function_pointer_for_unmanaged_callers_only_method(
         pdcstr!("System.Management.Automation.PowerShellUnsafeAssemblyLoad, System.Management.Automation"),
-    pdcstr!("LoadAssemblyFromNativeMemory"));
+        pdcstr!("LoadAssemblyFromNativeMemory"),
+    );
     assert!(load_assembly_from_native_memory.is_ok());
     let load_assembly_from_native_memory = load_assembly_from_native_memory.unwrap();
 
-    let load_assembly_from_native_memory: extern "system" fn(
-        bytes: *const libc::c_uchar,
-        size: libc::c_uint,
-    ) -> i32 = unsafe { std::mem::transmute(load_assembly_from_native_memory) };
-    let result =
-        (load_assembly_from_native_memory)(BINDINGS_DLL.as_ptr(), BINDINGS_DLL.len() as u32);
+    let load_assembly_from_native_memory: extern "system" fn(bytes: *const libc::c_uchar, size: libc::c_uint) -> i32 =
+        unsafe { std::mem::transmute(load_assembly_from_native_memory) };
+    let result = (load_assembly_from_native_memory)(BINDINGS_DLL.as_ptr(), BINDINGS_DLL.len() as u32);
     HostExitCode::from(result).into_result().unwrap();
 
     fn_loader

--- a/src/pdcstring/error.rs
+++ b/src/pdcstring/error.rs
@@ -1,5 +1,7 @@
+use std::error::Error;
+use std::fmt;
+
 use super::PdUChar;
-use std::{error::Error, fmt};
 
 // same definition as ffi::NulError and widestring::NulError<u16>
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/src/pdcstring/shared.rs
+++ b/src/pdcstring/shared.rs
@@ -1,11 +1,10 @@
+use std::borrow::Borrow;
+use std::convert::TryFrom;
+use std::fmt::{self, Debug, Display, Formatter};
+use std::ops::Deref;
+use std::str::FromStr;
+
 use super::{NulError, PdCStrInner, PdCStringInner, PdUChar};
-use std::{
-    borrow::Borrow,
-    convert::TryFrom,
-    fmt::{self, Debug, Display, Formatter},
-    ops::Deref,
-    str::FromStr,
-};
 
 /// A platform-dependent c-like string type for interacting with the hostfxr API.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]

--- a/src/pdcstring/windows.rs
+++ b/src/pdcstring/windows.rs
@@ -1,8 +1,10 @@
-use super::{NulError, PdCStr, PdCString};
 use std::ffi::{OsStr, OsString};
 use std::str::FromStr;
 use std::string;
+
 use widestring::{U16CStr, U16CString};
+
+use super::{NulError, PdCStr, PdCString};
 
 pub type PdCStringInner = U16CString;
 pub type PdCStrInner = U16CStr;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod pwsh {
+    use uuid::Uuid;
+
     use crate::bindings::PowerShell;
     use crate::cli_xml::{parse_cli_xml, CliObject};
-    use uuid::Uuid;
 
     #[test]
     fn load_pwsh_sdk_invoke_api() {
@@ -55,12 +56,9 @@ mod pwsh {
 
         let verb_xml = pwsh.export_to_xml("Verb");
         println!("\nVerb (XML):\n{}", &verb_xml);
-        assert!(verb_xml.starts_with(
-            "<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\">"
-        ));
         assert!(verb_xml
-            .find("<T>System.Management.Automation.VerbInfo</T>")
-            .is_some());
+            .starts_with("<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\">"));
+        assert!(verb_xml.find("<T>System.Management.Automation.VerbInfo</T>").is_some());
         assert!(verb_xml
             .find("<ToString>System.Management.Automation.VerbInfo</ToString>")
             .is_some());
@@ -230,10 +228,7 @@ mod pwsh {
 
         let script_block_prop = obj.values.get(21).unwrap();
         assert!(script_block_prop.is_script_block());
-        assert_eq!(
-            script_block_prop.as_script_block(),
-            Some("Get-Command -Type Cmdlet")
-        );
+        assert_eq!(script_block_prop.as_script_block(), Some("Get-Command -Type Cmdlet"));
 
         let null_prop = obj.values.get(22).unwrap();
         assert!(null_prop.is_null());
@@ -278,9 +273,7 @@ mod pwsh {
         assert_eq!(vmid_prop.get_name(), Some("VMId"));
         assert_eq!(
             vmid_prop.as_guid(),
-            Uuid::parse_str("fbac8867-40ca-4032-a8e0-901c7f004cd7")
-                .ok()
-                .as_ref()
+            Uuid::parse_str("fbac8867-40ca-4032-a8e0-901c7f004cd7").ok().as_ref()
         );
 
         let vmname_prop = vm_obj.values.get(1).unwrap();
@@ -400,9 +393,9 @@ mod pwsh {
         let _objs: Vec<CliObject> = parse_cli_xml(cmd_xml);
     }
 
-        #[test]
-        fn test_cli_xml_refs_containers_and_psrp_encoding() {
-                let xml = r#"<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    #[test]
+    fn test_cli_xml_refs_containers_and_psrp_encoding() {
+        let xml = r#"<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
     <Obj RefId="0">
         <TN RefId="10">
             <T>System.Management.Automation.PSCustomObject</T>
@@ -434,41 +427,41 @@ mod pwsh {
     </Obj>
 </Objs>"#;
 
-                let objs: Vec<CliObject> = parse_cli_xml(xml);
-                assert_eq!(objs.len(), 2);
+        let objs: Vec<CliObject> = parse_cli_xml(xml);
+        assert_eq!(objs.len(), 2);
 
-                let first = objs.get(0).unwrap();
-                assert_eq!(first.type_names.len(), 2);
+        let first = objs.get(0).unwrap();
+        assert_eq!(first.type_names.len(), 2);
 
-                let second = objs.get(1).unwrap();
-                assert_eq!(second.type_names, first.type_names);
+        let second = objs.get(1).unwrap();
+        assert_eq!(second.type_names, first.type_names);
 
-                let copy = second.values.get(0).unwrap();
-                assert!(copy.is_object());
-                let copy_obj = copy.as_object().unwrap();
-                assert_eq!(copy_obj.name.as_deref(), Some("Copy"));
+        let copy = second.values.get(0).unwrap();
+        assert!(copy.is_object());
+        let copy_obj = copy.as_object().unwrap();
+        assert_eq!(copy_obj.name.as_deref(), Some("Copy"));
 
-                let msg = copy_obj.values.get(0).unwrap();
-                assert!(msg.is_string());
-                assert_eq!(msg.get_name(), Some("Message"));
-                assert_eq!(msg.as_str(), Some("Line1\nLine2"));
+        let msg = copy_obj.values.get(0).unwrap();
+        assert!(msg.is_string());
+        assert_eq!(msg.get_name(), Some("Message"));
+        assert_eq!(msg.as_str(), Some("Line1\nLine2"));
 
-                let items = second.values.get(1).unwrap();
-                assert!(items.is_object());
-                let items_obj = items.as_object().unwrap();
-                assert_eq!(items_obj.name.as_deref(), Some("Items"));
-                assert_eq!(items_obj.values.len(), 2);
-                assert_eq!(items_obj.values.get(0).unwrap().as_str(), Some("one"));
-                assert_eq!(items_obj.values.get(1).unwrap().as_str(), Some("two"));
+        let items = second.values.get(1).unwrap();
+        assert!(items.is_object());
+        let items_obj = items.as_object().unwrap();
+        assert_eq!(items_obj.name.as_deref(), Some("Items"));
+        assert_eq!(items_obj.values.len(), 2);
+        assert_eq!(items_obj.values.get(0).unwrap().as_str(), Some("one"));
+        assert_eq!(items_obj.values.get(1).unwrap().as_str(), Some("two"));
 
-                let map = second.values.get(2).unwrap();
-                assert!(map.is_object());
-                let map_obj = map.as_object().unwrap();
-                assert_eq!(map_obj.name.as_deref(), Some("Map"));
-                assert_eq!(map_obj.values.len(), 2);
-                assert_eq!(map_obj.values.get(0).unwrap().get_name(), Some("Key"));
-                assert_eq!(map_obj.values.get(0).unwrap().as_str(), Some("Order_x0020_"));
-                assert_eq!(map_obj.values.get(1).unwrap().get_name(), Some("Value"));
-                assert_eq!(map_obj.values.get(1).unwrap().as_i32(), Some(7));
-        }
+        let map = second.values.get(2).unwrap();
+        assert!(map.is_object());
+        let map_obj = map.as_object().unwrap();
+        assert_eq!(map_obj.name.as_deref(), Some("Map"));
+        assert_eq!(map_obj.values.len(), 2);
+        assert_eq!(map_obj.values.get(0).unwrap().get_name(), Some("Key"));
+        assert_eq!(map_obj.values.get(0).unwrap().as_str(), Some("Order_x0020_"));
+        assert_eq!(map_obj.values.get(1).unwrap().get_name(), Some("Value"));
+        assert_eq!(map_obj.values.get(1).unwrap().as_i32(), Some(7));
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -399,4 +399,76 @@ mod pwsh {
 
         let _objs: Vec<CliObject> = parse_cli_xml(cmd_xml);
     }
+
+        #[test]
+        fn test_cli_xml_refs_containers_and_psrp_encoding() {
+                let xml = r#"<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="10">
+            <T>System.Management.Automation.PSCustomObject</T>
+            <T>System.Object</T>
+        </TN>
+        <MS>
+            <S N="Message">Line1_x000A_Line2</S>
+        </MS>
+    </Obj>
+    <Obj RefId="1">
+        <TNRef RefId="10" />
+        <MS>
+            <Ref N="Copy" RefId="0" />
+            <Obj N="Items" RefId="2">
+                <LST>
+                    <S>one</S>
+                    <S>two</S>
+                </LST>
+            </Obj>
+            <Obj N="Map" RefId="3">
+                <DCT>
+                    <En>
+                        <S N="Key">Order_x005f_x0020_</S>
+                        <I32 N="Value">7</I32>
+                    </En>
+                </DCT>
+            </Obj>
+        </MS>
+    </Obj>
+</Objs>"#;
+
+                let objs: Vec<CliObject> = parse_cli_xml(xml);
+                assert_eq!(objs.len(), 2);
+
+                let first = objs.get(0).unwrap();
+                assert_eq!(first.type_names.len(), 2);
+
+                let second = objs.get(1).unwrap();
+                assert_eq!(second.type_names, first.type_names);
+
+                let copy = second.values.get(0).unwrap();
+                assert!(copy.is_object());
+                let copy_obj = copy.as_object().unwrap();
+                assert_eq!(copy_obj.name.as_deref(), Some("Copy"));
+
+                let msg = copy_obj.values.get(0).unwrap();
+                assert!(msg.is_string());
+                assert_eq!(msg.get_name(), Some("Message"));
+                assert_eq!(msg.as_str(), Some("Line1\nLine2"));
+
+                let items = second.values.get(1).unwrap();
+                assert!(items.is_object());
+                let items_obj = items.as_object().unwrap();
+                assert_eq!(items_obj.name.as_deref(), Some("Items"));
+                assert_eq!(items_obj.values.len(), 2);
+                assert_eq!(items_obj.values.get(0).unwrap().as_str(), Some("one"));
+                assert_eq!(items_obj.values.get(1).unwrap().as_str(), Some("two"));
+
+                let map = second.values.get(2).unwrap();
+                assert!(map.is_object());
+                let map_obj = map.as_object().unwrap();
+                assert_eq!(map_obj.name.as_deref(), Some("Map"));
+                assert_eq!(map_obj.values.len(), 2);
+                assert_eq!(map_obj.values.get(0).unwrap().get_name(), Some("Key"));
+                assert_eq!(map_obj.values.get(0).unwrap().as_str(), Some("Order_x0020_"));
+                assert_eq!(map_obj.values.get(1).unwrap().get_name(), Some("Value"));
+                assert_eq!(map_obj.values.get(1).unwrap().as_i32(), Some(7));
+        }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,7 +5,7 @@ pub struct DateTime {
     inner: String,
 }
 
-#[allow(dead_code)] 
+#[allow(dead_code)]
 impl DateTime {
     pub fn parse(input: &str) -> Option<Self> {
         if input.parse::<jiff::Timestamp>().is_ok() {
@@ -54,16 +54,12 @@ fn normalize_offset_datetime(input: &str) -> String {
 
 #[cfg(test)]
 mod pwsh {
-    use crate::time::parse_iso8601_duration;
-    use crate::time::DateTime;
+    use crate::time::{parse_iso8601_duration, DateTime};
 
     #[test]
     fn parse_duration() {
         // 0 seconds
-        assert_eq!(
-            parse_iso8601_duration("PT0S"),
-            Some(std::time::Duration::new(0, 0))
-        );
+        assert_eq!(parse_iso8601_duration("PT0S"), Some(std::time::Duration::new(0, 0)));
 
         // 9 seconds, 26.9026 milliseconds
         assert_eq!(

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,47 +1,55 @@
-use time::format_description::well_known::Iso8601;
-use time::macros::{date, time, format_description};
-use time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
+use jiff::fmt::temporal::SpanParser;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DateTime {
-    inner: OffsetDateTime,
+    inner: String,
 }
 
 #[allow(dead_code)] 
 impl DateTime {
     pub fn parse(input: &str) -> Option<Self> {
-        // Try parsing as OffsetDateTime (with timezone)
-        if let Ok(inner) = OffsetDateTime::parse(input, &Iso8601::DEFAULT) {
-            return Some(Self { inner });
+        if input.parse::<jiff::Timestamp>().is_ok() {
+            return Some(Self {
+                inner: normalize_offset_datetime(input),
+            });
         }
-        
-        // If parsing without timezone, assume UTC (Offset +00:00)
-        let format = format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond]");
-        if let Ok(primitive) = PrimitiveDateTime::parse(input, &format) {
-            let inner = primitive.assume_offset(UtcOffset::UTC);
-            return Some(Self { inner });
+
+        if input.parse::<jiff::civil::DateTime>().is_ok() {
+            return Some(Self {
+                inner: format!("{}+00:00", input),
+            });
         }
 
         None
     }
 
     pub fn format(&self) -> String {
-        let format = format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:7][offset_hour sign:mandatory]:[offset_minute]");
-        self.inner.format(&format).unwrap()
+        self.inner.clone()
     }
 }
 
 impl Default for DateTime {
     fn default() -> Self {
-        let inner = OffsetDateTime::new_utc(date!(2000 - 01 - 01), time!(0:00));
-        DateTime { inner: inner }
+        DateTime {
+            inner: "2000-01-01T00:00:00.0000000+00:00".to_string(),
+        }
     }
 }
 
 pub fn parse_iso8601_duration(input: &str) -> Option<std::time::Duration> {
-    iso8601_duration::Duration::parse(input)
-        .ok()
-        .map(|x| x.to_std())
+    static PARSER: SpanParser = SpanParser::new();
+
+    PARSER.parse_unsigned_duration(input).ok()
+}
+
+fn normalize_offset_datetime(input: &str) -> String {
+    if let Some(without_zulu) = input.strip_suffix('Z') {
+        return format!("{}+00:00", without_zulu);
+    }
+    if let Some(without_zulu) = input.strip_suffix('z') {
+        return format!("{}+00:00", without_zulu);
+    }
+    input.to_string()
 }
 
 #[cfg(test)]
@@ -60,7 +68,7 @@ mod pwsh {
         // 9 seconds, 26.9026 milliseconds
         assert_eq!(
             parse_iso8601_duration("PT9.0269026S"),
-            Some(std::time::Duration::from_secs_f32(9.0269026))
+            Some(std::time::Duration::new(9, 26_902_600))
         );
     }
 


### PR DESCRIPTION
## Summary
- Replaces legacy time/duration parsing with `jiff` and updates duration precision expectations.
- Expands CLI XML parsing toward MS-PSRP behavior: nested object handling, `RefId`/`Ref` resolution, `TN`/`TNRef` reuse, container tag support, and PSRP `_xHHHH_` decoding.
- Imports Rust formatting rules from Devolutions Gateway and applies formatting.

## Key Changes
- Dependency updates in `Cargo.toml`
- Time parsing migration in `src/time.rs`
- CLI XML parser enhancements in `src/cli_xml.rs`
- Regression coverage in `src/tests.rs`
- Added `rustfmt.toml` from Devolutions Gateway

## Validation
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build pwsh-host-rs.sln`
- `dotnet test pwsh-host-rs.sln --no-build`