### PR TITLE
Bump crates to 0.5.0 and add multi-pwsh bootstrap tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to build/publish (for example v0.4.0)
+        description: Release tag to build/publish
         required: true
         type: string
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "flate2",
  "home",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "pwsh-host",

--- a/README.md
+++ b/README.md
@@ -93,6 +93,44 @@ cargo run -p pwsh-host-cli --bin pwsh-host -- -NoLogo -NoProfile -Command "$PSVe
 - Alias location: `~/.pwsh/bin`
 - Alias format: `pwsh-<major.minor>` (example: `pwsh-7.4`)
 
+### Install `multi-pwsh` from GitHub Releases
+
+Latest release bootstrap scripts:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/awakecoding/pwsh-host-rs/main/tools/install-multi-pwsh.sh | bash
+```
+
+```powershell
+irm https://raw.githubusercontent.com/awakecoding/pwsh-host-rs/main/tools/install-multi-pwsh.ps1 | iex
+```
+
+Both scripts:
+
+- Download the latest `multi-pwsh` release archive for the current OS/architecture
+- Install the executable to `~/.pwsh/bin`
+- Add `~/.pwsh/bin` to PATH if missing
+
+Uninstall bootstrap scripts:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/awakecoding/pwsh-host-rs/main/tools/uninstall-multi-pwsh.sh | bash
+```
+
+```powershell
+irm https://raw.githubusercontent.com/awakecoding/pwsh-host-rs/main/tools/uninstall-multi-pwsh.ps1 | iex
+```
+
+Install a specific tag (for example `v0.5.0`):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/awakecoding/pwsh-host-rs/main/tools/install-multi-pwsh.sh | bash -s -- v0.5.0
+```
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/awakecoding/pwsh-host-rs/main/tools/install-multi-pwsh.ps1))) -Version v0.5.0
+```
+
 Examples:
 
 ```powershell
@@ -112,7 +150,7 @@ cargo run -p multi-pwsh -- list
 cargo run -p multi-pwsh -- doctor --repair-aliases
 ```
 
-`multi-pwsh` does not modify PATH automatically. Add `~/.pwsh/bin` to PATH once in your shell profile to make aliases discoverable.
+When `multi-pwsh` is installed via the bootstrap scripts above, `~/.pwsh/bin` is added to PATH automatically if needed.
 
 ## `-NamedPipeCommand` (Windows)
 

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "Install and update side-by-side PowerShell versions in user context"

--- a/crates/pwsh-host-cli/Cargo.toml
+++ b/crates/pwsh-host-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "pwsh-compatible CLI backed by pwsh-host and hostfxr"

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/awakecoding/pwsh-host-rs"

--- a/scripts/Bump-CrateVersions.ps1
+++ b/scripts/Bump-CrateVersions.ps1
@@ -12,6 +12,7 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $cratesRoot = Join-Path $repoRoot 'crates'
+$releaseWorkflow = Join-Path $repoRoot '.github/workflows/release.yml'
 
 if (-not (Test-Path -Path $cratesRoot -PathType Container)) {
     throw "Crates directory not found: $cratesRoot"
@@ -27,6 +28,7 @@ if (-not $cargoFiles) {
 
 $encoding = New-Object System.Text.UTF8Encoding($false)
 $updated = @()
+$workflowUpdated = $false
 
 foreach ($cargoFile in $cargoFiles) {
     $content = [System.IO.File]::ReadAllText($cargoFile)
@@ -52,10 +54,38 @@ foreach ($cargoFile in $cargoFiles) {
     $updated += $cargoFile
 }
 
-if ($updated.Count -eq 0) {
+if (Test-Path -Path $releaseWorkflow -PathType Leaf) {
+    $workflowContent = [System.IO.File]::ReadAllText($releaseWorkflow)
+    $workflowPattern = '(?m)(?<prefix>for example\s+v)(?<current>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)'
+    $workflowMatch = [System.Text.RegularExpressions.Regex]::Match($workflowContent, $workflowPattern)
+
+    if ($workflowMatch.Success -and $workflowMatch.Groups['current'].Value -ne $Version) {
+        $replacement = $workflowMatch.Groups['prefix'].Value + $Version
+        $newWorkflowContent = $workflowContent.Substring(0, $workflowMatch.Index) +
+            $replacement +
+            $workflowContent.Substring($workflowMatch.Index + $workflowMatch.Length)
+
+        if (-not $DryRun) {
+            [System.IO.File]::WriteAllText($releaseWorkflow, $newWorkflowContent, $encoding)
+        }
+
+        $workflowUpdated = $true
+    }
+}
+
+if ($updated.Count -eq 0 -and -not $workflowUpdated) {
     Write-Host "All crate package versions are already $Version"
+    if (Test-Path -Path $releaseWorkflow -PathType Leaf) {
+        Write-Host "No release workflow example tag needed updating"
+    }
     exit 0
 }
 
-Write-Host "Updated crate versions to ${Version}:"
-$updated | ForEach-Object { Write-Host " - $_" }
+if ($updated.Count -gt 0) {
+    Write-Host "Updated crate versions to ${Version}:"
+    $updated | ForEach-Object { Write-Host " - $_" }
+}
+
+if ($workflowUpdated) {
+    Write-Host "Updated release workflow example tag in: $releaseWorkflow"
+}

--- a/tools/install-multi-pwsh.ps1
+++ b/tools/install-multi-pwsh.ps1
@@ -1,0 +1,127 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$Version = 'latest',
+
+    [Parameter(Mandatory = $false)]
+    [string]$Owner = 'awakecoding',
+
+    [Parameter(Mandatory = $false)]
+    [string]$Repository = 'pwsh-host-rs'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-ReleaseArch {
+    $candidates = @($env:PROCESSOR_ARCHITECTURE, $env:PROCESSOR_ARCHITEW6432) | Where-Object { $_ }
+
+    foreach ($candidate in $candidates) {
+        switch ($candidate.ToUpperInvariant()) {
+            'ARM64' { return 'arm64' }
+            'AMD64' { return 'x64' }
+        }
+    }
+
+    if ([Environment]::Is64BitOperatingSystem) {
+        return 'x64'
+    }
+
+    throw "Unsupported architecture. Supported architectures: AMD64, ARM64"
+}
+
+function Test-PathContainsEntry {
+    param(
+        [string]$PathValue,
+        [string]$Entry
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return $false
+    }
+
+    $entryNormalized = $Entry.Trim().TrimEnd('\\')
+    $segments = $PathValue -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+    foreach ($segment in $segments) {
+        if ([string]::Equals($segment.Trim().TrimEnd('\\'), $entryNormalized, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+$arch = Get-ReleaseArch
+$assetName = "multi-pwsh-windows-$arch.zip"
+
+if ($Version -eq 'latest') {
+    $releasePath = 'latest/download'
+    $displayVersion = 'latest'
+}
+else {
+    if (-not $Version.StartsWith('v', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $Version = "v$Version"
+    }
+
+    $releasePath = "download/$Version"
+    $displayVersion = $Version
+}
+
+$downloadUrl = "https://github.com/$Owner/$Repository/releases/$releasePath/$assetName"
+$installRoot = Join-Path $HOME '.pwsh'
+$binDir = Join-Path $installRoot 'bin'
+$targetExe = Join-Path $binDir 'multi-pwsh.exe'
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("multi-pwsh-install-" + [System.Guid]::NewGuid().ToString('N'))
+$archivePath = Join-Path $tempRoot $assetName
+$extractDir = Join-Path $tempRoot 'extract'
+
+New-Item -Path $extractDir -ItemType Directory -Force | Out-Null
+
+try {
+    Write-Host "Downloading $assetName ($displayVersion)..."
+
+    $invokeParams = @{
+        Uri = $downloadUrl
+        OutFile = $archivePath
+    }
+
+    if ($PSVersionTable.PSEdition -eq 'Desktop') {
+        $invokeParams['UseBasicParsing'] = $true
+    }
+
+    Invoke-WebRequest @invokeParams
+
+    Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+
+    $sourceExe = Join-Path $extractDir 'multi-pwsh.exe'
+    if (-not (Test-Path -Path $sourceExe -PathType Leaf)) {
+        throw 'Archive did not contain expected binary: multi-pwsh.exe'
+    }
+
+    New-Item -Path $binDir -ItemType Directory -Force | Out-Null
+    Copy-Item -Path $sourceExe -Destination $targetExe -Force
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not (Test-PathContainsEntry -PathValue $userPath -Entry $binDir)) {
+        $newUserPath = if ([string]::IsNullOrWhiteSpace($userPath)) { $binDir } else { "$userPath;$binDir" }
+        [Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
+        $pathStatus = "Added $binDir to user PATH."
+    }
+    else {
+        $pathStatus = "$binDir is already present in user PATH."
+    }
+
+    if (-not (Test-PathContainsEntry -PathValue $env:Path -Entry $binDir)) {
+        $env:Path = "$binDir;$env:Path"
+    }
+
+    Write-Host "Installed multi-pwsh to $targetExe"
+    Write-Host $pathStatus
+    Write-Host 'Run: multi-pwsh --help'
+}
+finally {
+    if (Test-Path -Path $tempRoot -PathType Container) {
+        Remove-Item -Path $tempRoot -Recurse -Force
+    }
+}

--- a/tools/install-multi-pwsh.sh
+++ b/tools/install-multi-pwsh.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_owner="awakecoding"
+repo_name="pwsh-host-rs"
+
+version="${1:-latest}"
+install_root="${HOME}/.pwsh"
+bin_dir="${install_root}/bin"
+
+if [[ "${version}" == "latest" ]]; then
+  release_path="latest/download"
+  display_version="latest"
+else
+  if [[ "${version}" != v* ]]; then
+    version="v${version}"
+  fi
+  release_path="download/${version}"
+  display_version="${version}"
+fi
+
+uname_s="$(uname -s)"
+case "${uname_s}" in
+  Linux) os="linux" ;;
+  Darwin) os="macos" ;;
+  *)
+    echo "Unsupported OS: ${uname_s}. Supported OS: Linux, macOS." >&2
+    exit 1
+    ;;
+esac
+
+uname_m="$(uname -m)"
+case "${uname_m}" in
+  x86_64 | amd64) arch="x64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *)
+    echo "Unsupported architecture: ${uname_m}. Supported arch: x86_64/amd64, aarch64/arm64." >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if ! command -v unzip >/dev/null 2>&1; then
+  echo "unzip is required but was not found in PATH." >&2
+  exit 1
+fi
+
+asset="multi-pwsh-${os}-${arch}.zip"
+download_url="https://github.com/${repo_owner}/${repo_name}/releases/${release_path}/${asset}"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+archive_path="${tmp_dir}/${asset}"
+extract_dir="${tmp_dir}/extract"
+
+echo "Downloading ${asset} (${display_version})..."
+curl -fsSL "${download_url}" -o "${archive_path}"
+
+mkdir -p "${extract_dir}"
+unzip -q "${archive_path}" -d "${extract_dir}"
+
+binary_source="${extract_dir}/multi-pwsh"
+if [[ ! -f "${binary_source}" ]]; then
+  echo "Archive did not contain expected binary: multi-pwsh" >&2
+  exit 1
+fi
+
+mkdir -p "${bin_dir}"
+if command -v install >/dev/null 2>&1; then
+  install -m 0755 "${binary_source}" "${bin_dir}/multi-pwsh"
+else
+  cp "${binary_source}" "${bin_dir}/multi-pwsh"
+  chmod 0755 "${bin_dir}/multi-pwsh"
+fi
+
+if [[ ":${PATH}:" != *":${bin_dir}:"* ]]; then
+  export PATH="${bin_dir}:${PATH}"
+fi
+
+profile_candidates=()
+if [[ "${SHELL:-}" == *"zsh"* ]]; then
+  profile_candidates+=("${HOME}/.zshrc")
+fi
+if [[ "${SHELL:-}" == *"bash"* ]]; then
+  profile_candidates+=("${HOME}/.bashrc")
+fi
+profile_candidates+=("${HOME}/.profile")
+
+profile_file=""
+for candidate in "${profile_candidates[@]}"; do
+  if [[ -f "${candidate}" ]]; then
+    profile_file="${candidate}"
+    break
+  fi
+done
+
+if [[ -z "${profile_file}" ]]; then
+  profile_file="${profile_candidates[0]}"
+fi
+
+touch "${profile_file}"
+if grep -Fq '.pwsh/bin' "${profile_file}"; then
+  path_status="PATH already contains ${bin_dir} in ${profile_file}"
+else
+  {
+    echo ""
+    echo "# Added by multi-pwsh installer"
+    echo 'export PATH="$HOME/.pwsh/bin:$PATH"'
+  } >>"${profile_file}"
+  path_status="Added ${bin_dir} to PATH in ${profile_file}"
+fi
+
+echo "Installed multi-pwsh to ${bin_dir}/multi-pwsh"
+echo "${path_status}"
+echo "Run: multi-pwsh --help"

--- a/tools/uninstall-multi-pwsh.ps1
+++ b/tools/uninstall-multi-pwsh.ps1
@@ -1,0 +1,59 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+function Remove-PathEntry {
+    param(
+        [string]$PathValue,
+        [string]$Entry
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return $PathValue
+    }
+
+    $entryNormalized = $Entry.Trim().TrimEnd('\\')
+    $segments = $PathValue -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+    $filtered = $segments | Where-Object {
+        -not [string]::Equals($_.Trim().TrimEnd('\\'), $entryNormalized, [System.StringComparison]::OrdinalIgnoreCase)
+    }
+
+    return ($filtered -join ';')
+}
+
+$installRoot = Join-Path $HOME '.pwsh'
+$binDir = Join-Path $installRoot 'bin'
+$targetExe = Join-Path $binDir 'multi-pwsh.exe'
+
+if (Test-Path -Path $targetExe -PathType Leaf) {
+    Remove-Item -Path $targetExe -Force
+    Write-Host "Removed $targetExe"
+}
+else {
+    Write-Host "No installed binary found at $targetExe"
+}
+
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+$newUserPath = Remove-PathEntry -PathValue $userPath -Entry $binDir
+
+if ($newUserPath -ne $userPath) {
+    [Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
+    Write-Host "Removed $binDir from user PATH"
+}
+
+$newProcessPath = Remove-PathEntry -PathValue $env:Path -Entry $binDir
+if ($newProcessPath -ne $env:Path) {
+    $env:Path = $newProcessPath
+}
+
+if (Test-Path -Path $binDir -PathType Container) {
+    $remaining = Get-ChildItem -Path $binDir -Force -ErrorAction SilentlyContinue
+    if (-not $remaining) {
+        Remove-Item -Path $binDir -Force
+        Write-Host "Removed empty directory $binDir"
+    }
+}
+
+Write-Host 'multi-pwsh uninstall complete'

--- a/tools/uninstall-multi-pwsh.sh
+++ b/tools/uninstall-multi-pwsh.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install_root="${HOME}/.pwsh"
+bin_dir="${install_root}/bin"
+binary_path="${bin_dir}/multi-pwsh"
+
+remove_profile_entries() {
+  local profile_file="$1"
+
+  [[ -f "${profile_file}" ]] || return 0
+
+  local temp_file
+  temp_file="$(mktemp)"
+
+  awk '
+    $0 == "# Added by multi-pwsh installer" { changed = 1; next }
+    $0 == "export PATH=\"$HOME/.pwsh/bin:$PATH\"" { changed = 1; next }
+    { print }
+  ' "${profile_file}" > "${temp_file}"
+
+  if ! cmp -s "${profile_file}" "${temp_file}"; then
+    mv "${temp_file}" "${profile_file}"
+    echo "Removed PATH profile entry from ${profile_file}"
+  else
+    rm -f "${temp_file}"
+  fi
+}
+
+if [[ -f "${binary_path}" ]]; then
+  rm -f "${binary_path}"
+  echo "Removed ${binary_path}"
+else
+  echo "No installed binary found at ${binary_path}"
+fi
+
+if [[ ":${PATH}:" == *":${bin_dir}:"* ]]; then
+  export PATH=":${PATH}:"
+  export PATH="${PATH//:${bin_dir}:/}"
+  export PATH="${PATH#:}"
+  export PATH="${PATH%:}"
+fi
+
+remove_profile_entries "${HOME}/.zshrc"
+remove_profile_entries "${HOME}/.bashrc"
+remove_profile_entries "${HOME}/.profile"
+
+if [[ -d "${bin_dir}" ]] && [[ -z "$(ls -A "${bin_dir}")" ]]; then
+  rmdir "${bin_dir}"
+  echo "Removed empty directory ${bin_dir}"
+fi
+
+echo "multi-pwsh uninstall complete"


### PR DESCRIPTION
## Summary
- bump workspace crates to 0.5.0 and refresh Cargo.lock workspace package entries
- enhance version bump script to also update the release workflow example tag when present
- add multi-pwsh bootstrap install/uninstall scripts for bash and Windows PowerShell under tools/
- document install/uninstall one-liners and versioned install usage in README

## Validation
- cargo build --all-targets
- cargo test --all-targets
- dotnet build dotnet/Bindings.csproj
- dotnet test dotnet/Bindings.csproj --no-build
- script syntax checks for install/uninstall scripts (bash -n and PowerShell parser)