### PR TITLE
multi-pwsh: support online/prerelease listing and prerelease-friendly installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Install PowerShell aliases
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           multi-pwsh install 7.4
           multi-pwsh install 7.5
@@ -90,6 +92,8 @@ jobs:
 
       - name: Install PowerShell aliases
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           multi-pwsh install 7.4
           multi-pwsh install 7.5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,16 @@ This file is guidance for AI/code agents working in this repository.
 - .NET target framework is `net8.0` in `dotnet/Bindings.csproj`.
 - Rust crate uses edition 2018.
 
-## Pre-PR checklist (match CI lint job)
+## PR preparation policy (mandatory)
 
-Run these before opening a PR to avoid lint failures:
+- During local iteration, it is acceptable to skip lint/test commands for speed.
+- Before any PR-ready action (`git commit` for review, `git push`, or opening/updating a PR), agents **MUST** run the PR gate below and ensure it passes.
+- Do not open or update a PR with known failing lint/checks unless the user explicitly asks for that.
+- If a gate command cannot run due to environment limitations, call that out clearly to the user before PR creation.
+
+## Mandatory PR gate (match CI lint job)
+
+Run these before opening/updating a PR to avoid immediate CI failures:
 
 ```powershell
 rustup toolchain install stable --profile minimal
@@ -30,7 +37,7 @@ If `cargo fmt --all --check` fails, run `cargo fmt --all` and re-run the check.
 
 ## Required verification
 
-Run these after meaningful code changes:
+Run these after meaningful code changes, and before PR if those changes are part of the PR:
 
 ```powershell
 cargo build --all-targets

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ multi-pwsh install 7.5
 Verify aliases:
 
 ```powershell
+pwsh-7 -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
 pwsh-7.4 -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
 pwsh-7.5 -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
 ```
@@ -61,6 +62,13 @@ Manage installed lines:
 multi-pwsh update 7.4
 multi-pwsh update 7.5
 multi-pwsh list
+multi-pwsh list --available
+multi-pwsh list --available --include-prerelease
+multi-pwsh install 7.6 --include-prerelease
+multi-pwsh install 7.6-preview6
+multi-pwsh install 7.6-rc1
+multi-pwsh install 7.6.0-rc.1
+multi-pwsh update 7.6 --include-prerelease
 multi-pwsh doctor --repair-aliases
 ```
 

--- a/crates/multi-pwsh/src/aliases.rs
+++ b/crates/multi-pwsh/src/aliases.rs
@@ -10,6 +10,12 @@ use crate::layout::InstallLayout;
 use crate::platform::HostOs;
 use crate::versions::MajorMinor;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AliasSelector {
+    Major(u64),
+    MajorMinor(MajorMinor),
+}
+
 pub fn create_or_update_alias(
     layout: &InstallLayout,
     os: HostOs,
@@ -17,10 +23,30 @@ pub fn create_or_update_alias(
     version: &Version,
     target: &Path,
 ) -> Result<PathBuf> {
+    create_or_update_alias_with_selector(layout, os, AliasSelector::MajorMinor(line), version, target)
+}
+
+pub fn create_or_update_major_alias(
+    layout: &InstallLayout,
+    os: HostOs,
+    major: u64,
+    version: &Version,
+    target: &Path,
+) -> Result<PathBuf> {
+    create_or_update_alias_with_selector(layout, os, AliasSelector::Major(major), version, target)
+}
+
+fn create_or_update_alias_with_selector(
+    layout: &InstallLayout,
+    os: HostOs,
+    selector: AliasSelector,
+    version: &Version,
+    target: &Path,
+) -> Result<PathBuf> {
     fs::create_dir_all(layout.bin_dir())?;
 
-    let alias_command = alias_command_name(line);
-    let alias_file = alias_file_name(line, os);
+    let alias_command = alias_command_name(selector);
+    let alias_file = alias_file_name(selector, os);
     let alias_path = layout.bin_dir().join(alias_file);
 
     if os == HostOs::Windows {
@@ -68,16 +94,22 @@ pub fn remove_alias(layout: &InstallLayout, os: HostOs, alias_command: &str) -> 
     Ok(removed)
 }
 
-pub fn parse_alias_command_line(alias_command: &str) -> Option<MajorMinor> {
-    let line = alias_command.strip_prefix("pwsh-")?;
-    let parts: Vec<&str> = line.split('.').collect();
-    if parts.len() != 2 {
-        return None;
+pub fn parse_alias_command_selector(alias_command: &str) -> Option<AliasSelector> {
+    let selector = alias_command.strip_prefix("pwsh-")?;
+
+    let parts: Vec<&str> = selector.split('.').collect();
+    if parts.len() == 1 {
+        let major = parts[0].parse::<u64>().ok()?;
+        return Some(AliasSelector::Major(major));
     }
 
-    let major = parts[0].parse::<u64>().ok()?;
-    let minor = parts[1].parse::<u64>().ok()?;
-    Some(MajorMinor { major, minor })
+    if parts.len() == 2 {
+        let major = parts[0].parse::<u64>().ok()?;
+        let minor = parts[1].parse::<u64>().ok()?;
+        return Some(AliasSelector::MajorMinor(MajorMinor { major, minor }));
+    }
+
+    None
 }
 
 pub fn read_alias_metadata(layout: &InstallLayout) -> Result<HashMap<String, String>> {
@@ -99,8 +131,8 @@ fn write_alias_metadata(layout: &InstallLayout, aliases: HashMap<String, String>
     Ok(())
 }
 
-fn alias_file_name(line: MajorMinor, os: HostOs) -> String {
-    alias_file_name_from_command(&alias_command_name(line), os)
+fn alias_file_name(selector: AliasSelector, os: HostOs) -> String {
+    alias_file_name_from_command(&alias_command_name(selector), os)
 }
 
 fn alias_file_name_from_command(alias_command: &str, os: HostOs) -> String {
@@ -110,8 +142,11 @@ fn alias_file_name_from_command(alias_command: &str, os: HostOs) -> String {
     }
 }
 
-fn alias_command_name(line: MajorMinor) -> String {
-    format!("pwsh-{}.{}", line.major, line.minor)
+fn alias_command_name(selector: AliasSelector) -> String {
+    match selector {
+        AliasSelector::Major(major) => format!("pwsh-{}", major),
+        AliasSelector::MajorMinor(line) => format!("pwsh-{}.{}", line.major, line.minor),
+    }
 }
 
 #[cfg(unix)]
@@ -168,23 +203,40 @@ mod tests {
     #[test]
     fn alias_name_uses_major_minor() {
         let line = MajorMinor { major: 7, minor: 4 };
-        assert_eq!(alias_command_name(line), "pwsh-7.4");
-        assert_eq!(alias_file_name(line, HostOs::Linux), "pwsh-7.4");
-        assert_eq!(alias_file_name(line, HostOs::Windows), "pwsh-7.4.cmd");
+        assert_eq!(alias_command_name(AliasSelector::MajorMinor(line)), "pwsh-7.4");
+        assert_eq!(
+            alias_file_name(AliasSelector::MajorMinor(line), HostOs::Linux),
+            "pwsh-7.4"
+        );
+        assert_eq!(
+            alias_file_name(AliasSelector::MajorMinor(line), HostOs::Windows),
+            "pwsh-7.4.cmd"
+        );
     }
 
     #[test]
-    fn parses_alias_line() {
-        let line = parse_alias_command_line("pwsh-7.5").unwrap();
-        assert_eq!(line.major, 7);
-        assert_eq!(line.minor, 5);
+    fn alias_name_supports_major() {
+        assert_eq!(alias_command_name(AliasSelector::Major(7)), "pwsh-7");
+        assert_eq!(alias_file_name(AliasSelector::Major(7), HostOs::Linux), "pwsh-7");
+        assert_eq!(alias_file_name(AliasSelector::Major(7), HostOs::Windows), "pwsh-7.cmd");
     }
 
     #[test]
-    fn rejects_invalid_alias_line() {
-        assert!(parse_alias_command_line("pwsh").is_none());
-        assert!(parse_alias_command_line("pwsh-7").is_none());
-        assert!(parse_alias_command_line("pwsh-7.5.1").is_none());
-        assert!(parse_alias_command_line("not-pwsh-7.5").is_none());
+    fn parses_alias_major_minor_selector() {
+        let selector = parse_alias_command_selector("pwsh-7.5").unwrap();
+        assert_eq!(selector, AliasSelector::MajorMinor(MajorMinor { major: 7, minor: 5 }));
+    }
+
+    #[test]
+    fn parses_alias_major_selector() {
+        let selector = parse_alias_command_selector("pwsh-7").unwrap();
+        assert_eq!(selector, AliasSelector::Major(7));
+    }
+
+    #[test]
+    fn rejects_invalid_alias_selector() {
+        assert!(parse_alias_command_selector("pwsh").is_none());
+        assert!(parse_alias_command_selector("pwsh-7.5.1").is_none());
+        assert!(parse_alias_command_selector("not-pwsh-7.5").is_none());
     }
 }

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -12,7 +12,9 @@ use std::process;
 
 use semver::Version;
 
-use aliases::{create_or_update_alias, parse_alias_command_line, remove_alias};
+use aliases::{
+    create_or_update_alias, create_or_update_major_alias, parse_alias_command_selector, remove_alias, AliasSelector,
+};
 use error::{MultiPwshError, Result};
 use install::ensure_installed;
 use layout::InstallLayout;
@@ -22,34 +24,80 @@ use versions::{parse_exact_version, parse_install_selector, parse_major_minor_se
 
 fn print_usage() {
     eprintln!(
-        "Usage:\n  multi-pwsh install <version|major.minor> [--arch <auto|x64|x86|arm64|arm32>]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>]\n  multi-pwsh uninstall <version> [--force]\n  multi-pwsh list\n  multi-pwsh doctor --repair-aliases"
+        "Usage:\n  multi-pwsh install <version|major|major.minor> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh uninstall <version> [--force]\n  multi-pwsh list [--available] [--include-prerelease]\n  multi-pwsh doctor --repair-aliases"
     );
 }
 
-fn parse_arch_option(args: &[String]) -> Result<Option<HostArch>> {
-    if args.is_empty() {
-        return Ok(None);
+struct ReleaseSelectionOptions {
+    arch: Option<HostArch>,
+    include_prerelease: bool,
+}
+
+enum ListOption {
+    Installed,
+    Available { include_prerelease: bool },
+}
+
+fn latest_installed_in_major(layout: &InstallLayout, major: u64) -> Result<Option<Version>> {
+    let versions = layout.installed_versions()?;
+    Ok(versions.into_iter().find(|version| version.major == major))
+}
+
+fn parse_release_selection_options(args: &[String]) -> Result<ReleaseSelectionOptions> {
+    let mut arch = None;
+    let mut arch_specified = false;
+    let mut include_prerelease = false;
+
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--arch" | "-a" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --arch".to_string(),
+                    ));
+                }
+
+                if arch_specified {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--arch can only be specified once".to_string(),
+                    ));
+                }
+                arch_specified = true;
+
+                if args[index + 1] == "auto" {
+                    arch = None;
+                } else {
+                    arch = Some(HostArch::parse(&args[index + 1]).ok_or_else(|| {
+                        MultiPwshError::InvalidArguments(format!(
+                            "unsupported architecture '{}', expected one of: auto, x64, x86, arm64, arm32",
+                            args[index + 1]
+                        ))
+                    })?);
+                }
+
+                index += 2;
+            }
+            "--include-prerelease" | "--prerelease" => {
+                include_prerelease = true;
+                index += 1;
+            }
+            _ => {
+                return Err(MultiPwshError::InvalidArguments(
+                    "expected optional --arch <value> and/or --include-prerelease"
+                        .to_string(),
+                ));
+            }
+        }
     }
 
-    if args.len() != 2 || (args[0] != "--arch" && args[0] != "-a") {
-        return Err(MultiPwshError::InvalidArguments(
-            "expected optional --arch <value>".to_string(),
-        ));
-    }
-
-    if args[1] == "auto" {
-        return Ok(None);
-    }
-
-    HostArch::parse(&args[1]).map(Some).ok_or_else(|| {
-        MultiPwshError::InvalidArguments(format!(
-            "unsupported architecture '{}', expected one of: auto, x64, x86, arm64, arm32",
-            args[1]
-        ))
+    Ok(ReleaseSelectionOptions {
+        arch,
+        include_prerelease,
     })
 }
 
-fn run_install(selector_input: &str, arch: Option<HostArch>) -> Result<()> {
+fn run_install(selector_input: &str, arch: Option<HostArch>, include_prerelease: bool) -> Result<()> {
     let selector = parse_install_selector(selector_input)?;
     let os = HostOs::detect()?;
     let arch = arch.unwrap_or_else(HostArch::detect);
@@ -59,21 +107,30 @@ fn run_install(selector_input: &str, arch: Option<HostArch>) -> Result<()> {
 
     let token = env::var("GITHUB_TOKEN").ok();
     let release_client = ReleaseClient::new(token)?;
-    let release = release_client.resolve_selector(selector, os, arch)?;
+    let release = release_client.resolve_selector(selector, os, arch, include_prerelease)?;
     let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release)?;
 
     let line = release.version_line();
     let alias_path = create_or_update_alias(&layout, os, line, &release.version, &executable_path)?;
+    let major_alias_path = latest_installed_in_major(&layout, release.version.major)?
+        .map(|version| {
+            let target = layout.version_executable(&version);
+            create_or_update_major_alias(&layout, os, version.major, &version, &target)
+        })
+        .transpose()?;
 
     println!("Installed PowerShell {}", release.version);
     println!("Version path: {}", layout.version_dir(&release.version).display());
     println!("Updated alias: {}", alias_path.display());
+    if let Some(path) = major_alias_path {
+        println!("Updated major alias: {}", path.display());
+    }
     println!("Add to PATH once: {}", layout.bin_dir().display());
 
     Ok(())
 }
 
-fn run_update(line_input: &str, arch: Option<HostArch>) -> Result<()> {
+fn run_update(line_input: &str, arch: Option<HostArch>, include_prerelease: bool) -> Result<()> {
     let line = parse_major_minor_selector(line_input)?;
     let os = HostOs::detect()?;
     let arch = arch.unwrap_or_else(HostArch::detect);
@@ -83,14 +140,23 @@ fn run_update(line_input: &str, arch: Option<HostArch>) -> Result<()> {
 
     let token = env::var("GITHUB_TOKEN").ok();
     let release_client = ReleaseClient::new(token)?;
-    let release = release_client.resolve_latest_in_line(line, os, arch)?;
+    let release = release_client.resolve_latest_in_line(line, os, arch, include_prerelease)?;
     let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release)?;
 
     let alias_path = create_or_update_alias(&layout, os, line, &release.version, &executable_path)?;
+    let major_alias_path = latest_installed_in_major(&layout, release.version.major)?
+        .map(|version| {
+            let target = layout.version_executable(&version);
+            create_or_update_major_alias(&layout, os, version.major, &version, &target)
+        })
+        .transpose()?;
 
     println!("Updated line {} to {}", line, release.version);
     println!("Version path: {}", layout.version_dir(&release.version).display());
     println!("Updated alias: {}", alias_path.display());
+    if let Some(path) = major_alias_path {
+        println!("Updated major alias: {}", path.display());
+    }
     println!("Add to PATH once: {}", layout.bin_dir().display());
 
     Ok(())
@@ -107,6 +173,47 @@ fn parse_force_option(args: &[String]) -> Result<bool> {
 
     Err(MultiPwshError::InvalidArguments(
         "expected optional --force".to_string(),
+    ))
+}
+
+fn parse_list_option(args: &[String]) -> Result<ListOption> {
+    if args.is_empty() {
+        return Ok(ListOption::Installed);
+    }
+
+    let mut available = false;
+    let mut include_prerelease = false;
+
+    for arg in args {
+        match arg.as_str() {
+            "--available" | "--online" => {
+                available = true;
+            }
+            "--include-prerelease" | "--prerelease" => {
+                include_prerelease = true;
+            }
+            _ => {
+                return Err(MultiPwshError::InvalidArguments(
+                    "expected optional --available and/or --include-prerelease".to_string(),
+                ));
+            }
+        }
+    }
+
+    if include_prerelease && !available {
+        return Err(MultiPwshError::InvalidArguments(
+            "--include-prerelease requires --available".to_string(),
+        ));
+    }
+
+    if available {
+        return Ok(ListOption::Available {
+            include_prerelease,
+        });
+    }
+
+    Err(MultiPwshError::InvalidArguments(
+        "expected optional --available".to_string(),
     ))
 }
 
@@ -158,17 +265,29 @@ fn run_uninstall(version_input: &str, force: bool) -> Result<()> {
     let mut removed_aliases = 0usize;
 
     for alias_name in affected_aliases {
-        let fallback_version = parse_alias_command_line(&alias_name).and_then(|line| {
-            installed_versions
+        let alias_selector = parse_alias_command_selector(&alias_name);
+        let fallback_version = alias_selector.and_then(|selector| match selector {
+            AliasSelector::MajorMinor(line) => installed_versions
                 .iter()
                 .find(|candidate| MajorMinor::from_version(candidate) == line)
-                .cloned()
+                .cloned(),
+            AliasSelector::Major(major) => installed_versions
+                .iter()
+                .find(|candidate| candidate.major == major)
+                .cloned(),
         });
 
         if let Some(fallback_version) = fallback_version {
-            let line = MajorMinor::from_version(&fallback_version);
             let target = layout.version_executable(&fallback_version);
-            let alias_path = create_or_update_alias(&layout, os, line, &fallback_version, &target)?;
+            let alias_path = match alias_selector {
+                Some(AliasSelector::MajorMinor(line)) => {
+                    create_or_update_alias(&layout, os, line, &fallback_version, &target)?
+                }
+                Some(AliasSelector::Major(major)) => {
+                    create_or_update_major_alias(&layout, os, major, &fallback_version, &target)?
+                }
+                None => continue,
+            };
             println!("Updated alias: {} -> {}", alias_name, fallback_version);
             println!("Alias path: {}", alias_path.display());
             updated_aliases += 1;
@@ -189,38 +308,65 @@ fn run_uninstall(version_input: &str, force: bool) -> Result<()> {
     Ok(())
 }
 
-fn run_list() -> Result<()> {
-    let os = HostOs::detect()?;
-    let layout = InstallLayout::new(os)?;
-    let versions = layout.installed_versions()?;
-    let aliases = aliases::read_alias_metadata(&layout)?;
+fn run_list(option: ListOption) -> Result<()> {
+    match option {
+        ListOption::Installed => {
+            let os = HostOs::detect()?;
+            let layout = InstallLayout::new(os)?;
+            let versions = layout.installed_versions()?;
+            let aliases = aliases::read_alias_metadata(&layout)?;
 
-    println!("Install root: {}", layout.root().display());
-    println!("Alias bin: {}", layout.bin_dir().display());
-    println!();
+            println!("Install root: {}", layout.root().display());
+            println!("Alias bin: {}", layout.bin_dir().display());
+            println!();
 
-    if versions.is_empty() {
-        println!("Installed versions: (none)");
-    } else {
-        println!("Installed versions:");
-        for version in versions {
-            println!("  - {}", version);
+            if versions.is_empty() {
+                println!("Installed versions: (none)");
+            } else {
+                println!("Installed versions:");
+                for version in versions {
+                    println!("  - {}", version);
+                }
+            }
+
+            println!();
+            if aliases.is_empty() {
+                println!("Aliases: (none)");
+            } else {
+                println!("Aliases:");
+                let mut items: Vec<_> = aliases.into_iter().collect();
+                items.sort_by(|a, b| a.0.cmp(&b.0));
+                for (alias, version) in items {
+                    println!("  - {} -> {}", alias, version);
+                }
+            }
+
+            Ok(())
+        }
+        ListOption::Available {
+            include_prerelease,
+        } => {
+            let token = env::var("GITHUB_TOKEN").ok();
+            let release_client = ReleaseClient::new(token)?;
+            let versions = release_client.list_available_versions(include_prerelease)?;
+
+            if versions.is_empty() {
+                println!("Available online versions: (none)");
+                return Ok(());
+            }
+
+            if include_prerelease {
+                println!("Available online versions (including prerelease):");
+            } else {
+                println!("Available online versions:");
+            }
+            for version in versions {
+                println!("  - {}", version);
+            }
+
+            Ok(())
         }
     }
-
-    println!();
-    if aliases.is_empty() {
-        println!("Aliases: (none)");
-    } else {
-        println!("Aliases:");
-        let mut items: Vec<_> = aliases.into_iter().collect();
-        items.sort_by(|a, b| a.0.cmp(&b.0));
-        for (alias, version) in items {
-            println!("  - {} -> {}", alias, version);
-        }
-    }
-
-    Ok(())
 }
 
 fn run_doctor(args: &[String]) -> Result<()> {
@@ -267,8 +413,15 @@ fn run_doctor(args: &[String]) -> Result<()> {
             continue;
         }
 
-        let line = MajorMinor::from_version(&version);
-        let alias_path = create_or_update_alias(&layout, os, line, &version, &target)?;
+        let alias_path = match parse_alias_command_selector(&alias_name) {
+            Some(AliasSelector::MajorMinor(line)) => create_or_update_alias(&layout, os, line, &version, &target)?,
+            Some(AliasSelector::Major(major)) => create_or_update_major_alias(&layout, os, major, &version, &target)?,
+            None => {
+                eprintln!("Skipping alias {}: unsupported alias name format", alias_name);
+                skipped += 1;
+                continue;
+            }
+        };
         println!("Repaired alias: {}", alias_path.display());
         repaired += 1;
     }
@@ -288,11 +441,11 @@ fn run() -> Result<()> {
         "install" => {
             if args.len() < 2 {
                 return Err(MultiPwshError::InvalidArguments(
-                    "install requires <version|major.minor>".to_string(),
+                    "install requires <version|major|major.minor>".to_string(),
                 ));
             }
-            let arch = parse_arch_option(&args[2..])?;
-            run_install(&args[1], arch)
+            let options = parse_release_selection_options(&args[2..])?;
+            run_install(&args[1], options.arch, options.include_prerelease)
         }
         "update" => {
             if args.len() < 2 {
@@ -300,8 +453,8 @@ fn run() -> Result<()> {
                     "update requires <major.minor>".to_string(),
                 ));
             }
-            let arch = parse_arch_option(&args[2..])?;
-            run_update(&args[1], arch)
+            let options = parse_release_selection_options(&args[2..])?;
+            run_update(&args[1], options.arch, options.include_prerelease)
         }
         "uninstall" => {
             if args.len() < 2 {
@@ -313,12 +466,8 @@ fn run() -> Result<()> {
             run_uninstall(&args[1], force)
         }
         "list" => {
-            if args.len() != 1 {
-                return Err(MultiPwshError::InvalidArguments(
-                    "list does not accept additional arguments".to_string(),
-                ));
-            }
-            run_list()
+            let list_option = parse_list_option(&args[1..])?;
+            run_list(list_option)
         }
         "doctor" => run_doctor(&args[1..]),
         "-h" | "--help" | "help" => {
@@ -359,5 +508,61 @@ mod tests {
     fn parse_force_option_rejects_unexpected_args() {
         let args = vec!["--arch".to_string(), "x64".to_string()];
         assert!(parse_force_option(&args).is_err());
+    }
+
+    #[test]
+    fn parse_list_option_defaults_to_installed() {
+        let args: Vec<String> = Vec::new();
+        assert!(matches!(parse_list_option(&args).unwrap(), ListOption::Installed));
+    }
+
+    #[test]
+    fn parse_list_option_accepts_available() {
+        let args = vec!["--available".to_string()];
+        assert!(matches!(
+            parse_list_option(&args).unwrap(),
+            ListOption::Available {
+                include_prerelease: false
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_list_option_accepts_available_with_prerelease() {
+        let args = vec!["--available".to_string(), "--include-prerelease".to_string()];
+        assert!(matches!(
+            parse_list_option(&args).unwrap(),
+            ListOption::Available {
+                include_prerelease: true
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_list_option_rejects_unexpected_args() {
+        let args = vec!["--arch".to_string(), "x64".to_string()];
+        assert!(parse_list_option(&args).is_err());
+    }
+
+    #[test]
+    fn parse_list_option_rejects_prerelease_without_available() {
+        let args = vec!["--include-prerelease".to_string()];
+        assert!(parse_list_option(&args).is_err());
+    }
+
+    #[test]
+    fn parse_release_selection_options_accepts_prerelease() {
+        let args = vec!["--include-prerelease".to_string()];
+        let options = parse_release_selection_options(&args).unwrap();
+        assert!(options.include_prerelease);
+        assert!(options.arch.is_none());
+    }
+
+    #[test]
+    fn parse_release_selection_options_accepts_arch_and_prerelease() {
+        let args = vec!["--arch".to_string(), "x64".to_string(), "--include-prerelease".to_string()];
+        let options = parse_release_selection_options(&args).unwrap();
+        assert!(options.include_prerelease);
+        assert!(matches!(options.arch, Some(HostArch::X64)));
     }
 }

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -84,8 +84,7 @@ fn parse_release_selection_options(args: &[String]) -> Result<ReleaseSelectionOp
             }
             _ => {
                 return Err(MultiPwshError::InvalidArguments(
-                    "expected optional --arch <value> and/or --include-prerelease"
-                        .to_string(),
+                    "expected optional --arch <value> and/or --include-prerelease".to_string(),
                 ));
             }
         }
@@ -207,9 +206,7 @@ fn parse_list_option(args: &[String]) -> Result<ListOption> {
     }
 
     if available {
-        return Ok(ListOption::Available {
-            include_prerelease,
-        });
+        return Ok(ListOption::Available { include_prerelease });
     }
 
     Err(MultiPwshError::InvalidArguments(
@@ -343,9 +340,7 @@ fn run_list(option: ListOption) -> Result<()> {
 
             Ok(())
         }
-        ListOption::Available {
-            include_prerelease,
-        } => {
+        ListOption::Available { include_prerelease } => {
             let token = env::var("GITHUB_TOKEN").ok();
             let release_client = ReleaseClient::new(token)?;
             let versions = release_client.list_available_versions(include_prerelease)?;
@@ -560,7 +555,11 @@ mod tests {
 
     #[test]
     fn parse_release_selection_options_accepts_arch_and_prerelease() {
-        let args = vec!["--arch".to_string(), "x64".to_string(), "--include-prerelease".to_string()];
+        let args = vec![
+            "--arch".to_string(),
+            "x64".to_string(),
+            "--include-prerelease".to_string(),
+        ];
         let options = parse_release_selection_options(&args).unwrap();
         assert!(options.include_prerelease);
         assert!(matches!(options.arch, Some(HostArch::X64)));

--- a/crates/multi-pwsh/src/release.rs
+++ b/crates/multi-pwsh/src/release.rs
@@ -53,9 +53,7 @@ impl ReleaseClient {
         match selector {
             VersionSelector::Major(major) => self.resolve_latest_in_major(major, os, arch, include_prerelease),
             VersionSelector::Exact(version) => self.resolve_exact(version, os, arch),
-            VersionSelector::MajorMinor(line) => {
-                self.resolve_latest_in_line(line, os, arch, include_prerelease)
-            }
+            VersionSelector::MajorMinor(line) => self.resolve_latest_in_line(line, os, arch, include_prerelease),
         }
     }
 

--- a/crates/multi-pwsh/src/release.rs
+++ b/crates/multi-pwsh/src/release.rs
@@ -43,18 +43,57 @@ impl ReleaseClient {
         &self.http
     }
 
-    pub fn resolve_selector(&self, selector: VersionSelector, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
+    pub fn resolve_selector(
+        &self,
+        selector: VersionSelector,
+        os: HostOs,
+        arch: HostArch,
+        include_prerelease: bool,
+    ) -> Result<ResolvedRelease> {
         match selector {
+            VersionSelector::Major(major) => self.resolve_latest_in_major(major, os, arch, include_prerelease),
             VersionSelector::Exact(version) => self.resolve_exact(version, os, arch),
-            VersionSelector::MajorMinor(line) => self.resolve_latest_in_line(line, os, arch),
+            VersionSelector::MajorMinor(line) => {
+                self.resolve_latest_in_line(line, os, arch, include_prerelease)
+            }
         }
     }
 
-    pub fn resolve_latest_in_line(&self, line: MajorMinor, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
+    pub fn resolve_latest_in_major(
+        &self,
+        major: u64,
+        os: HostOs,
+        arch: HostArch,
+        include_prerelease: bool,
+    ) -> Result<ResolvedRelease> {
         let releases = self.fetch_releases()?;
         let mut candidates: Vec<ParsedRelease> = releases
             .into_iter()
-            .filter(|release| !release.prerelease)
+            .filter(|release| include_prerelease || !release.prerelease)
+            .filter_map(ParsedRelease::from_github_release)
+            .filter(|release| release.version.major == major)
+            .collect();
+
+        candidates.sort_by(|a, b| b.version.cmp(&a.version));
+        let release = candidates
+            .into_iter()
+            .next()
+            .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("no release found for major {}", major)))?;
+
+        resolve_release_asset(release, os, arch)
+    }
+
+    pub fn resolve_latest_in_line(
+        &self,
+        line: MajorMinor,
+        os: HostOs,
+        arch: HostArch,
+        include_prerelease: bool,
+    ) -> Result<ResolvedRelease> {
+        let releases = self.fetch_releases()?;
+        let mut candidates: Vec<ParsedRelease> = releases
+            .into_iter()
+            .filter(|release| include_prerelease || !release.prerelease)
             .filter_map(ParsedRelease::from_github_release)
             .filter(|release| release.version.major == line.major && release.version.minor == line.minor)
             .collect();
@@ -66,6 +105,20 @@ impl ReleaseClient {
             .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("no release found for line {}", line)))?;
 
         resolve_release_asset(release, os, arch)
+    }
+
+    pub fn list_available_versions(&self, include_prerelease: bool) -> Result<Vec<Version>> {
+        let releases = self.fetch_releases()?;
+        let mut versions: Vec<Version> = releases
+            .into_iter()
+            .filter(|release| include_prerelease || !release.prerelease)
+            .filter_map(ParsedRelease::from_github_release)
+            .map(|release| release.version)
+            .collect();
+
+        versions.sort_by(|a, b| b.cmp(a));
+        versions.dedup();
+        Ok(versions)
     }
 
     fn resolve_exact(&self, version: Version, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {

--- a/crates/multi-pwsh/src/versions.rs
+++ b/crates/multi-pwsh/src/versions.rs
@@ -27,17 +27,36 @@ impl fmt::Display for MajorMinor {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VersionSelector {
+    Major(u64),
     Exact(Version),
     MajorMinor(MajorMinor),
 }
 
 pub fn parse_install_selector(value: &str) -> Result<VersionSelector> {
+    if let Ok(major) = parse_major_selector(value) {
+        return Ok(VersionSelector::Major(major));
+    }
+
     if let Ok(line) = parse_major_minor_selector(value) {
         return Ok(VersionSelector::MajorMinor(line));
     }
 
     let exact = parse_exact_version(value)?;
     Ok(VersionSelector::Exact(exact))
+}
+
+pub fn parse_major_selector(value: &str) -> Result<u64> {
+    let trimmed = value.trim().trim_start_matches('v');
+    if trimmed.is_empty() || trimmed.contains('.') {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "'{}' is not a major selector",
+            value
+        )));
+    }
+
+    trimmed.parse::<u64>().map_err(|_| {
+        MultiPwshError::InvalidArguments(format!("invalid major version '{}' in selector '{}'", trimmed, value))
+    })
 }
 
 pub fn parse_major_minor_selector(value: &str) -> Result<MajorMinor> {
@@ -63,14 +82,74 @@ pub fn parse_major_minor_selector(value: &str) -> Result<MajorMinor> {
 
 pub fn parse_exact_version(value: &str) -> Result<Version> {
     let trimmed = value.trim().trim_start_matches('v');
-    if trimmed.matches('.').count() != 2 {
+    if trimmed.is_empty() {
         return Err(MultiPwshError::InvalidArguments(format!(
             "'{}' is not an exact major.minor.patch version",
             value
         )));
     }
 
-    Ok(Version::parse(trimmed)?)
+    if let Ok(version) = Version::parse(trimmed) {
+        return Ok(version);
+    }
+
+    if let Some(normalized) = normalize_prerelease_shorthand(trimmed) {
+        if let Ok(version) = Version::parse(&normalized) {
+            return Ok(version);
+        }
+    }
+
+    Err(MultiPwshError::InvalidArguments(format!(
+        "'{}' is not an exact major.minor.patch version",
+        value
+    )))
+}
+
+fn normalize_prerelease_shorthand(value: &str) -> Option<String> {
+    if let Some((major_minor, suffix)) = value.split_once('-') {
+        return normalize_prerelease_parts(major_minor, suffix);
+    }
+
+    let dot_index = value.find('.')?;
+    let major_text = &value[..dot_index];
+    let rest = &value[dot_index + 1..];
+
+    let minor_digit_count = rest.chars().take_while(|character| character.is_ascii_digit()).count();
+    if minor_digit_count == 0 || minor_digit_count == rest.len() {
+        return None;
+    }
+
+    let minor_text = &rest[..minor_digit_count];
+    let suffix = &rest[minor_digit_count..];
+    let major_minor = format!("{}.{}", major_text, minor_text);
+
+    normalize_prerelease_parts(&major_minor, suffix)
+}
+
+fn normalize_prerelease_parts(major_minor: &str, suffix: &str) -> Option<String> {
+    let parts: Vec<&str> = major_minor.split('.').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+
+    let major = parts[0].parse::<u64>().ok()?;
+    let minor = parts[1].parse::<u64>().ok()?;
+
+    let lowercase = suffix.to_ascii_lowercase();
+    let (label, number_text) = if let Some(rest) = lowercase.strip_prefix("preview") {
+        ("preview", rest)
+    } else if let Some(rest) = lowercase.strip_prefix("rc") {
+        ("rc", rest)
+    } else {
+        return None;
+    };
+
+    let number_text = number_text.strip_prefix('.').unwrap_or(number_text);
+    if number_text.is_empty() || !number_text.chars().all(|character| character.is_ascii_digit()) {
+        return None;
+    }
+
+    Some(format!("{}.{}.0-{}.{}", major, minor, label, number_text))
 }
 
 #[cfg(test)]
@@ -85,6 +164,17 @@ mod tests {
     }
 
     #[test]
+    fn parses_major_selector() {
+        let selector = parse_install_selector("7").unwrap();
+        match selector {
+            VersionSelector::Major(major) => {
+                assert_eq!(major, 7);
+            }
+            _ => panic!("expected major selector"),
+        }
+    }
+
+    #[test]
     fn parses_exact_selector() {
         let selector = parse_install_selector("7.4.13").unwrap();
         match selector {
@@ -92,6 +182,62 @@ mod tests {
                 assert_eq!(version.major, 7);
                 assert_eq!(version.minor, 4);
                 assert_eq!(version.patch, 13);
+            }
+            _ => panic!("expected exact selector"),
+        }
+    }
+
+    #[test]
+    fn parses_exact_selector_with_prerelease() {
+        let selector = parse_install_selector("7.6.0-rc.1").unwrap();
+        match selector {
+            VersionSelector::Exact(version) => {
+                assert_eq!(version.major, 7);
+                assert_eq!(version.minor, 6);
+                assert_eq!(version.patch, 0);
+                assert_eq!(version.pre.as_str(), "rc.1");
+            }
+            _ => panic!("expected exact selector"),
+        }
+    }
+
+    #[test]
+    fn parses_exact_selector_with_prerelease_shorthand() {
+        let selector = parse_install_selector("7.6-preview6").unwrap();
+        match selector {
+            VersionSelector::Exact(version) => {
+                assert_eq!(version.major, 7);
+                assert_eq!(version.minor, 6);
+                assert_eq!(version.patch, 0);
+                assert_eq!(version.pre.as_str(), "preview.6");
+            }
+            _ => panic!("expected exact selector"),
+        }
+    }
+
+    #[test]
+    fn parses_exact_selector_with_rc_shorthand() {
+        let selector = parse_install_selector("7.6-rc1").unwrap();
+        match selector {
+            VersionSelector::Exact(version) => {
+                assert_eq!(version.major, 7);
+                assert_eq!(version.minor, 6);
+                assert_eq!(version.patch, 0);
+                assert_eq!(version.pre.as_str(), "rc.1");
+            }
+            _ => panic!("expected exact selector"),
+        }
+    }
+
+    #[test]
+    fn parses_exact_selector_with_compact_rc_shorthand() {
+        let selector = parse_install_selector("7.6rc1").unwrap();
+        match selector {
+            VersionSelector::Exact(version) => {
+                assert_eq!(version.major, 7);
+                assert_eq!(version.minor, 6);
+                assert_eq!(version.patch, 0);
+                assert_eq!(version.pre.as_str(), "rc.1");
             }
             _ => panic!("expected exact selector"),
         }

--- a/crates/multi-pwsh/tests/cli_args.rs
+++ b/crates/multi-pwsh/tests/cli_args.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn find_multi_pwsh_binary() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_multi-pwsh") {
+        return PathBuf::from(path);
+    }
+
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_multi_pwsh") {
+        return PathBuf::from(path);
+    }
+
+    let mut path = std::env::current_exe().expect("failed to resolve current test executable path");
+    path.pop();
+
+    if path.ends_with("deps") {
+        path.pop();
+    }
+
+    path.push(format!("multi-pwsh{}", std::env::consts::EXE_SUFFIX));
+    path
+}
+
+#[test]
+fn update_accepts_include_prerelease_flag() {
+    let exe = find_multi_pwsh_binary();
+    assert!(
+        exe.exists(),
+        "failed to locate multi-pwsh test binary at {}",
+        exe.display()
+    );
+
+    let output = Command::new(exe)
+        .args(["update", "not-a-line", "--include-prerelease"])
+        .output()
+        .expect("failed to run multi-pwsh test binary");
+
+    assert!(!output.status.success(), "expected command to fail on invalid line selector");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not a major.minor selector"),
+        "expected selector parse error, got stderr: {}",
+        stderr
+    );
+}

--- a/crates/multi-pwsh/tests/cli_args.rs
+++ b/crates/multi-pwsh/tests/cli_args.rs
@@ -35,7 +35,10 @@ fn update_accepts_include_prerelease_flag() {
         .output()
         .expect("failed to run multi-pwsh test binary");
 
-    assert!(!output.status.success(), "expected command to fail on invalid line selector");
+    assert!(
+        !output.status.success(),
+        "expected command to fail on invalid line selector"
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/crates/pwsh-host/src/bindings/bindings_generated.rs
+++ b/crates/pwsh-host/src/bindings/bindings_generated.rs
@@ -11,13 +11,17 @@ pub type PowerShellHandle = *mut libc::c_void;
 
 pub type FnPowerShellCreate = unsafe extern "system" fn() -> PowerShellHandle;
 
-pub type FnPowerShellAddArgumentString = unsafe extern "system" fn(handle: PowerShellHandle, argument: *const libc::c_char);
+pub type FnPowerShellAddArgumentString =
+    unsafe extern "system" fn(handle: PowerShellHandle, argument: *const libc::c_char);
 
-pub type FnPowerShellAddParameterString = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: *const libc::c_char);
+pub type FnPowerShellAddParameterString =
+    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: *const libc::c_char);
 
-pub type FnPowerShellAddParameterInt = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: i32);
+pub type FnPowerShellAddParameterInt =
+    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: i32);
 
-pub type FnPowerShellAddParameterLong = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: i64);
+pub type FnPowerShellAddParameterLong =
+    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: i64);
 
 pub type FnPowerShellAddCommand = unsafe extern "system" fn(handle: PowerShellHandle, command: *const libc::c_char);
 
@@ -29,37 +33,65 @@ pub type FnPowerShellInvoke = unsafe extern "system" fn(handle: PowerShellHandle
 
 pub type FnPowerShellClear = unsafe extern "system" fn(handle: PowerShellHandle);
 
-pub type FnPowerShellExportToXml = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
+pub type FnPowerShellExportToXml =
+    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnPowerShellExportToJson = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
+pub type FnPowerShellExportToJson =
+    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnPowerShellExportToString = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
+pub type FnPowerShellExportToString =
+    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnBindingsInvokeMemberJson = unsafe extern "system" fn(handle: PowerShellHandle, member_name: *const libc::c_char, arguments_json: *const libc::c_char) -> *const libc::c_char;
+pub type FnBindingsInvokeMemberJson = unsafe extern "system" fn(
+    handle: PowerShellHandle,
+    member_name: *const libc::c_char,
+    arguments_json: *const libc::c_char,
+) -> *const libc::c_char;
 
-pub type FnBindingsGetPropertyJson = unsafe extern "system" fn(handle: PowerShellHandle, property_name: *const libc::c_char) -> *const libc::c_char;
+pub type FnBindingsGetPropertyJson =
+    unsafe extern "system" fn(handle: PowerShellHandle, property_name: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnBindingsSetPropertyJson = unsafe extern "system" fn(handle: PowerShellHandle, property_name: *const libc::c_char, value_json: *const libc::c_char) -> *const libc::c_char;
+pub type FnBindingsSetPropertyJson = unsafe extern "system" fn(
+    handle: PowerShellHandle,
+    property_name: *const libc::c_char,
+    value_json: *const libc::c_char,
+) -> *const libc::c_char;
 
-pub type FnBindingsInvokeStaticMemberJson = unsafe extern "system" fn(member_name: *const libc::c_char, arguments_json: *const libc::c_char) -> *const libc::c_char;
+pub type FnBindingsInvokeStaticMemberJson = unsafe extern "system" fn(
+    member_name: *const libc::c_char,
+    arguments_json: *const libc::c_char,
+) -> *const libc::c_char;
 
 pub type FnGCHandleFree = unsafe extern "system" fn(handle: PowerShellHandle);
 
 pub type FnMarshalFreeCoTaskMem = unsafe extern "system" fn(ptr: *mut libc::c_void);
 
-pub type FnPowerShell_Auto_AddCommand_String = unsafe extern "system" fn(handle: PowerShellHandle, cmdlet: *const libc::c_char) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddCommand_String =
+    unsafe extern "system" fn(handle: PowerShellHandle, cmdlet: *const libc::c_char) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_AddCommand_String_Bool = unsafe extern "system" fn(handle: PowerShellHandle, cmdlet: *const libc::c_char, useLocalScope: i32) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddCommand_String_Bool = unsafe extern "system" fn(
+    handle: PowerShellHandle,
+    cmdlet: *const libc::c_char,
+    useLocalScope: i32,
+) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_AddParameter_String = unsafe extern "system" fn(handle: PowerShellHandle, parameterName: *const libc::c_char) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddParameter_String =
+    unsafe extern "system" fn(handle: PowerShellHandle, parameterName: *const libc::c_char) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_AddScript_String = unsafe extern "system" fn(handle: PowerShellHandle, script: *const libc::c_char) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddScript_String =
+    unsafe extern "system" fn(handle: PowerShellHandle, script: *const libc::c_char) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_AddScript_String_Bool = unsafe extern "system" fn(handle: PowerShellHandle, script: *const libc::c_char, useLocalScope: i32) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddScript_String_Bool = unsafe extern "system" fn(
+    handle: PowerShellHandle,
+    script: *const libc::c_char,
+    useLocalScope: i32,
+) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_AddStatement_NoArgs = unsafe extern "system" fn(handle: PowerShellHandle) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddStatement_NoArgs =
+    unsafe extern "system" fn(handle: PowerShellHandle) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_CreateNestedPowerShell_NoArgs = unsafe extern "system" fn(handle: PowerShellHandle) -> PowerShellHandle;
+pub type FnPowerShell_Auto_CreateNestedPowerShell_NoArgs =
+    unsafe extern "system" fn(handle: PowerShellHandle) -> PowerShellHandle;
 
 pub type FnPowerShell_Auto_Dispose_NoArgs = unsafe extern "system" fn(handle: PowerShellHandle);
 
@@ -181,14 +213,30 @@ impl Bindings {
             invoke_static_member_json_fn: unsafe { std::mem::transmute(api.invoke_static_member_json_fn) },
             gc_handle_free_fn: unsafe { std::mem::transmute(api.gc_handle_free_fn) },
             marshal_free_co_task_mem_fn: unsafe { std::mem::transmute(api.marshal_free_co_task_mem_fn) },
-            power_shell_auto_add_command_string_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_command_string_fn) },
-            power_shell_auto_add_command_string_bool_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_command_string_bool_fn) },
-            power_shell_auto_add_parameter_string_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_parameter_string_fn) },
-            power_shell_auto_add_script_string_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_script_string_fn) },
-            power_shell_auto_add_script_string_bool_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_script_string_bool_fn) },
-            power_shell_auto_add_statement_no_args_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_statement_no_args_fn) },
-            power_shell_auto_create_nested_power_shell_no_args_fn: unsafe { std::mem::transmute(api.power_shell_auto_create_nested_power_shell_no_args_fn) },
-            power_shell_auto_dispose_no_args_fn: unsafe { std::mem::transmute(api.power_shell_auto_dispose_no_args_fn) },
+            power_shell_auto_add_command_string_fn: unsafe {
+                std::mem::transmute(api.power_shell_auto_add_command_string_fn)
+            },
+            power_shell_auto_add_command_string_bool_fn: unsafe {
+                std::mem::transmute(api.power_shell_auto_add_command_string_bool_fn)
+            },
+            power_shell_auto_add_parameter_string_fn: unsafe {
+                std::mem::transmute(api.power_shell_auto_add_parameter_string_fn)
+            },
+            power_shell_auto_add_script_string_fn: unsafe {
+                std::mem::transmute(api.power_shell_auto_add_script_string_fn)
+            },
+            power_shell_auto_add_script_string_bool_fn: unsafe {
+                std::mem::transmute(api.power_shell_auto_add_script_string_bool_fn)
+            },
+            power_shell_auto_add_statement_no_args_fn: unsafe {
+                std::mem::transmute(api.power_shell_auto_add_statement_no_args_fn)
+            },
+            power_shell_auto_create_nested_power_shell_no_args_fn: unsafe {
+                std::mem::transmute(api.power_shell_auto_create_nested_power_shell_no_args_fn)
+            },
+            power_shell_auto_dispose_no_args_fn: unsafe {
+                std::mem::transmute(api.power_shell_auto_dispose_no_args_fn)
+            },
             power_shell_auto_stop_no_args_fn: unsafe { std::mem::transmute(api.power_shell_auto_stop_no_args_fn) },
         })
     }

--- a/crates/pwsh-host/src/bindings/bindings_generated.rs
+++ b/crates/pwsh-host/src/bindings/bindings_generated.rs
@@ -11,17 +11,13 @@ pub type PowerShellHandle = *mut libc::c_void;
 
 pub type FnPowerShellCreate = unsafe extern "system" fn() -> PowerShellHandle;
 
-pub type FnPowerShellAddArgumentString =
-    unsafe extern "system" fn(handle: PowerShellHandle, argument: *const libc::c_char);
+pub type FnPowerShellAddArgumentString = unsafe extern "system" fn(handle: PowerShellHandle, argument: *const libc::c_char);
 
-pub type FnPowerShellAddParameterString =
-    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: *const libc::c_char);
+pub type FnPowerShellAddParameterString = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: *const libc::c_char);
 
-pub type FnPowerShellAddParameterInt =
-    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: i32);
+pub type FnPowerShellAddParameterInt = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: i32);
 
-pub type FnPowerShellAddParameterLong =
-    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: i64);
+pub type FnPowerShellAddParameterLong = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char, value: i64);
 
 pub type FnPowerShellAddCommand = unsafe extern "system" fn(handle: PowerShellHandle, command: *const libc::c_char);
 
@@ -33,65 +29,37 @@ pub type FnPowerShellInvoke = unsafe extern "system" fn(handle: PowerShellHandle
 
 pub type FnPowerShellClear = unsafe extern "system" fn(handle: PowerShellHandle);
 
-pub type FnPowerShellExportToXml =
-    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
+pub type FnPowerShellExportToXml = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnPowerShellExportToJson =
-    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
+pub type FnPowerShellExportToJson = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnPowerShellExportToString =
-    unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
+pub type FnPowerShellExportToString = unsafe extern "system" fn(handle: PowerShellHandle, name: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnBindingsInvokeMemberJson = unsafe extern "system" fn(
-    handle: PowerShellHandle,
-    member_name: *const libc::c_char,
-    arguments_json: *const libc::c_char,
-) -> *const libc::c_char;
+pub type FnBindingsInvokeMemberJson = unsafe extern "system" fn(handle: PowerShellHandle, member_name: *const libc::c_char, arguments_json: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnBindingsGetPropertyJson =
-    unsafe extern "system" fn(handle: PowerShellHandle, property_name: *const libc::c_char) -> *const libc::c_char;
+pub type FnBindingsGetPropertyJson = unsafe extern "system" fn(handle: PowerShellHandle, property_name: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnBindingsSetPropertyJson = unsafe extern "system" fn(
-    handle: PowerShellHandle,
-    property_name: *const libc::c_char,
-    value_json: *const libc::c_char,
-) -> *const libc::c_char;
+pub type FnBindingsSetPropertyJson = unsafe extern "system" fn(handle: PowerShellHandle, property_name: *const libc::c_char, value_json: *const libc::c_char) -> *const libc::c_char;
 
-pub type FnBindingsInvokeStaticMemberJson = unsafe extern "system" fn(
-    member_name: *const libc::c_char,
-    arguments_json: *const libc::c_char,
-) -> *const libc::c_char;
+pub type FnBindingsInvokeStaticMemberJson = unsafe extern "system" fn(member_name: *const libc::c_char, arguments_json: *const libc::c_char) -> *const libc::c_char;
 
 pub type FnGCHandleFree = unsafe extern "system" fn(handle: PowerShellHandle);
 
 pub type FnMarshalFreeCoTaskMem = unsafe extern "system" fn(ptr: *mut libc::c_void);
 
-pub type FnPowerShell_Auto_AddCommand_String =
-    unsafe extern "system" fn(handle: PowerShellHandle, cmdlet: *const libc::c_char) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddCommand_String = unsafe extern "system" fn(handle: PowerShellHandle, cmdlet: *const libc::c_char) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_AddCommand_String_Bool = unsafe extern "system" fn(
-    handle: PowerShellHandle,
-    cmdlet: *const libc::c_char,
-    useLocalScope: i32,
-) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddCommand_String_Bool = unsafe extern "system" fn(handle: PowerShellHandle, cmdlet: *const libc::c_char, useLocalScope: i32) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_AddParameter_String =
-    unsafe extern "system" fn(handle: PowerShellHandle, parameterName: *const libc::c_char) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddParameter_String = unsafe extern "system" fn(handle: PowerShellHandle, parameterName: *const libc::c_char) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_AddScript_String =
-    unsafe extern "system" fn(handle: PowerShellHandle, script: *const libc::c_char) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddScript_String = unsafe extern "system" fn(handle: PowerShellHandle, script: *const libc::c_char) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_AddScript_String_Bool = unsafe extern "system" fn(
-    handle: PowerShellHandle,
-    script: *const libc::c_char,
-    useLocalScope: i32,
-) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddScript_String_Bool = unsafe extern "system" fn(handle: PowerShellHandle, script: *const libc::c_char, useLocalScope: i32) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_AddStatement_NoArgs =
-    unsafe extern "system" fn(handle: PowerShellHandle) -> PowerShellHandle;
+pub type FnPowerShell_Auto_AddStatement_NoArgs = unsafe extern "system" fn(handle: PowerShellHandle) -> PowerShellHandle;
 
-pub type FnPowerShell_Auto_CreateNestedPowerShell_NoArgs =
-    unsafe extern "system" fn(handle: PowerShellHandle) -> PowerShellHandle;
+pub type FnPowerShell_Auto_CreateNestedPowerShell_NoArgs = unsafe extern "system" fn(handle: PowerShellHandle) -> PowerShellHandle;
 
 pub type FnPowerShell_Auto_Dispose_NoArgs = unsafe extern "system" fn(handle: PowerShellHandle);
 
@@ -213,30 +181,14 @@ impl Bindings {
             invoke_static_member_json_fn: unsafe { std::mem::transmute(api.invoke_static_member_json_fn) },
             gc_handle_free_fn: unsafe { std::mem::transmute(api.gc_handle_free_fn) },
             marshal_free_co_task_mem_fn: unsafe { std::mem::transmute(api.marshal_free_co_task_mem_fn) },
-            power_shell_auto_add_command_string_fn: unsafe {
-                std::mem::transmute(api.power_shell_auto_add_command_string_fn)
-            },
-            power_shell_auto_add_command_string_bool_fn: unsafe {
-                std::mem::transmute(api.power_shell_auto_add_command_string_bool_fn)
-            },
-            power_shell_auto_add_parameter_string_fn: unsafe {
-                std::mem::transmute(api.power_shell_auto_add_parameter_string_fn)
-            },
-            power_shell_auto_add_script_string_fn: unsafe {
-                std::mem::transmute(api.power_shell_auto_add_script_string_fn)
-            },
-            power_shell_auto_add_script_string_bool_fn: unsafe {
-                std::mem::transmute(api.power_shell_auto_add_script_string_bool_fn)
-            },
-            power_shell_auto_add_statement_no_args_fn: unsafe {
-                std::mem::transmute(api.power_shell_auto_add_statement_no_args_fn)
-            },
-            power_shell_auto_create_nested_power_shell_no_args_fn: unsafe {
-                std::mem::transmute(api.power_shell_auto_create_nested_power_shell_no_args_fn)
-            },
-            power_shell_auto_dispose_no_args_fn: unsafe {
-                std::mem::transmute(api.power_shell_auto_dispose_no_args_fn)
-            },
+            power_shell_auto_add_command_string_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_command_string_fn) },
+            power_shell_auto_add_command_string_bool_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_command_string_bool_fn) },
+            power_shell_auto_add_parameter_string_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_parameter_string_fn) },
+            power_shell_auto_add_script_string_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_script_string_fn) },
+            power_shell_auto_add_script_string_bool_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_script_string_bool_fn) },
+            power_shell_auto_add_statement_no_args_fn: unsafe { std::mem::transmute(api.power_shell_auto_add_statement_no_args_fn) },
+            power_shell_auto_create_nested_power_shell_no_args_fn: unsafe { std::mem::transmute(api.power_shell_auto_create_nested_power_shell_no_args_fn) },
+            power_shell_auto_dispose_no_args_fn: unsafe { std::mem::transmute(api.power_shell_auto_dispose_no_args_fn) },
             power_shell_auto_stop_no_args_fn: unsafe { std::mem::transmute(api.power_shell_auto_stop_no_args_fn) },
         })
     }

--- a/scripts/Discover-Bindings.ps1
+++ b/scripts/Discover-Bindings.ps1
@@ -483,7 +483,6 @@ $mergedContract = [ordered]@{
 
 $surfaceReport = [ordered]@{
     runtimePsVersion = [string]$PSVersionTable.PSVersion
-    generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
     baseEntryCount = $baseEntries.Count
     discoveredEntryCount = $discoveredEntries.Count
     totalEntryCount = $mergedEntries.Count

--- a/scripts/Generate-Bindings.ps1
+++ b/scripts/Generate-Bindings.ps1
@@ -160,5 +160,16 @@ if (-not (Test-Path -Path $rustDirectory)) {
 Set-Content -Path $resolvedCSharpOutputPath -Value $csharpContent -Encoding UTF8
 Set-Content -Path $resolvedRustOutputPath -Value $rustContent -Encoding UTF8
 
+$rustfmtCommand = Get-Command rustfmt -ErrorAction SilentlyContinue
+if ($null -ne $rustfmtCommand) {
+    & $rustfmtCommand.Source --edition 2018 $resolvedRustOutputPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "rustfmt failed for generated Rust bindings: $resolvedRustOutputPath"
+    }
+}
+else {
+    Write-Warning "rustfmt not found; generated Rust bindings may require formatting."
+}
+
 Write-Output "Generated: $resolvedCSharpOutputPath"
 Write-Output "Generated: $resolvedRustOutputPath"


### PR DESCRIPTION
## Summary
- add multi-pwsh list --available to list online downloadable PowerShell versions
- add prerelease-aware flows for install and update via --include-prerelease
- support friendly prerelease selectors like 7.6-preview6, 7.6-rc1, and 7.6rc1
- keep deterministic bindings discovery output by removing generation timestamp metadata
- add integration-style CLI test for update ... --include-prerelease argument handling

## Validation
- cargo test -p multi-pwsh
- cargo run -p multi-pwsh -- list --available --include-prerelease
- cargo run -p multi-pwsh -- install 7.6-preview6 --arch auto
- cargo run -p multi-pwsh -- update 7.6 --include-prerelease --arch auto
- dotnet build dotnet/Bindings.csproj