### PR TITLE
Add multi-pwsh uninstall and make release builds size-optimized

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to build/publish (for example v0.1.0)
+        description: Release tag to build/publish (for example v0.4.0)
         required: true
         type: string
 
@@ -22,38 +22,50 @@ jobs:
           - name: linux-x64
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            archive: pwsh-host-linux-x64.zip
-            binary: pwsh-host
+            host_archive: pwsh-host-linux-x64.zip
+            host_binary: pwsh-host
+            multi_archive: pwsh-multi-linux-x64.zip
+            multi_binary: multi-pwsh
 
           - name: linux-arm64
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            archive: pwsh-host-linux-arm64.zip
-            binary: pwsh-host
+            host_archive: pwsh-host-linux-arm64.zip
+            host_binary: pwsh-host
+            multi_archive: pwsh-multi-linux-arm64.zip
+            multi_binary: multi-pwsh
 
           - name: windows-x64
             os: windows-latest
             target: x86_64-pc-windows-msvc
-            archive: pwsh-host-windows-x64.zip
-            binary: pwsh-host.exe
+            host_archive: pwsh-host-windows-x64.zip
+            host_binary: pwsh-host.exe
+            multi_archive: pwsh-multi-windows-x64.zip
+            multi_binary: multi-pwsh.exe
 
           - name: windows-arm64
             os: windows-latest
             target: aarch64-pc-windows-msvc
-            archive: pwsh-host-windows-arm64.zip
-            binary: pwsh-host.exe
+            host_archive: pwsh-host-windows-arm64.zip
+            host_binary: pwsh-host.exe
+            multi_archive: pwsh-multi-windows-arm64.zip
+            multi_binary: multi-pwsh.exe
 
           - name: macos-x64
             os: macos-14
             target: x86_64-apple-darwin
-            archive: pwsh-host-macos-x64.zip
-            binary: pwsh-host
+            host_archive: pwsh-host-macos-x64.zip
+            host_binary: pwsh-host
+            multi_archive: pwsh-multi-macos-x64.zip
+            multi_binary: multi-pwsh
 
           - name: macos-arm64
             os: macos-14
             target: aarch64-apple-darwin
-            archive: pwsh-host-macos-arm64.zip
-            binary: pwsh-host
+            host_archive: pwsh-host-macos-arm64.zip
+            host_binary: pwsh-host
+            multi_archive: pwsh-multi-macos-arm64.zip
+            multi_binary: multi-pwsh
 
     steps:
       - name: Checkout
@@ -90,54 +102,72 @@ jobs:
         run: |
           "RUSTFLAGS=-C target-feature=+crt-static" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Build binary
+      - name: Build binaries
         shell: pwsh
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: |
           cargo build --locked --release --package pwsh-host-cli --bin pwsh-host --target "${{ matrix.target }}"
+          cargo build --locked --release --package multi-pwsh --bin multi-pwsh --target "${{ matrix.target }}"
 
-      - name: Package artifact
+      - name: Package artifacts
         shell: pwsh
         env:
           TARGET: ${{ matrix.target }}
-          BIN_NAME: ${{ matrix.binary }}
-          ARCHIVE_NAME: ${{ matrix.archive }}
+          HOST_BIN_NAME: ${{ matrix.host_binary }}
+          HOST_ARCHIVE_NAME: ${{ matrix.host_archive }}
+          MULTI_BIN_NAME: ${{ matrix.multi_binary }}
+          MULTI_ARCHIVE_NAME: ${{ matrix.multi_archive }}
         run: |
           $target = $env:TARGET
-          $binName = $env:BIN_NAME
-          $archiveName = $env:ARCHIVE_NAME
-
-          $binaryPath = [System.IO.Path]::Combine("target", $target, "release", $binName)
-          if (-not (Test-Path -Path $binaryPath)) {
-            throw "Binary not found: $binaryPath"
-          }
-
-          if (Test-Path -Path $archiveName) {
-            Remove-Item -Path $archiveName -Force
-          }
-
           Add-Type -AssemblyName System.IO.Compression.FileSystem
-          $archive = [System.IO.Compression.ZipFile]::Open($archiveName, [System.IO.Compression.ZipArchiveMode]::Create)
-          try {
-            [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
-              $archive,
-              $binaryPath,
-              $binName,
-              [System.IO.Compression.CompressionLevel]::Optimal
-            ) | Out-Null
-          }
-          finally {
-            $archive.Dispose()
+
+          function New-BinaryArchive {
+            param(
+              [string]$BinaryName,
+              [string]$ArchiveName
+            )
+
+            $binaryPath = [System.IO.Path]::Combine("target", $target, "release", $BinaryName)
+            if (-not (Test-Path -Path $binaryPath)) {
+              throw "Binary not found: $binaryPath"
+            }
+
+            if (Test-Path -Path $ArchiveName) {
+              Remove-Item -Path $ArchiveName -Force
+            }
+
+            $archive = [System.IO.Compression.ZipFile]::Open($ArchiveName, [System.IO.Compression.ZipArchiveMode]::Create)
+            try {
+              [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+                $archive,
+                $binaryPath,
+                $BinaryName,
+                [System.IO.Compression.CompressionLevel]::Optimal
+              ) | Out-Null
+            }
+            finally {
+              $archive.Dispose()
+            }
+
+            Write-Host "Created $ArchiveName"
           }
 
-          Write-Host "Created $archiveName"
+          New-BinaryArchive -BinaryName $env:HOST_BIN_NAME -ArchiveName $env:HOST_ARCHIVE_NAME
+          New-BinaryArchive -BinaryName $env:MULTI_BIN_NAME -ArchiveName $env:MULTI_ARCHIVE_NAME
 
-      - name: Upload packaged artifact
+      - name: Upload pwsh-host artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.archive }}
-          path: ${{ matrix.archive }}
+          name: ${{ matrix.host_archive }}
+          path: ${{ matrix.host_archive }}
+          if-no-files-found: error
+
+      - name: Upload pwsh-multi artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.multi_archive }}
+          path: ${{ matrix.multi_archive }}
           if-no-files-found: error
 
   publish:
@@ -165,7 +195,8 @@ jobs:
         shell: pwsh
         working-directory: dist
         run: |
-          $zipFiles = Get-ChildItem -Recurse -File -Filter 'pwsh-host-*.zip' |
+          $zipFiles = Get-ChildItem -Recurse -File |
+            Where-Object { $_.Name -like 'pwsh-host-*.zip' -or $_.Name -like 'pwsh-multi-*.zip' } |
             Sort-Object Name
 
           if (-not $zipFiles) {
@@ -190,7 +221,8 @@ jobs:
           RELEASE_TAG: ${{ github.event.inputs.tag }}
           RELEASE_TARGET: ${{ github.sha }}
         run: |
-          $zipFiles = Get-ChildItem -Path dist -Recurse -File -Filter 'pwsh-host-*.zip' |
+          $zipFiles = Get-ChildItem -Path dist -Recurse -File |
+            Where-Object { $_.Name -like 'pwsh-host-*.zip' -or $_.Name -like 'pwsh-multi-*.zip' } |
             Sort-Object Name |
             ForEach-Object { $_.FullName }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,23 @@ This file is guidance for AI/code agents working in this repository.
 
 ## Baseline
 
-- .NET SDK pinned in `global.json` (currently `8.0.418`).
+- .NET SDK pinned in `global.json` (currently `8.0.400` with `latestPatch` roll-forward).
 - .NET target framework is `net8.0` in `dotnet/Bindings.csproj`.
 - Rust crate uses edition 2018.
+
+## Pre-PR checklist (match CI lint job)
+
+Run these before opening a PR to avoid lint failures:
+
+```powershell
+rustup toolchain install stable --profile minimal
+rustup default stable
+rustup component add rustfmt clippy --toolchain stable
+cargo fmt --all --check
+cargo clippy --workspace --all-targets
+```
+
+If `cargo fmt --all --check` fails, run `cargo fmt --all` and re-run the check.
 
 ## Required verification
 
@@ -21,8 +35,8 @@ Run these after meaningful code changes:
 ```powershell
 cargo build --all-targets
 cargo test --all-targets
-dotnet build pwsh-host-rs.sln
-dotnet test pwsh-host-rs.sln --no-build
+dotnet build dotnet/Bindings.csproj
+dotnet test dotnet/Bindings.csproj --no-build
 ```
 
 If dependency changes are made in `dotnet/Bindings.csproj`, also run:
@@ -48,4 +62,11 @@ dotnet list dotnet/Bindings.csproj package --vulnerable --include-transitive
 ## Operational notes
 
 - Tests and runtime behavior expect `pwsh` to be resolvable from `PATH`.
+- CI installs PowerShell `stable`/`lts` (7.4.x) and that matches `Discover-Bindings.ps1` requirements.
+- If your default `pwsh` is not 7.4.x, set `PwshExePath` before verification commands, for example:
+
+```powershell
+$env:PwshExePath = "$HOME/.pwsh/bin/pwsh-7.4"
+```
+
 - For .NET 8 compatibility with current PowerShell SDK dependency chain, `UseRidGraph` is intentionally enabled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,10 +33,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -49,6 +73,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "cstr"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,7 +119,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a8ab77e91baeb15034c3be91e87bff4665c9036216148e4996d9a9f5792114d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "libc",
 ]
@@ -110,10 +165,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -125,10 +223,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "icu_collections"
@@ -212,6 +358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,8 +391,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
@@ -254,7 +414,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -300,10 +460,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -322,6 +505,32 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "multi-pwsh"
+version = "0.4.0"
+dependencies = [
+ "flate2",
+ "home",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "ureq",
+ "zip",
+]
 
 [[package]]
 name = "num_enum"
@@ -349,6 +558,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "percent-encoding"
@@ -381,6 +596,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,7 +621,7 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -410,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",
@@ -433,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host-cli"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "pwsh-host",
@@ -473,10 +698,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.4",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -485,6 +847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -508,10 +871,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "smallvec"
@@ -526,6 +908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,7 +921,7 @@ checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "unicode-xid",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -567,6 +955,30 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.44",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -639,6 +1051,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +1104,30 @@ checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -712,6 +1176,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wchar"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +1227,24 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.44",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -776,12 +1292,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -793,10 +1382,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid 0.2.6",
+ "wasmparser",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"
@@ -843,6 +1530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,3 +1567,21 @@ dependencies = [
  "quote 1.0.44",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ members = ["crates/pwsh-host", "crates/pwsh-host-cli", "crates/multi-pwsh"]
 default-members = ["crates/pwsh-host", "crates/pwsh-host-cli", "crates/multi-pwsh"]
 
 [profile.release]
-lto = "thin"
+opt-level = "z"
+lto = "fat"
 codegen-units = 1
+panic = "abort"
 strip = "symbols"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
-members = ["crates/pwsh-host", "crates/pwsh-host-cli"]
-default-members = ["crates/pwsh-host", "crates/pwsh-host-cli"]
+members = ["crates/pwsh-host", "crates/pwsh-host-cli", "crates/multi-pwsh"]
+default-members = ["crates/pwsh-host", "crates/pwsh-host-cli", "crates/multi-pwsh"]
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ cargo build --all-targets
 dotnet build pwsh-host-rs.sln
 ```
 
+## Build smaller release binaries
+
+The default `release` profile is tuned for smaller binaries. Build `pwsh-host-cli` and `multi-pwsh` with:
+
+```powershell
+cargo build --release -p pwsh-host-cli --bin pwsh-host
+cargo build --release -p multi-pwsh --bin multi-pwsh
+```
+
 If PowerShell 7.4 is not in `PATH`, pass it explicitly:
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Rust PowerShell hosting library that loads .NET delegates and drives `System.Man
 
 - `crates/pwsh-host` – Rust library crate
 - `crates/pwsh-host-cli` – Rust CLI crate
+- `crates/multi-pwsh` – Rust tool to install/update side-by-side `pwsh` versions
 - `dotnet` – unmanaged-callable .NET bindings project
 
 ## Origin
@@ -74,6 +75,36 @@ dotnet build pwsh-host-rs.sln -p:PwshExePath="C:\Program Files\PowerShell\7.4\pw
 cargo run -p pwsh-host-cli --bin pwsh-host -- -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"
 ```
 
+## Manage side-by-side PowerShell installs with `multi-pwsh`
+
+`multi-pwsh` downloads official PowerShell release archives from GitHub and installs them under the current user profile (no package manager or system installer required).
+
+- Install root: `~/.pwsh`
+- Per-version location: `~/.pwsh/<version>` (example: `~/.pwsh/7.4.13`)
+- Alias location: `~/.pwsh/bin`
+- Alias format: `pwsh-<major.minor>` (example: `pwsh-7.4`)
+
+Examples:
+
+```powershell
+# Install exact version and update pwsh-7.4 alias
+cargo run -p multi-pwsh -- install 7.4.13
+
+# Install latest patch in a line and update alias
+cargo run -p multi-pwsh -- install 7.4
+
+# Update an existing line alias to the newest available patch
+cargo run -p multi-pwsh -- update 7.4
+
+# Show installed versions and alias mapping metadata
+cargo run -p multi-pwsh -- list
+
+# Repair/regenerate aliases from metadata (useful after upgrading older aliases)
+cargo run -p multi-pwsh -- doctor --repair-aliases
+```
+
+`multi-pwsh` does not modify PATH automatically. Add `~/.pwsh/bin` to PATH once in your shell profile to make aliases discoverable.
+
 ## `-NamedPipeCommand` (Windows)
 
 `pwsh-host` supports a custom shim argument to read command text from a Windows named pipe and forward it to PowerShell through `-EncodedCommand`.
@@ -133,6 +164,7 @@ assert_eq!(date_json, "\"2019-12-31T19:00:00-05:00\"");
 - `crates/pwsh-host/` – Rust host library crate
 - `crates/pwsh-host/src/` – hostfxr interop, delegate loading, CLIXML parsing, tests
 - `crates/pwsh-host-cli/` – Rust CLI crate that runs `pwsh.dll` through hostfxr command-line initialization
+- `crates/multi-pwsh/` – Rust side-by-side PowerShell installer/updater and alias manager
 - `dotnet/` – .NET unmanaged-callable bindings
 - `global.json` – pinned .NET SDK version
 - `pwsh-host-rs.sln` – .NET solution for bindings

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "multi-pwsh"
+version = "0.4.0"
+edition = "2018"
+license = "MIT/Apache-2.0"
+description = "Install and update side-by-side PowerShell versions in user context"
+
+[[bin]]
+name = "multi-pwsh"
+path = "src/main.rs"
+
+[dependencies]
+thiserror = "1.0"
+ureq = { version = "2.12", default-features = false, features = ["tls", "native-certs"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+semver = "1.0"
+flate2 = "1.0"
+tar = "0.4"
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
+home = "0.5"
+tempfile = "3.12"

--- a/crates/multi-pwsh/src/aliases.rs
+++ b/crates/multi-pwsh/src/aliases.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{MultiPwshError, Result};
+use crate::layout::InstallLayout;
+use crate::platform::HostOs;
+use crate::versions::MajorMinor;
+
+pub fn create_or_update_alias(
+    layout: &InstallLayout,
+    os: HostOs,
+    line: MajorMinor,
+    version: &Version,
+    target: &Path,
+) -> Result<PathBuf> {
+    fs::create_dir_all(layout.bin_dir())?;
+
+    let alias_command = alias_command_name(line);
+    let alias_file = alias_file_name(line, os);
+    let alias_path = layout.bin_dir().join(alias_file);
+
+    if os == HostOs::Windows {
+        let legacy_exe_alias = layout.bin_dir().join(format!("{}.exe", alias_command));
+        if legacy_exe_alias != alias_path && legacy_exe_alias.exists() {
+            fs::remove_file(&legacy_exe_alias)?;
+        }
+    }
+
+    if alias_path.exists() {
+        fs::remove_file(&alias_path)?;
+    }
+
+    match os {
+        HostOs::Windows => {
+            create_windows_cmd_alias(target, &alias_path)?;
+        }
+        HostOs::Linux | HostOs::Macos => {
+            create_symlink(target, &alias_path)?;
+        }
+    }
+
+    let mut metadata = read_alias_metadata(layout)?;
+    metadata.insert(alias_command, version.to_string());
+    write_alias_metadata(layout, metadata)?;
+
+    Ok(alias_path)
+}
+
+pub fn read_alias_metadata(layout: &InstallLayout) -> Result<HashMap<String, String>> {
+    let path = layout.aliases_file();
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
+
+    let content = fs::read_to_string(path)?;
+    let metadata: AliasMetadata = serde_json::from_str(&content)?;
+    Ok(metadata.aliases)
+}
+
+fn write_alias_metadata(layout: &InstallLayout, aliases: HashMap<String, String>) -> Result<()> {
+    let path = layout.aliases_file();
+    let metadata = AliasMetadata { aliases };
+    let payload = serde_json::to_string_pretty(&metadata)?;
+    fs::write(path, payload)?;
+    Ok(())
+}
+
+fn alias_file_name(line: MajorMinor, os: HostOs) -> String {
+    match os {
+        HostOs::Windows => format!("{}.cmd", alias_command_name(line)),
+        HostOs::Linux | HostOs::Macos => alias_command_name(line),
+    }
+}
+
+fn alias_command_name(line: MajorMinor) -> String {
+    format!("pwsh-{}.{}", line.major, line.minor)
+}
+
+#[cfg(unix)]
+fn create_symlink(target: &Path, link_path: &Path) -> Result<()> {
+    use std::os::unix::fs::symlink;
+
+    symlink(target, link_path)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_symlink(_target: &Path, _link_path: &Path) -> Result<()> {
+    Err(MultiPwshError::AliasCreation(
+        "symlink is not available on this platform".to_string(),
+    ))
+}
+
+#[cfg(windows)]
+fn create_windows_cmd_alias(target: &Path, alias_path: &Path) -> Result<()> {
+    let target_string = target
+        .to_str()
+        .ok_or_else(|| MultiPwshError::AliasCreation("target path is not valid UTF-8".to_string()))?;
+
+    let script = format!(
+        "@echo off\r\n\"{}\" %*\r\nexit /b %ERRORLEVEL%\r\n",
+        target_string
+    );
+
+    fs::write(alias_path, script).map_err(|error| {
+        MultiPwshError::AliasCreation(format!(
+            "failed to write windows command alias '{}' -> '{}': {}",
+            alias_path.display(),
+            target.display(),
+            error
+        ))
+    })?;
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn create_windows_cmd_alias(_target: &Path, _alias_path: &Path) -> Result<()> {
+    Err(MultiPwshError::AliasCreation(
+        "windows command alias is not available on this platform".to_string(),
+    ))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AliasMetadata {
+    aliases: HashMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alias_name_uses_major_minor() {
+        let line = MajorMinor { major: 7, minor: 4 };
+        assert_eq!(alias_command_name(line), "pwsh-7.4");
+        assert_eq!(alias_file_name(line, HostOs::Linux), "pwsh-7.4");
+        assert_eq!(alias_file_name(line, HostOs::Windows), "pwsh-7.4.cmd");
+    }
+}

--- a/crates/multi-pwsh/src/aliases.rs
+++ b/crates/multi-pwsh/src/aliases.rs
@@ -135,10 +135,7 @@ fn create_windows_cmd_alias(target: &Path, alias_path: &Path) -> Result<()> {
         .to_str()
         .ok_or_else(|| MultiPwshError::AliasCreation("target path is not valid UTF-8".to_string()))?;
 
-    let script = format!(
-        "@echo off\r\n\"{}\" %*\r\nexit /b %ERRORLEVEL%\r\n",
-        target_string
-    );
+    let script = format!("@echo off\r\n\"{}\" %*\r\nexit /b %ERRORLEVEL%\r\n", target_string);
 
     fs::write(alias_path, script).map_err(|error| {
         MultiPwshError::AliasCreation(format!(

--- a/crates/multi-pwsh/src/aliases.rs
+++ b/crates/multi-pwsh/src/aliases.rs
@@ -50,6 +50,36 @@ pub fn create_or_update_alias(
     Ok(alias_path)
 }
 
+pub fn remove_alias(layout: &InstallLayout, os: HostOs, alias_command: &str) -> Result<bool> {
+    let alias_path = layout.bin_dir().join(alias_file_name_from_command(alias_command, os));
+    let mut removed = false;
+
+    if alias_path.exists() {
+        fs::remove_file(&alias_path)?;
+        removed = true;
+    }
+
+    let mut metadata = read_alias_metadata(layout)?;
+    if metadata.remove(alias_command).is_some() {
+        write_alias_metadata(layout, metadata)?;
+        removed = true;
+    }
+
+    Ok(removed)
+}
+
+pub fn parse_alias_command_line(alias_command: &str) -> Option<MajorMinor> {
+    let line = alias_command.strip_prefix("pwsh-")?;
+    let parts: Vec<&str> = line.split('.').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+
+    let major = parts[0].parse::<u64>().ok()?;
+    let minor = parts[1].parse::<u64>().ok()?;
+    Some(MajorMinor { major, minor })
+}
+
 pub fn read_alias_metadata(layout: &InstallLayout) -> Result<HashMap<String, String>> {
     let path = layout.aliases_file();
     if !path.exists() {
@@ -70,9 +100,13 @@ fn write_alias_metadata(layout: &InstallLayout, aliases: HashMap<String, String>
 }
 
 fn alias_file_name(line: MajorMinor, os: HostOs) -> String {
+    alias_file_name_from_command(&alias_command_name(line), os)
+}
+
+fn alias_file_name_from_command(alias_command: &str, os: HostOs) -> String {
     match os {
-        HostOs::Windows => format!("{}.cmd", alias_command_name(line)),
-        HostOs::Linux | HostOs::Macos => alias_command_name(line),
+        HostOs::Windows => format!("{}.cmd", alias_command),
+        HostOs::Linux | HostOs::Macos => alias_command.to_string(),
     }
 }
 
@@ -140,5 +174,20 @@ mod tests {
         assert_eq!(alias_command_name(line), "pwsh-7.4");
         assert_eq!(alias_file_name(line, HostOs::Linux), "pwsh-7.4");
         assert_eq!(alias_file_name(line, HostOs::Windows), "pwsh-7.4.cmd");
+    }
+
+    #[test]
+    fn parses_alias_line() {
+        let line = parse_alias_command_line("pwsh-7.5").unwrap();
+        assert_eq!(line.major, 7);
+        assert_eq!(line.minor, 5);
+    }
+
+    #[test]
+    fn rejects_invalid_alias_line() {
+        assert!(parse_alias_command_line("pwsh").is_none());
+        assert!(parse_alias_command_line("pwsh-7").is_none());
+        assert!(parse_alias_command_line("pwsh-7.5.1").is_none());
+        assert!(parse_alias_command_line("not-pwsh-7.5").is_none());
     }
 }

--- a/crates/multi-pwsh/src/error.rs
+++ b/crates/multi-pwsh/src/error.rs
@@ -1,0 +1,47 @@
+use std::io;
+
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, MultiPwshError>;
+
+#[derive(Debug, Error)]
+pub enum MultiPwshError {
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("http error: {0}")]
+    Http(#[from] ureq::Error),
+
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("archive error: {0}")]
+    Archive(String),
+
+    #[error("version parse error: {0}")]
+    Version(#[from] semver::Error),
+
+    #[error("invalid arguments: {0}")]
+    InvalidArguments(String),
+
+    #[error("unsupported platform: {0}")]
+    UnsupportedPlatform(String),
+
+    #[error("release not found: {0}")]
+    ReleaseNotFound(String),
+
+    #[error("asset not found: {0}")]
+    AssetNotFound(String),
+
+    #[error("home directory not found")]
+    HomeDirectoryNotFound,
+
+    #[error("alias creation failed: {0}")]
+    AliasCreation(String),
+}
+
+impl From<zip::result::ZipError> for MultiPwshError {
+    fn from(value: zip::result::ZipError) -> Self {
+        MultiPwshError::Archive(value.to_string())
+    }
+}

--- a/crates/multi-pwsh/src/install.rs
+++ b/crates/multi-pwsh/src/install.rs
@@ -1,0 +1,167 @@
+use std::fs;
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+
+use flate2::read::GzDecoder;
+use ureq::Agent;
+
+use crate::error::{MultiPwshError, Result};
+use crate::layout::InstallLayout;
+use crate::platform::HostOs;
+use crate::release::ResolvedRelease;
+
+pub fn ensure_installed(
+    layout: &InstallLayout,
+    http: &Agent,
+    os: HostOs,
+    release: &ResolvedRelease,
+) -> Result<PathBuf> {
+    let executable = layout.version_executable(&release.version);
+    if executable.exists() {
+        return Ok(executable);
+    }
+
+    let install_dir = layout.version_dir(&release.version);
+    if install_dir.exists() {
+        fs::remove_dir_all(&install_dir)?;
+    }
+    fs::create_dir_all(&install_dir)?;
+
+    let temp_dir = tempfile::tempdir()?;
+    let archive_path = temp_dir.path().join(&release.asset_name);
+
+    download_with_retry(http, &release.asset_url, &archive_path, 8)?;
+    extract_archive(&archive_path, &install_dir)?;
+
+    let executable = layout.version_executable(&release.version);
+    if !executable.exists() {
+        return Err(MultiPwshError::Archive(format!(
+            "installation completed but executable '{}' was not found",
+            executable.display()
+        )));
+    }
+
+    if os != HostOs::Windows {
+        ensure_executable_bit(&executable)?;
+    }
+
+    Ok(executable)
+}
+
+fn download_with_retry(http: &Agent, url: &str, destination: &Path, retries: usize) -> Result<()> {
+    let mut last_error = None;
+
+    for attempt in 1..=retries {
+        let result = (|| -> Result<()> {
+            let response = http.get(url).set("User-Agent", "multi-pwsh").call()?;
+            let mut response_reader = response.into_reader();
+            let mut file = File::create(destination)?;
+            io::copy(&mut response_reader, &mut file)?;
+            file.flush()?;
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                last_error = Some(error);
+                if attempt < retries {
+                    let delay_seconds = 2u64.pow(attempt as u32);
+                    thread::sleep(Duration::from_secs(delay_seconds.min(30)));
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| MultiPwshError::Archive("download failed without detailed error".to_string())))
+}
+
+fn extract_archive(archive_path: &Path, install_dir: &Path) -> Result<()> {
+    let name = archive_path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    if name.ends_with(".zip") {
+        extract_zip(archive_path, install_dir)?;
+        return Ok(());
+    }
+
+    if name.ends_with(".tar.gz") {
+        extract_tar_gz(archive_path, install_dir)?;
+        return Ok(());
+    }
+
+    Err(MultiPwshError::Archive(format!(
+        "unsupported archive format '{}'",
+        name
+    )))
+}
+
+fn extract_zip(archive_path: &Path, install_dir: &Path) -> Result<()> {
+    let file = File::open(archive_path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
+
+    for index in 0..archive.len() {
+        let mut zipped_file = archive.by_index(index)?;
+        let relative_path = match zipped_file.enclosed_name() {
+            Some(path) => path.to_owned(),
+            None => continue,
+        };
+        let out_path = install_dir.join(relative_path);
+
+        if zipped_file.name().ends_with('/') {
+            fs::create_dir_all(&out_path)?;
+            continue;
+        }
+
+        if let Some(parent) = out_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut output = File::create(&out_path)?;
+        io::copy(&mut zipped_file, &mut output)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            if let Some(mode) = zipped_file.unix_mode() {
+                fs::set_permissions(&out_path, fs::Permissions::from_mode(mode))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn extract_tar_gz(archive_path: &Path, install_dir: &Path) -> Result<()> {
+    let file = File::open(archive_path)?;
+    let decompressed = GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decompressed);
+    archive.unpack(install_dir)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn ensure_executable_bit(executable: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = fs::metadata(executable)?;
+    let mut permissions = metadata.permissions();
+    let mode = permissions.mode();
+    if mode & 0o111 == 0 {
+        permissions.set_mode(mode | 0o755);
+        fs::set_permissions(executable, permissions)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_executable_bit(_executable: &Path) -> Result<()> {
+    Ok(())
+}

--- a/crates/multi-pwsh/src/layout.rs
+++ b/crates/multi-pwsh/src/layout.rs
@@ -1,0 +1,87 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use semver::Version;
+
+use crate::error::{MultiPwshError, Result};
+use crate::platform::HostOs;
+
+pub struct InstallLayout {
+    root: PathBuf,
+    os: HostOs,
+}
+
+impl InstallLayout {
+    pub fn new(os: HostOs) -> Result<Self> {
+        let home = home::home_dir().ok_or(MultiPwshError::HomeDirectoryNotFound)?;
+        Ok(InstallLayout {
+            root: home.join(".pwsh"),
+            os,
+        })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn bin_dir(&self) -> PathBuf {
+        self.root.join("bin")
+    }
+
+    pub fn aliases_file(&self) -> PathBuf {
+        self.root.join("aliases.json")
+    }
+
+    pub fn executable_name(&self) -> &'static str {
+        self.os.executable_name()
+    }
+
+    pub fn version_dir(&self, version: &Version) -> PathBuf {
+        self.root.join(version.to_string())
+    }
+
+    pub fn version_executable(&self, version: &Version) -> PathBuf {
+        self.version_dir(version).join(self.executable_name())
+    }
+
+    pub fn ensure_base_dirs(&self) -> Result<()> {
+        fs::create_dir_all(&self.root)?;
+        fs::create_dir_all(self.bin_dir())?;
+        Ok(())
+    }
+
+    pub fn installed_versions(&self) -> Result<Vec<Version>> {
+        if !self.root.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut versions = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if !path.is_dir() {
+                continue;
+            }
+
+            let file_name = entry.file_name();
+            let file_name = file_name.to_string_lossy();
+            if file_name == "bin" {
+                continue;
+            }
+
+            let version = match Version::parse(file_name.as_ref()) {
+                Ok(version) => version,
+                Err(_) => continue,
+            };
+
+            let executable = path.join(self.executable_name());
+            if executable.exists() {
+                versions.push(version);
+            }
+        }
+
+        versions.sort_by(|a, b| b.cmp(a));
+        Ok(versions)
+    }
+}

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -1,0 +1,237 @@
+mod aliases;
+mod error;
+mod install;
+mod layout;
+mod platform;
+mod release;
+mod versions;
+
+use std::env;
+use std::process;
+
+use semver::Version;
+
+use aliases::create_or_update_alias;
+use error::{MultiPwshError, Result};
+use install::ensure_installed;
+use layout::InstallLayout;
+use platform::{HostArch, HostOs};
+use release::ReleaseClient;
+use versions::{parse_install_selector, parse_major_minor_selector, MajorMinor};
+
+fn print_usage() {
+    eprintln!(
+        "Usage:\n  multi-pwsh install <version|major.minor> [--arch <auto|x64|x86|arm64|arm32>]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>]\n  multi-pwsh list\n  multi-pwsh doctor --repair-aliases"
+    );
+}
+
+fn parse_arch_option(args: &[String]) -> Result<Option<HostArch>> {
+    if args.is_empty() {
+        return Ok(None);
+    }
+
+    if args.len() != 2 || (args[0] != "--arch" && args[0] != "-a") {
+        return Err(MultiPwshError::InvalidArguments(
+            "expected optional --arch <value>".to_string(),
+        ));
+    }
+
+    if args[1] == "auto" {
+        return Ok(None);
+    }
+
+    HostArch::parse(&args[1]).map(Some).ok_or_else(|| {
+        MultiPwshError::InvalidArguments(format!(
+            "unsupported architecture '{}', expected one of: auto, x64, x86, arm64, arm32",
+            args[1]
+        ))
+    })
+}
+
+fn run_install(selector_input: &str, arch: Option<HostArch>) -> Result<()> {
+    let selector = parse_install_selector(selector_input)?;
+    let os = HostOs::detect()?;
+    let arch = arch.unwrap_or_else(HostArch::detect);
+
+    let layout = InstallLayout::new(os)?;
+    layout.ensure_base_dirs()?;
+
+    let token = env::var("GITHUB_TOKEN").ok();
+    let release_client = ReleaseClient::new(token)?;
+    let release = release_client.resolve_selector(selector, os, arch)?;
+    let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release)?;
+
+    let line = release.version_line();
+    let alias_path = create_or_update_alias(&layout, os, line, &release.version, &executable_path)?;
+
+    println!("Installed PowerShell {}", release.version);
+    println!("Version path: {}", layout.version_dir(&release.version).display());
+    println!("Updated alias: {}", alias_path.display());
+    println!("Add to PATH once: {}", layout.bin_dir().display());
+
+    Ok(())
+}
+
+fn run_update(line_input: &str, arch: Option<HostArch>) -> Result<()> {
+    let line = parse_major_minor_selector(line_input)?;
+    let os = HostOs::detect()?;
+    let arch = arch.unwrap_or_else(HostArch::detect);
+
+    let layout = InstallLayout::new(os)?;
+    layout.ensure_base_dirs()?;
+
+    let token = env::var("GITHUB_TOKEN").ok();
+    let release_client = ReleaseClient::new(token)?;
+    let release = release_client.resolve_latest_in_line(line, os, arch)?;
+    let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release)?;
+
+    let alias_path = create_or_update_alias(&layout, os, line, &release.version, &executable_path)?;
+
+    println!("Updated line {} to {}", line, release.version);
+    println!("Version path: {}", layout.version_dir(&release.version).display());
+    println!("Updated alias: {}", alias_path.display());
+    println!("Add to PATH once: {}", layout.bin_dir().display());
+
+    Ok(())
+}
+
+fn run_list() -> Result<()> {
+    let os = HostOs::detect()?;
+    let layout = InstallLayout::new(os)?;
+    let versions = layout.installed_versions()?;
+    let aliases = aliases::read_alias_metadata(&layout)?;
+
+    println!("Install root: {}", layout.root().display());
+    println!("Alias bin: {}", layout.bin_dir().display());
+    println!();
+
+    if versions.is_empty() {
+        println!("Installed versions: (none)");
+    } else {
+        println!("Installed versions:");
+        for version in versions {
+            println!("  - {}", version);
+        }
+    }
+
+    println!();
+    if aliases.is_empty() {
+        println!("Aliases: (none)");
+    } else {
+        println!("Aliases:");
+        let mut items: Vec<_> = aliases.into_iter().collect();
+        items.sort_by(|a, b| a.0.cmp(&b.0));
+        for (alias, version) in items {
+            println!("  - {} -> {}", alias, version);
+        }
+    }
+
+    Ok(())
+}
+
+fn run_doctor(args: &[String]) -> Result<()> {
+    if args.len() != 1 || args[0] != "--repair-aliases" {
+        return Err(MultiPwshError::InvalidArguments(
+            "doctor currently supports only: --repair-aliases".to_string(),
+        ));
+    }
+
+    let os = HostOs::detect()?;
+    let layout = InstallLayout::new(os)?;
+    layout.ensure_base_dirs()?;
+
+    let aliases = aliases::read_alias_metadata(&layout)?;
+    if aliases.is_empty() {
+        println!("No aliases found in metadata.");
+        return Ok(());
+    }
+
+    let mut repaired = 0usize;
+    let mut skipped = 0usize;
+
+    let mut items: Vec<_> = aliases.into_iter().collect();
+    items.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (alias_name, version_text) in items {
+        let version = match Version::parse(&version_text) {
+            Ok(version) => version,
+            Err(_) => {
+                eprintln!("Skipping alias {}: invalid version '{}'", alias_name, version_text);
+                skipped += 1;
+                continue;
+            }
+        };
+
+        let target = layout.version_executable(&version);
+        if !target.exists() {
+            eprintln!(
+                "Skipping alias {}: target executable not found at {}",
+                alias_name,
+                target.display()
+            );
+            skipped += 1;
+            continue;
+        }
+
+        let line = MajorMinor::from_version(&version);
+        let alias_path = create_or_update_alias(&layout, os, line, &version, &target)?;
+        println!("Repaired alias: {}", alias_path.display());
+        repaired += 1;
+    }
+
+    println!("Repair complete: {} repaired, {} skipped", repaired, skipped);
+    Ok(())
+}
+
+fn run() -> Result<()> {
+    let args: Vec<String> = env::args().skip(1).collect();
+    if args.is_empty() {
+        print_usage();
+        return Err(MultiPwshError::InvalidArguments("missing command".to_string()));
+    }
+
+    match args[0].as_str() {
+        "install" => {
+            if args.len() < 2 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "install requires <version|major.minor>".to_string(),
+                ));
+            }
+            let arch = parse_arch_option(&args[2..])?;
+            run_install(&args[1], arch)
+        }
+        "update" => {
+            if args.len() < 2 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "update requires <major.minor>".to_string(),
+                ));
+            }
+            let arch = parse_arch_option(&args[2..])?;
+            run_update(&args[1], arch)
+        }
+        "list" => {
+            if args.len() != 1 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "list does not accept additional arguments".to_string(),
+                ));
+            }
+            run_list()
+        }
+        "doctor" => run_doctor(&args[1..]),
+        "-h" | "--help" | "help" => {
+            print_usage();
+            Ok(())
+        }
+        command => Err(MultiPwshError::InvalidArguments(format!(
+            "unknown command '{}'. expected: install, update, list, doctor",
+            command
+        ))),
+    }
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("error: {}", error);
+        process::exit(1);
+    }
+}

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -7,21 +7,22 @@ mod release;
 mod versions;
 
 use std::env;
+use std::fs;
 use std::process;
 
 use semver::Version;
 
-use aliases::create_or_update_alias;
+use aliases::{create_or_update_alias, parse_alias_command_line, remove_alias};
 use error::{MultiPwshError, Result};
 use install::ensure_installed;
 use layout::InstallLayout;
 use platform::{HostArch, HostOs};
 use release::ReleaseClient;
-use versions::{parse_install_selector, parse_major_minor_selector, MajorMinor};
+use versions::{parse_exact_version, parse_install_selector, parse_major_minor_selector, MajorMinor};
 
 fn print_usage() {
     eprintln!(
-        "Usage:\n  multi-pwsh install <version|major.minor> [--arch <auto|x64|x86|arm64|arm32>]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>]\n  multi-pwsh list\n  multi-pwsh doctor --repair-aliases"
+        "Usage:\n  multi-pwsh install <version|major.minor> [--arch <auto|x64|x86|arm64|arm32>]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>]\n  multi-pwsh uninstall <version> [--force]\n  multi-pwsh list\n  multi-pwsh doctor --repair-aliases"
     );
 }
 
@@ -91,6 +92,99 @@ fn run_update(line_input: &str, arch: Option<HostArch>) -> Result<()> {
     println!("Version path: {}", layout.version_dir(&release.version).display());
     println!("Updated alias: {}", alias_path.display());
     println!("Add to PATH once: {}", layout.bin_dir().display());
+
+    Ok(())
+}
+
+fn parse_force_option(args: &[String]) -> Result<bool> {
+    if args.is_empty() {
+        return Ok(false);
+    }
+
+    if args.len() == 1 && args[0] == "--force" {
+        return Ok(true);
+    }
+
+    Err(MultiPwshError::InvalidArguments(
+        "expected optional --force".to_string(),
+    ))
+}
+
+fn run_uninstall(version_input: &str, force: bool) -> Result<()> {
+    let version = parse_exact_version(version_input)?;
+    let os = HostOs::detect()?;
+
+    let layout = InstallLayout::new(os)?;
+    layout.ensure_base_dirs()?;
+
+    let version_dir = layout.version_dir(&version);
+    if version_dir.exists() {
+        fs::remove_dir_all(&version_dir)?;
+        println!("Removed PowerShell {}", version);
+    } else if force {
+        println!(
+            "PowerShell {} is not installed; continuing because --force was provided",
+            version
+        );
+    } else {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "version {} is not installed (use --force to ignore)",
+            version
+        )));
+    }
+
+    let aliases = aliases::read_alias_metadata(&layout)?;
+    let removed_version_text = version.to_string();
+    let mut affected_aliases: Vec<String> = aliases
+        .into_iter()
+        .filter_map(|(alias_name, alias_version)| {
+            if alias_version == removed_version_text {
+                Some(alias_name)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if affected_aliases.is_empty() {
+        println!("No aliases referenced version {}", version);
+        return Ok(());
+    }
+
+    affected_aliases.sort();
+    let installed_versions = layout.installed_versions()?;
+
+    let mut updated_aliases = 0usize;
+    let mut removed_aliases = 0usize;
+
+    for alias_name in affected_aliases {
+        let fallback_version = parse_alias_command_line(&alias_name).and_then(|line| {
+            installed_versions
+                .iter()
+                .find(|candidate| MajorMinor::from_version(candidate) == line)
+                .cloned()
+        });
+
+        if let Some(fallback_version) = fallback_version {
+            let line = MajorMinor::from_version(&fallback_version);
+            let target = layout.version_executable(&fallback_version);
+            let alias_path = create_or_update_alias(&layout, os, line, &fallback_version, &target)?;
+            println!("Updated alias: {} -> {}", alias_name, fallback_version);
+            println!("Alias path: {}", alias_path.display());
+            updated_aliases += 1;
+            continue;
+        }
+
+        if remove_alias(&layout, os, &alias_name)? {
+            println!("Removed alias: {}", alias_name);
+        }
+        removed_aliases += 1;
+    }
+
+    println!(
+        "Alias cleanup complete: {} updated, {} removed",
+        updated_aliases, removed_aliases
+    );
 
     Ok(())
 }
@@ -209,6 +303,15 @@ fn run() -> Result<()> {
             let arch = parse_arch_option(&args[2..])?;
             run_update(&args[1], arch)
         }
+        "uninstall" => {
+            if args.len() < 2 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "uninstall requires <version>".to_string(),
+                ));
+            }
+            let force = parse_force_option(&args[2..])?;
+            run_uninstall(&args[1], force)
+        }
         "list" => {
             if args.len() != 1 {
                 return Err(MultiPwshError::InvalidArguments(
@@ -223,7 +326,7 @@ fn run() -> Result<()> {
             Ok(())
         }
         command => Err(MultiPwshError::InvalidArguments(format!(
-            "unknown command '{}'. expected: install, update, list, doctor",
+            "unknown command '{}'. expected: install, update, uninstall, list, doctor",
             command
         ))),
     }
@@ -233,5 +336,28 @@ fn main() {
     if let Err(error) = run() {
         eprintln!("error: {}", error);
         process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_force_option_defaults_to_false() {
+        let args: Vec<String> = Vec::new();
+        assert!(!parse_force_option(&args).unwrap());
+    }
+
+    #[test]
+    fn parse_force_option_accepts_force_flag() {
+        let args = vec!["--force".to_string()];
+        assert!(parse_force_option(&args).unwrap());
+    }
+
+    #[test]
+    fn parse_force_option_rejects_unexpected_args() {
+        let args = vec!["--arch".to_string(), "x64".to_string()];
+        assert!(parse_force_option(&args).is_err());
     }
 }

--- a/crates/multi-pwsh/src/platform.rs
+++ b/crates/multi-pwsh/src/platform.rs
@@ -1,0 +1,59 @@
+use crate::error::{MultiPwshError, Result};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HostOs {
+    Windows,
+    Macos,
+    Linux,
+}
+
+impl HostOs {
+    pub fn detect() -> Result<Self> {
+        match std::env::consts::OS {
+            "windows" => Ok(HostOs::Windows),
+            "macos" => Ok(HostOs::Macos),
+            "linux" => Ok(HostOs::Linux),
+            value => Err(MultiPwshError::UnsupportedPlatform(format!(
+                "operating system '{}' is not supported",
+                value
+            ))),
+        }
+    }
+
+    pub fn executable_name(self) -> &'static str {
+        match self {
+            HostOs::Windows => "pwsh.exe",
+            HostOs::Macos | HostOs::Linux => "pwsh",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HostArch {
+    X64,
+    X86,
+    Arm64,
+    Arm32,
+}
+
+impl HostArch {
+    pub fn detect() -> Self {
+        match std::env::consts::ARCH {
+            "x86_64" => HostArch::X64,
+            "x86" | "i686" => HostArch::X86,
+            "aarch64" => HostArch::Arm64,
+            "arm" | "armv7" | "armv7l" => HostArch::Arm32,
+            _ => HostArch::X64,
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "x64" => Some(HostArch::X64),
+            "x86" => Some(HostArch::X86),
+            "arm64" => Some(HostArch::Arm64),
+            "arm32" => Some(HostArch::Arm32),
+            _ => None,
+        }
+    }
+}

--- a/crates/multi-pwsh/src/release.rs
+++ b/crates/multi-pwsh/src/release.rs
@@ -1,0 +1,265 @@
+use semver::Version;
+use serde::Deserialize;
+use ureq::Agent;
+
+use crate::error::{MultiPwshError, Result};
+use crate::platform::{HostArch, HostOs};
+use crate::versions::{MajorMinor, VersionSelector};
+
+#[derive(Clone, Debug)]
+pub struct ResolvedRelease {
+    pub version: Version,
+    pub asset_name: String,
+    pub asset_url: String,
+}
+
+impl ResolvedRelease {
+    pub fn version_line(&self) -> MajorMinor {
+        MajorMinor::from_version(&self.version)
+    }
+}
+
+#[derive(Clone)]
+pub struct ReleaseClient {
+    http: Agent,
+    authorization_header: Option<String>,
+}
+
+impl ReleaseClient {
+    pub fn new(github_token: Option<String>) -> Result<Self> {
+        let authorization_header = github_token
+            .filter(|token| !token.trim().is_empty())
+            .map(|token| format!("Bearer {}", token));
+
+        let http = ureq::AgentBuilder::new().build();
+
+        Ok(ReleaseClient {
+            http,
+            authorization_header,
+        })
+    }
+
+    pub fn http_client(&self) -> &Agent {
+        &self.http
+    }
+
+    pub fn resolve_selector(&self, selector: VersionSelector, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
+        match selector {
+            VersionSelector::Exact(version) => self.resolve_exact(version, os, arch),
+            VersionSelector::MajorMinor(line) => self.resolve_latest_in_line(line, os, arch),
+        }
+    }
+
+    pub fn resolve_latest_in_line(&self, line: MajorMinor, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
+        let releases = self.fetch_releases()?;
+        let mut candidates: Vec<ParsedRelease> = releases
+            .into_iter()
+            .filter(|release| !release.prerelease)
+            .filter_map(ParsedRelease::from_github_release)
+            .filter(|release| release.version.major == line.major && release.version.minor == line.minor)
+            .collect();
+
+        candidates.sort_by(|a, b| b.version.cmp(&a.version));
+        let release = candidates
+            .into_iter()
+            .next()
+            .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("no release found for line {}", line)))?;
+
+        resolve_release_asset(release, os, arch)
+    }
+
+    fn resolve_exact(&self, version: Version, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
+        let releases = self.fetch_releases()?;
+        let release = releases
+            .into_iter()
+            .filter_map(ParsedRelease::from_github_release)
+            .find(|release| release.version == version)
+            .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("version {}", version)))?;
+
+        resolve_release_asset(release, os, arch)
+    }
+
+    fn fetch_releases(&self) -> Result<Vec<GithubRelease>> {
+        let mut all_releases = Vec::new();
+
+        for page in 1..=10 {
+            let url = format!(
+                "https://api.github.com/repos/PowerShell/PowerShell/releases?per_page=100&page={}",
+                page
+            );
+
+            let mut request = self
+                .http
+                .get(&url)
+                .set("Accept", "application/vnd.github.v3+json")
+                .set("User-Agent", "multi-pwsh");
+
+            if let Some(value) = self.authorization_header.as_deref() {
+                request = request.set("Authorization", value);
+            }
+
+            let response = request.call()?;
+            let body = response.into_string()?;
+            let mut page_releases: Vec<GithubRelease> = serde_json::from_str(&body)?;
+
+            if page_releases.is_empty() {
+                break;
+            }
+
+            let is_last_page = page_releases.len() < 100;
+            all_releases.append(&mut page_releases);
+
+            if is_last_page {
+                break;
+            }
+        }
+
+        Ok(all_releases)
+    }
+}
+
+fn resolve_release_asset(release: ParsedRelease, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
+    let pattern = asset_pattern(os, arch)?;
+    let tag_name = release.tag_name.clone();
+    let asset = release
+        .assets
+        .into_iter()
+        .find(|asset| wildcard_match(pattern, &asset.name))
+        .ok_or_else(|| {
+            MultiPwshError::AssetNotFound(format!("no asset found for pattern '{}' in {}", pattern, tag_name))
+        })?;
+
+    Ok(ResolvedRelease {
+        version: release.version,
+        asset_name: asset.name,
+        asset_url: asset.browser_download_url,
+    })
+}
+
+fn asset_pattern(os: HostOs, arch: HostArch) -> Result<&'static str> {
+    match os {
+        HostOs::Windows => match arch {
+            HostArch::X64 => Ok("PowerShell-*-win-x64.zip"),
+            HostArch::X86 => Ok("PowerShell-*-win-x86.zip"),
+            HostArch::Arm64 => Ok("PowerShell-*-win-arm64.zip"),
+            HostArch::Arm32 => Err(MultiPwshError::UnsupportedPlatform(
+                "arm32 is not supported on windows".to_string(),
+            )),
+        },
+        HostOs::Macos => match arch {
+            HostArch::X64 => Ok("powershell-*-osx-x64.tar.gz"),
+            HostArch::Arm64 => Ok("powershell-*-osx-arm64.tar.gz"),
+            HostArch::X86 | HostArch::Arm32 => Err(MultiPwshError::UnsupportedPlatform(
+                "architecture is not supported on macos".to_string(),
+            )),
+        },
+        HostOs::Linux => match arch {
+            HostArch::X64 => Ok("powershell-*-linux-x64.tar.gz"),
+            HostArch::Arm64 => Ok("powershell-*-linux-arm64.tar.gz"),
+            HostArch::Arm32 => Ok("powershell-*-linux-arm32.tar.gz"),
+            HostArch::X86 => Err(MultiPwshError::UnsupportedPlatform(
+                "x86 is not supported on linux".to_string(),
+            )),
+        },
+    }
+}
+
+fn wildcard_match(pattern: &str, text: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+
+    let starts_with_wildcard = pattern.starts_with('*');
+    let ends_with_wildcard = pattern.ends_with('*');
+    let parts: Vec<&str> = pattern.split('*').filter(|part| !part.is_empty()).collect();
+
+    if parts.is_empty() {
+        return true;
+    }
+
+    let mut cursor = 0usize;
+    for (index, part) in parts.iter().enumerate() {
+        if index == 0 && !starts_with_wildcard {
+            if !text[cursor..].starts_with(part) {
+                return false;
+            }
+            cursor += part.len();
+            continue;
+        }
+
+        if index == parts.len() - 1 && !ends_with_wildcard {
+            if let Some(found) = text[cursor..].rfind(part) {
+                let absolute = cursor + found;
+                if absolute + part.len() != text.len() {
+                    return false;
+                }
+                cursor = absolute + part.len();
+            } else {
+                return false;
+            }
+            continue;
+        }
+
+        if let Some(found) = text[cursor..].find(part) {
+            cursor += found + part.len();
+        } else {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    prerelease: bool,
+    assets: Vec<GithubAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[derive(Debug)]
+struct ParsedRelease {
+    tag_name: String,
+    version: Version,
+    assets: Vec<GithubAsset>,
+}
+
+impl ParsedRelease {
+    fn from_github_release(release: GithubRelease) -> Option<Self> {
+        let version_text = release.tag_name.trim_start_matches('v');
+        let version = Version::parse(version_text).ok()?;
+
+        Some(ParsedRelease {
+            tag_name: release.tag_name,
+            version,
+            assets: release.assets,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wildcard_match_supports_single_star_segments() {
+        assert!(wildcard_match(
+            "PowerShell-*-win-x64.zip",
+            "PowerShell-7.4.13-win-x64.zip"
+        ));
+        assert!(wildcard_match(
+            "powershell-*-linux-arm64.tar.gz",
+            "powershell-7.5.1-linux-arm64.tar.gz"
+        ));
+        assert!(!wildcard_match(
+            "powershell-*-linux-arm64.tar.gz",
+            "powershell-7.5.1-linux-x64.tar.gz"
+        ));
+    }
+}

--- a/crates/multi-pwsh/src/versions.rs
+++ b/crates/multi-pwsh/src/versions.rs
@@ -1,0 +1,111 @@
+use std::fmt;
+
+use semver::Version;
+
+use crate::error::{MultiPwshError, Result};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct MajorMinor {
+    pub major: u64,
+    pub minor: u64,
+}
+
+impl MajorMinor {
+    pub fn from_version(version: &Version) -> Self {
+        MajorMinor {
+            major: version.major,
+            minor: version.minor,
+        }
+    }
+}
+
+impl fmt::Display for MajorMinor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VersionSelector {
+    Exact(Version),
+    MajorMinor(MajorMinor),
+}
+
+pub fn parse_install_selector(value: &str) -> Result<VersionSelector> {
+    if let Ok(line) = parse_major_minor_selector(value) {
+        return Ok(VersionSelector::MajorMinor(line));
+    }
+
+    let exact = parse_exact_version(value)?;
+    Ok(VersionSelector::Exact(exact))
+}
+
+pub fn parse_major_minor_selector(value: &str) -> Result<MajorMinor> {
+    let trimmed = value.trim().trim_start_matches('v');
+    let parts: Vec<&str> = trimmed.split('.').collect();
+    if parts.len() != 2 {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "'{}' is not a major.minor selector",
+            value
+        )));
+    }
+
+    let major = parts[0].parse::<u64>().map_err(|_| {
+        MultiPwshError::InvalidArguments(format!("invalid major version '{}' in selector '{}'", parts[0], value))
+    })?;
+
+    let minor = parts[1].parse::<u64>().map_err(|_| {
+        MultiPwshError::InvalidArguments(format!("invalid minor version '{}' in selector '{}'", parts[1], value))
+    })?;
+
+    Ok(MajorMinor { major, minor })
+}
+
+pub fn parse_exact_version(value: &str) -> Result<Version> {
+    let trimmed = value.trim().trim_start_matches('v');
+    if trimmed.matches('.').count() != 2 {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "'{}' is not an exact major.minor.patch version",
+            value
+        )));
+    }
+
+    Ok(Version::parse(trimmed)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_major_minor_selector() {
+        let selector = parse_major_minor_selector("7.4").unwrap();
+        assert_eq!(selector.major, 7);
+        assert_eq!(selector.minor, 4);
+    }
+
+    #[test]
+    fn parses_exact_selector() {
+        let selector = parse_install_selector("7.4.13").unwrap();
+        match selector {
+            VersionSelector::Exact(version) => {
+                assert_eq!(version.major, 7);
+                assert_eq!(version.minor, 4);
+                assert_eq!(version.patch, 13);
+            }
+            _ => panic!("expected exact selector"),
+        }
+    }
+
+    #[test]
+    fn parses_line_selector() {
+        let selector = parse_install_selector("7.5").unwrap();
+        match selector {
+            VersionSelector::MajorMinor(line) => {
+                assert_eq!(line.major, 7);
+                assert_eq!(line.minor, 5);
+            }
+            _ => panic!("expected major.minor selector"),
+        }
+    }
+}

--- a/crates/pwsh-host-cli/Cargo.toml
+++ b/crates/pwsh-host-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host-cli"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "pwsh-compatible CLI backed by pwsh-host and hostfxr"

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/awakecoding/pwsh-host-rs"

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.418",
+    "version": "8.0.400",
     "allowPrerelease": false,
-    "rollForward": "disable"
+    "rollForward": "latestPatch"
   }
 }

--- a/scripts/Bump-CrateVersions.ps1
+++ b/scripts/Bump-CrateVersions.ps1
@@ -1,0 +1,61 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$')]
+    [string]$Version,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$cratesRoot = Join-Path $repoRoot 'crates'
+
+if (-not (Test-Path -Path $cratesRoot -PathType Container)) {
+    throw "Crates directory not found: $cratesRoot"
+}
+
+$cargoFiles = Get-ChildItem -Path $cratesRoot -Directory |
+    ForEach-Object { Join-Path $_.FullName 'Cargo.toml' } |
+    Where-Object { Test-Path -Path $_ -PathType Leaf }
+
+if (-not $cargoFiles) {
+    throw "No crate Cargo.toml files found under $cratesRoot"
+}
+
+$encoding = New-Object System.Text.UTF8Encoding($false)
+$updated = @()
+
+foreach ($cargoFile in $cargoFiles) {
+    $content = [System.IO.File]::ReadAllText($cargoFile)
+
+    $pattern = '(?ms)^(\[package\]\s*.*?^version\s*=\s*")(?<current>[^"]+)(")'
+    $match = [System.Text.RegularExpressions.Regex]::Match($content, $pattern)
+    if (-not $match.Success) {
+        throw "Could not find package version field in $cargoFile"
+    }
+
+    $currentVersion = $match.Groups['current'].Value
+    if ($currentVersion -eq $Version) {
+        continue
+    }
+
+    $replacement = $match.Groups[1].Value + $Version + $match.Groups[3].Value
+    $newContent = $content.Substring(0, $match.Index) + $replacement + $content.Substring($match.Index + $match.Length)
+
+    if (-not $DryRun) {
+        [System.IO.File]::WriteAllText($cargoFile, $newContent, $encoding)
+    }
+
+    $updated += $cargoFile
+}
+
+if ($updated.Count -eq 0) {
+    Write-Host "All crate package versions are already $Version"
+    exit 0
+}
+
+Write-Host "Updated crate versions to ${Version}:"
+$updated | ForEach-Object { Write-Host " - $_" }


### PR DESCRIPTION
## Summary
- add `multi-pwsh uninstall <version> [--force]` with alias metadata cleanup
- add alias helper functions and parser tests for uninstall behavior
- relax .NET SDK pinning in `global.json` to .NET 8 roll-forward patch updates
- tune default Cargo `release` profile for smaller binaries and document usage

## Validation
- cargo build --release -p pwsh-host-cli --bin pwsh-host -p multi-pwsh --bin multi-pwsh
- cargo test --all-targets
- dotnet build dotnet/Bindings.csproj
- dotnet test dotnet/Bindings.csproj --no-build