### PR TITLE
Fix multi-pwsh release naming and Windows metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             host_archive: pwsh-host-linux-x64.zip
             host_binary: pwsh-host
-            multi_archive: pwsh-multi-linux-x64.zip
+            multi_archive: multi-pwsh-linux-x64.zip
             multi_binary: multi-pwsh
 
           - name: linux-arm64
@@ -32,7 +32,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             host_archive: pwsh-host-linux-arm64.zip
             host_binary: pwsh-host
-            multi_archive: pwsh-multi-linux-arm64.zip
+            multi_archive: multi-pwsh-linux-arm64.zip
             multi_binary: multi-pwsh
 
           - name: windows-x64
@@ -40,7 +40,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             host_archive: pwsh-host-windows-x64.zip
             host_binary: pwsh-host.exe
-            multi_archive: pwsh-multi-windows-x64.zip
+            multi_archive: multi-pwsh-windows-x64.zip
             multi_binary: multi-pwsh.exe
 
           - name: windows-arm64
@@ -48,7 +48,7 @@ jobs:
             target: aarch64-pc-windows-msvc
             host_archive: pwsh-host-windows-arm64.zip
             host_binary: pwsh-host.exe
-            multi_archive: pwsh-multi-windows-arm64.zip
+            multi_archive: multi-pwsh-windows-arm64.zip
             multi_binary: multi-pwsh.exe
 
           - name: macos-x64
@@ -56,7 +56,7 @@ jobs:
             target: x86_64-apple-darwin
             host_archive: pwsh-host-macos-x64.zip
             host_binary: pwsh-host
-            multi_archive: pwsh-multi-macos-x64.zip
+            multi_archive: multi-pwsh-macos-x64.zip
             multi_binary: multi-pwsh
 
           - name: macos-arm64
@@ -64,7 +64,7 @@ jobs:
             target: aarch64-apple-darwin
             host_archive: pwsh-host-macos-arm64.zip
             host_binary: pwsh-host
-            multi_archive: pwsh-multi-macos-arm64.zip
+            multi_archive: multi-pwsh-macos-arm64.zip
             multi_binary: multi-pwsh
 
     steps:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ matrix.host_archive }}
           if-no-files-found: error
 
-      - name: Upload pwsh-multi artifact
+      - name: Upload multi-pwsh artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.multi_archive }}
@@ -196,7 +196,7 @@ jobs:
         working-directory: dist
         run: |
           $zipFiles = Get-ChildItem -Recurse -File |
-            Where-Object { $_.Name -like 'pwsh-host-*.zip' -or $_.Name -like 'pwsh-multi-*.zip' } |
+            Where-Object { $_.Name -like 'pwsh-host-*.zip' -or $_.Name -like 'multi-pwsh-*.zip' } |
             Sort-Object Name
 
           if (-not $zipFiles) {
@@ -222,7 +222,7 @@ jobs:
           RELEASE_TARGET: ${{ github.sha }}
         run: |
           $zipFiles = Get-ChildItem -Path dist -Recurse -File |
-            Where-Object { $_.Name -like 'pwsh-host-*.zip' -or $_.Name -like 'pwsh-multi-*.zip' } |
+            Where-Object { $_.Name -like 'pwsh-host-*.zip' -or $_.Name -like 'multi-pwsh-*.zip' } |
             Sort-Object Name |
             ForEach-Object { $_.FullName }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "ureq",
+ "winresource",
  "zip",
 ]
 
@@ -662,6 +663,7 @@ version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "pwsh-host",
+ "winresource",
 ]
 
 [[package]]
@@ -884,6 +886,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,10 +1023,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1024,9 +1059,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "u16cstr"
@@ -1105,6 +1155,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1379,6 +1435,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
+name = "winresource"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e287ced0f21cd11f4035fe946fd3af145f068d1acb708afd248100f89ec7432d"
+dependencies = [
+ "toml",
+ "version_check",
 ]
 
 [[package]]

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -20,3 +20,6 @@ tar = "0.4"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 home = "0.5"
 tempfile = "3.12"
+
+[build-dependencies]
+winresource = "0.1"

--- a/crates/multi-pwsh/build.rs
+++ b/crates/multi-pwsh/build.rs
@@ -18,7 +18,5 @@ fn main() {
         .set("FileVersion", &version)
         .set("ProductVersion", &version);
 
-    resource
-        .compile()
-        .expect("failed to compile Windows resources");
+    resource.compile().expect("failed to compile Windows resources");
 }

--- a/crates/multi-pwsh/build.rs
+++ b/crates/multi-pwsh/build.rs
@@ -1,0 +1,24 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
+
+    if std::env::var_os("CARGO_CFG_WINDOWS").is_none() {
+        return;
+    }
+
+    let version = std::env::var("CARGO_PKG_VERSION").expect("missing CARGO_PKG_VERSION");
+
+    let mut resource = winresource::WindowsResource::new();
+    resource
+        .set("FileDescription", "Install and update side-by-side PowerShell versions")
+        .set("ProductName", "multi-pwsh")
+        .set("InternalName", "multi-pwsh")
+        .set("CompanyName", "Devolutions Inc")
+        .set("LegalCopyright", "Copyright 2021-2026 Devolutions Inc.")
+        .set("OriginalFilename", "multi-pwsh.exe")
+        .set("FileVersion", &version)
+        .set("ProductVersion", &version);
+
+    resource
+        .compile()
+        .expect("failed to compile Windows resources");
+}

--- a/crates/pwsh-host-cli/Cargo.toml
+++ b/crates/pwsh-host-cli/Cargo.toml
@@ -12,3 +12,6 @@ path = "src/main.rs"
 [dependencies]
 pwsh-host = { path = "../pwsh-host" }
 base64 = "0.22"
+
+[build-dependencies]
+winresource = "0.1"

--- a/crates/pwsh-host-cli/build.rs
+++ b/crates/pwsh-host-cli/build.rs
@@ -1,0 +1,24 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
+
+    if std::env::var_os("CARGO_CFG_WINDOWS").is_none() {
+        return;
+    }
+
+    let version = std::env::var("CARGO_PKG_VERSION").expect("missing CARGO_PKG_VERSION");
+
+    let mut resource = winresource::WindowsResource::new();
+    resource
+        .set("FileDescription", "pwsh-compatible CLI backed by pwsh-host and hostfxr")
+        .set("ProductName", "pwsh-host")
+        .set("InternalName", "pwsh-host")
+        .set("CompanyName", "Devolutions Inc")
+        .set("LegalCopyright", "Copyright 2021-2026 Devolutions Inc.")
+        .set("OriginalFilename", "pwsh-host.exe")
+        .set("FileVersion", &version)
+        .set("ProductVersion", &version);
+
+    resource
+        .compile()
+        .expect("failed to compile Windows resources");
+}

--- a/crates/pwsh-host-cli/build.rs
+++ b/crates/pwsh-host-cli/build.rs
@@ -18,7 +18,5 @@ fn main() {
         .set("FileVersion", &version)
         .set("ProductVersion", &version);
 
-    resource
-        .compile()
-        .expect("failed to compile Windows resources");
+    resource.compile().expect("failed to compile Windows resources");
 }

--- a/crates/pwsh-host-cli/src/named_pipe_command.rs
+++ b/crates/pwsh-host-cli/src/named_pipe_command.rs
@@ -1,13 +1,14 @@
 use std::error::Error;
 use std::ffi::{OsStr, OsString};
 use std::fmt::{Display, Formatter};
-use std::time::Duration;
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 
 const NAMED_PIPE_COMMAND_FLAG: &str = "-namedpipecommand";
 const ENCODED_COMMAND_FLAG: &str = "-EncodedCommand";
-const PIPE_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+#[cfg(windows)]
+const PIPE_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+#[cfg(windows)]
 const MAX_COMMAND_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug)]
@@ -126,7 +127,7 @@ fn read_named_pipe_command(pipe_name: &OsStr) -> Result<String, NamedPipeCommand
     use std::fs::OpenOptions;
     use std::io::Read;
     use std::thread::sleep;
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
 
     let pipe_name = pipe_name.to_string_lossy();
     if pipe_name.trim().is_empty() {


### PR DESCRIPTION
## Summary
- rename release artifacts from `pwsh-multi-*` to `multi-pwsh-*`
- add Windows version resource metadata for `multi-pwsh.exe` and `pwsh-host.exe`
- set company/copyright metadata to Devolutions Inc (2021-2026)
- silence non-Windows dead code warnings in named pipe command handling

## Validation
- `PwshExePath="$HOME/.pwsh/bin/pwsh-7.4" cargo check -p multi-pwsh -p pwsh-host-cli`
