### PR TITLE
Add native host mode aliases and bump crates to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ version = "0.5.0"
 dependencies = [
  "flate2",
  "home",
+ "pwsh-host",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "flate2",
  "home",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "pwsh-host",

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ multi-pwsh install 7.6.0-rc.1
 multi-pwsh update 7.6 --include-prerelease
 multi-pwsh alias set 7.4 7.4.11
 multi-pwsh alias unset 7.4
+multi-pwsh host 7.4 -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"
 multi-pwsh doctor --repair-aliases
 ```
 
@@ -83,6 +84,7 @@ multi-pwsh uninstall <version> [--force]
 multi-pwsh list [--available] [--include-prerelease]
 multi-pwsh alias set <major.minor> <version|latest>
 multi-pwsh alias unset <major.minor>
+multi-pwsh host <version|major|major.minor|pwsh-alias> [pwsh arguments...]
 multi-pwsh doctor --repair-aliases
 ```
 
@@ -96,6 +98,17 @@ Selector behavior:
 `multi-pwsh install 7.4.x` installs every available patch release in that line for your current platform and creates per-version aliases such as `pwsh-7.4.11`.
 The `pwsh-7.4` alias tracks latest by default; pin it with `multi-pwsh alias set 7.4 7.4.11` and unpin with `multi-pwsh alias unset 7.4`.
 If a pinned target version is not installed, the pin remains in metadata and the alias stays unresolved until you install that version or unpin.
+
+Native host mode:
+
+- `multi-pwsh host <selector> ...` runs PowerShell through native hosting (`pwsh-host` crate) instead of launching a `pwsh` subprocess.
+- `<selector>` supports `7`, `7.4`, `7.4.13`, or alias-form selectors such as `pwsh-7.4`.
+- Alias lifecycle now maintains native host shims as hard links to `multi-pwsh` automatically during install/update/doctor alias repair.
+- On Windows, host shims are `pwsh-*.exe` files alongside `.cmd` wrappers in `~/.pwsh/bin`.
+- On Linux/macOS, alias command paths (`pwsh-*`) are hard links to `multi-pwsh`.
+- `multi-pwsh doctor --repair-aliases` performs a shim health check and re-links broken hard links automatically.
+- You can still manually copy/rename `multi-pwsh.exe` under `~/.pwsh/bin` to an alias-like name (for example `pwsh-7.4.exe`); it automatically enters host mode and resolves the target installation from that alias name.
+- `-NamedPipeCommand <pipeName>` is supported in host mode (Windows only), matching `pwsh-host` behavior.
 
 Download cache behavior can be controlled with environment variables:
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ curl -fsSL https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads
 irm https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.5.0`):
+Install a specific tag (example `v0.6.0`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.5.0
+curl -fsSL https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.6.0
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.5.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.6.0
 ```
 
 Uninstall bootstrap scripts:

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -20,6 +20,7 @@ tar = "0.4"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 home = "0.5"
 tempfile = "3.12"
+pwsh-host = { path = "../pwsh-host" }
 
 [build-dependencies]
 winresource = "0.1"

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "Install and update side-by-side PowerShell versions in user context"

--- a/crates/multi-pwsh/src/aliases.rs
+++ b/crates/multi-pwsh/src/aliases.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
@@ -59,23 +62,16 @@ fn create_or_update_alias_with_selector(
     let alias_file = alias_file_name(&selector, os);
     let alias_path = layout.bin_dir().join(alias_file);
 
-    if os == HostOs::Windows {
-        let legacy_exe_alias = layout.bin_dir().join(format!("{}.exe", alias_command));
-        if legacy_exe_alias != alias_path && legacy_exe_alias.exists() {
-            fs::remove_file(&legacy_exe_alias)?;
-        }
-    }
-
-    if alias_path.exists() {
-        fs::remove_file(&alias_path)?;
-    }
-
     match os {
         HostOs::Windows => {
+            if alias_path.exists() {
+                fs::remove_file(&alias_path)?;
+            }
             create_windows_cmd_alias(target, &alias_path)?;
+            create_or_update_windows_host_shim(layout, &alias_command)?;
         }
         HostOs::Linux | HostOs::Macos => {
-            create_symlink(target, &alias_path)?;
+            create_or_update_posix_host_shim(layout, &alias_command)?;
         }
     }
 
@@ -95,6 +91,14 @@ pub fn remove_alias(layout: &InstallLayout, os: HostOs, alias_command: &str) -> 
         removed = true;
     }
 
+    if os == HostOs::Windows {
+        let host_shim_path = layout.bin_dir().join(format!("{}.exe", alias_command));
+        if host_shim_path.exists() {
+            fs::remove_file(host_shim_path)?;
+            removed = true;
+        }
+    }
+
     let mut document = read_alias_document(layout)?;
     if document.aliases.remove(alias_command).is_some() {
         write_alias_document(layout, &document)?;
@@ -102,6 +106,33 @@ pub fn remove_alias(layout: &InstallLayout, os: HostOs, alias_command: &str) -> 
     }
 
     Ok(removed)
+}
+
+pub fn repair_host_shim_if_needed(layout: &InstallLayout, os: HostOs, alias_command: &str) -> Result<bool> {
+    #[cfg(windows)]
+    {
+        if os == HostOs::Windows {
+            return create_or_update_windows_host_shim(layout, alias_command);
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        if matches!(os, HostOs::Linux | HostOs::Macos) {
+            return create_or_update_posix_host_shim(layout, alias_command);
+        }
+    }
+
+    #[cfg(not(any(windows, unix)))]
+    {
+        let _ = (layout, os, alias_command);
+        Ok(false)
+    }
+
+    #[cfg(any(windows, unix))]
+    {
+        Ok(false)
+    }
 }
 
 pub fn parse_alias_command_selector(alias_command: &str) -> Option<AliasSelector> {
@@ -206,21 +237,6 @@ fn alias_command_name(selector: &AliasSelector) -> String {
     }
 }
 
-#[cfg(unix)]
-fn create_symlink(target: &Path, link_path: &Path) -> Result<()> {
-    use std::os::unix::fs::symlink;
-
-    symlink(target, link_path)?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn create_symlink(_target: &Path, _link_path: &Path) -> Result<()> {
-    Err(MultiPwshError::AliasCreation(
-        "symlink is not available on this platform".to_string(),
-    ))
-}
-
 #[cfg(windows)]
 fn create_windows_cmd_alias(target: &Path, alias_path: &Path) -> Result<()> {
     let target_string = target
@@ -239,6 +255,135 @@ fn create_windows_cmd_alias(target: &Path, alias_path: &Path) -> Result<()> {
     })?;
 
     Ok(())
+}
+
+#[cfg(windows)]
+fn create_or_update_windows_host_shim(layout: &InstallLayout, alias_command: &str) -> Result<bool> {
+    let alias_exe_path = layout.bin_dir().join(format!("{}.exe", alias_command));
+    let source_exe = resolve_host_shim_source(layout)?;
+
+    if alias_exe_path == source_exe {
+        return Ok(false);
+    }
+
+    if alias_exe_path.exists() {
+        if are_hard_links_to_same_file(&source_exe, &alias_exe_path) {
+            return Ok(false);
+        }
+
+        fs::remove_file(&alias_exe_path)?;
+    }
+
+    fs::hard_link(&source_exe, &alias_exe_path).map_err(|error| {
+        MultiPwshError::AliasCreation(format!(
+            "failed to create windows host shim hard link '{}' from '{}': {}",
+            alias_exe_path.display(),
+            source_exe.display(),
+            error
+        ))
+    })?;
+
+    Ok(true)
+}
+
+#[cfg(not(windows))]
+fn create_or_update_windows_host_shim(_layout: &InstallLayout, _alias_command: &str) -> Result<bool> {
+    Err(MultiPwshError::AliasCreation(
+        "windows host shim hard links are not available on this platform".to_string(),
+    ))
+}
+
+#[cfg(unix)]
+fn create_or_update_posix_host_shim(layout: &InstallLayout, alias_command: &str) -> Result<bool> {
+    let alias_path = layout.bin_dir().join(alias_command);
+    let source_exe = resolve_host_shim_source(layout)?;
+
+    if alias_path == source_exe {
+        return Ok(false);
+    }
+
+    if alias_path.exists() {
+        if are_posix_hard_links_to_same_file(&source_exe, &alias_path)? {
+            return Ok(false);
+        }
+
+        fs::remove_file(&alias_path)?;
+    }
+
+    fs::hard_link(&source_exe, &alias_path).map_err(|error| {
+        MultiPwshError::AliasCreation(format!(
+            "failed to create host shim hard link '{}' from '{}': {}",
+            alias_path.display(),
+            source_exe.display(),
+            error
+        ))
+    })?;
+
+    Ok(true)
+}
+
+#[cfg(not(unix))]
+fn create_or_update_posix_host_shim(_layout: &InstallLayout, _alias_command: &str) -> Result<bool> {
+    Err(MultiPwshError::AliasCreation(
+        "posix host shim hard links are not available on this platform".to_string(),
+    ))
+}
+
+#[cfg(unix)]
+fn are_posix_hard_links_to_same_file(left: &Path, right: &Path) -> Result<bool> {
+    let left = fs::metadata(left)?;
+    let right = fs::metadata(right)?;
+    Ok(left.dev() == right.dev() && left.ino() == right.ino())
+}
+
+#[cfg(windows)]
+fn are_hard_links_to_same_file(left: &Path, right: &Path) -> bool {
+    let right_text = right.to_string_lossy().into_owned();
+
+    let output = match std::process::Command::new("cmd")
+        .args(["/C", "fsutil", "hardlink", "list", &right_text])
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return false,
+    };
+
+    let output_text = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
+    let left_text = left.to_string_lossy().replace('/', "\\").to_ascii_lowercase();
+
+    if output_text.contains(&left_text) {
+        return true;
+    }
+
+    let left_without_drive = strip_drive_prefix(&left_text);
+    output_text.contains(&left_without_drive)
+}
+
+#[cfg(windows)]
+fn strip_drive_prefix(path: &str) -> String {
+    if path.len() >= 2 && path.as_bytes()[1] == b':' {
+        return path[2..].to_string();
+    }
+
+    path.to_string()
+}
+
+fn resolve_host_shim_source(layout: &InstallLayout) -> Result<PathBuf> {
+    let preferred = layout
+        .bin_dir()
+        .join(format!("multi-pwsh{}", std::env::consts::EXE_SUFFIX));
+    if preferred.exists() {
+        return Ok(preferred);
+    }
+
+    let current = std::env::current_exe()?;
+    if current.exists() {
+        return Ok(current);
+    }
+
+    Err(MultiPwshError::AliasCreation(
+        "unable to locate multi-pwsh executable to build host shims".to_string(),
+    ))
 }
 
 #[cfg(not(windows))]

--- a/crates/multi-pwsh/src/error.rs
+++ b/crates/multi-pwsh/src/error.rs
@@ -38,6 +38,9 @@ pub enum MultiPwshError {
 
     #[error("alias creation failed: {0}")]
     AliasCreation(String),
+
+    #[error("host error: {0}")]
+    Host(String),
 }
 
 impl From<zip::result::ZipError> for MultiPwshError {

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -7,8 +7,9 @@ mod release;
 mod versions;
 
 use std::env;
+use std::ffi::OsString;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 
 use semver::Version;
@@ -22,11 +23,14 @@ use install::ensure_installed;
 use layout::InstallLayout;
 use platform::{HostArch, HostOs};
 use release::ReleaseClient;
-use versions::{parse_exact_version, parse_install_selector, parse_major_minor_selector, MajorMinor, VersionSelector};
+use versions::{
+    parse_exact_version, parse_install_selector, parse_major_minor_selector, parse_major_selector, MajorMinor,
+    VersionSelector,
+};
 
 fn print_usage() {
     eprintln!(
-        "Usage:\n  multi-pwsh install <version|major|major.minor|major.minor.x> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh uninstall <version> [--force]\n  multi-pwsh list [--available] [--include-prerelease]\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias unset <major.minor>\n  multi-pwsh doctor --repair-aliases"
+        "Usage:\n  multi-pwsh install <version|major|major.minor|major.minor.x> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh uninstall <version> [--force]\n  multi-pwsh list [--available] [--include-prerelease]\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias unset <major.minor>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
     );
 }
 
@@ -38,6 +42,164 @@ struct ReleaseSelectionOptions {
 enum ListOption {
     Installed,
     Available { include_prerelease: bool },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum HostSelector {
+    Major(u64),
+    MajorMinor(MajorMinor),
+    Exact(Version),
+}
+
+fn parse_host_selector(value: &str) -> Result<HostSelector> {
+    if let Some(selector) = parse_alias_command_selector(value) {
+        return Ok(match selector {
+            AliasSelector::Major(major) => HostSelector::Major(major),
+            AliasSelector::MajorMinor(line) => HostSelector::MajorMinor(line),
+            AliasSelector::Exact(version) => HostSelector::Exact(version),
+        });
+    }
+
+    if let Ok(version) = parse_exact_version(value) {
+        return Ok(HostSelector::Exact(version));
+    }
+
+    if let Ok(line) = parse_major_minor_selector(value) {
+        return Ok(HostSelector::MajorMinor(line));
+    }
+
+    if let Ok(major) = parse_major_selector(value) {
+        return Ok(HostSelector::Major(major));
+    }
+
+    Err(MultiPwshError::InvalidArguments(format!(
+        "host selector '{}' is invalid; expected one of: <major>, <major.minor>, <major.minor.patch>, or pwsh-<selector>",
+        value
+    )))
+}
+
+fn resolve_host_version(layout: &InstallLayout, selector: &HostSelector) -> Result<Version> {
+    match selector {
+        HostSelector::Exact(version) => Ok(version.clone()),
+        HostSelector::Major(major) => latest_installed_in_major(layout, *major)?.ok_or_else(|| {
+            MultiPwshError::InvalidArguments(format!(
+                "no installed PowerShell version found for major {}; install one with: multi-pwsh install {}",
+                major, major
+            ))
+        }),
+        HostSelector::MajorMinor(line) => {
+            let pinned = read_minor_pin(layout, *line)?;
+            if let Some(version) = pinned {
+                return Ok(version);
+            }
+
+            latest_installed_in_line(layout, *line)?.ok_or_else(|| {
+                MultiPwshError::InvalidArguments(format!(
+                    "no installed PowerShell version found for line {}; install one with: multi-pwsh install {}",
+                    line, line
+                ))
+            })
+        }
+    }
+}
+
+fn resolve_host_executable(layout: &InstallLayout, selector_input: &str) -> Result<(Version, PathBuf)> {
+    let selector = parse_host_selector(selector_input)?;
+    let version = resolve_host_version(layout, &selector)?;
+    let executable = layout.version_executable(&version);
+
+    if !executable.exists() {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "resolved host selector '{}' to {}, but executable was not found at {}",
+            selector_input,
+            version,
+            executable.display()
+        )));
+    }
+
+    Ok((version, executable))
+}
+
+fn preprocess_host_args(args: Vec<OsString>) -> Result<Vec<OsString>> {
+    pwsh_host::preprocess_named_pipe_command_args(args)
+        .map_err(|error| MultiPwshError::Host(format!("invalid host arguments: {}", error)))
+}
+
+fn run_host_mode(selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> {
+    let os = HostOs::detect()?;
+    let layout = InstallLayout::new(os)?;
+    layout.ensure_base_dirs()?;
+
+    let (_version, executable) = resolve_host_executable(&layout, selector_input)?;
+    let args = preprocess_host_args(pwsh_args)?;
+
+    pwsh_host::run_pwsh_command_line_for_pwsh_exe(&executable, args).map_err(|error| {
+        MultiPwshError::Host(format!(
+            "failed to start native host for selector '{}': {}",
+            selector_input, error
+        ))
+    })
+}
+
+fn run_host_command(args: &[String]) -> Result<i32> {
+    if args.is_empty() {
+        return Err(MultiPwshError::InvalidArguments(
+            "host requires: <version|major|major.minor|pwsh-alias> [pwsh arguments...]".to_string(),
+        ));
+    }
+
+    let selector = &args[0];
+    let pwsh_args: Vec<OsString> = args[1..].iter().map(OsString::from).collect();
+    run_host_mode(selector, pwsh_args)
+}
+
+fn paths_refer_to_same_location(left: &Path, right: &Path) -> bool {
+    match (fs::canonicalize(left), fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
+fn detect_implicit_host_selector(bin_dir: &Path, executable_path: &Path) -> Option<String> {
+    let stem = executable_path.file_stem()?.to_str()?;
+    if stem.eq_ignore_ascii_case("multi-pwsh") {
+        return None;
+    }
+
+    if parse_alias_command_selector(stem).is_none() {
+        return None;
+    }
+
+    let parent = executable_path.parent()?;
+    if !paths_refer_to_same_location(parent, bin_dir) {
+        return None;
+    }
+
+    Some(stem.to_string())
+}
+
+fn run_implicit_host_mode_if_needed() -> Result<Option<i32>> {
+    let executable_path = env::current_exe()?;
+
+    let stem = match executable_path.file_stem().and_then(|value| value.to_str()) {
+        Some(stem) => stem,
+        None => return Ok(None),
+    };
+    if stem.eq_ignore_ascii_case("multi-pwsh") || parse_alias_command_selector(stem).is_none() {
+        return Ok(None);
+    }
+
+    let os = HostOs::detect()?;
+    let layout = InstallLayout::new(os)?;
+
+    let bin_dir = layout.bin_dir();
+    let Some(selector) = detect_implicit_host_selector(&bin_dir, &executable_path) else {
+        return Ok(None);
+    };
+
+    let args: Vec<OsString> = env::args_os().skip(1).collect();
+    let exit_code = run_host_mode(&selector, args)?;
+    Ok(Some(exit_code))
 }
 
 fn latest_installed_in_major(layout: &InstallLayout, major: u64) -> Result<Option<Version>> {
@@ -584,6 +746,7 @@ fn run_doctor(args: &[String]) -> Result<()> {
 
     let mut repaired = 0usize;
     let mut skipped = 0usize;
+    let mut relinked_shims = 0usize;
 
     let mut items: Vec<_> = aliases.into_iter().collect();
     items.sort_by(|a, b| a.0.cmp(&b.0));
@@ -609,6 +772,22 @@ fn run_doctor(args: &[String]) -> Result<()> {
             continue;
         }
 
+        if aliases::repair_host_shim_if_needed(&layout, os, &alias_name)? {
+            println!(
+                "Relinked host shim: {}",
+                if os == HostOs::Windows {
+                    layout
+                        .bin_dir()
+                        .join(format!("{}.exe", alias_name))
+                        .display()
+                        .to_string()
+                } else {
+                    layout.bin_dir().join(&alias_name).display().to_string()
+                }
+            );
+            relinked_shims += 1;
+        }
+
         let alias_path = match parse_alias_command_selector(&alias_name) {
             Some(AliasSelector::MajorMinor(line)) => create_or_update_alias(&layout, os, line, &version, &target)?,
             Some(AliasSelector::Major(major)) => create_or_update_major_alias(&layout, os, major, &version, &target)?,
@@ -623,7 +802,14 @@ fn run_doctor(args: &[String]) -> Result<()> {
         repaired += 1;
     }
 
-    println!("Repair complete: {} repaired, {} skipped", repaired, skipped);
+    if matches!(os, HostOs::Windows | HostOs::Linux | HostOs::Macos) {
+        println!(
+            "Repair complete: {} repaired, {} skipped, {} host shims relinked",
+            repaired, skipped, relinked_shims
+        );
+    } else {
+        println!("Repair complete: {} repaired, {} skipped", repaired, skipped);
+    }
     Ok(())
 }
 
@@ -667,20 +853,32 @@ fn run() -> Result<()> {
             run_list(list_option)
         }
         "alias" => run_alias(&args[1..]),
+        "host" => {
+            let exit_code = run_host_command(&args[1..])?;
+            process::exit(exit_code);
+        }
         "doctor" => run_doctor(&args[1..]),
         "-h" | "--help" | "help" => {
             print_usage();
             Ok(())
         }
         command => Err(MultiPwshError::InvalidArguments(format!(
-            "unknown command '{}'. expected: install, update, uninstall, list, alias, doctor",
+            "unknown command '{}'. expected: install, update, uninstall, list, alias, host, doctor",
             command
         ))),
     }
 }
 
+fn main_impl() -> Result<()> {
+    if let Some(exit_code) = run_implicit_host_mode_if_needed()? {
+        process::exit(exit_code);
+    }
+
+    run()
+}
+
 fn main() {
-    if let Err(error) = run() {
+    if let Err(error) = main_impl() {
         eprintln!("error: {}", error);
         process::exit(1);
     }
@@ -746,6 +944,42 @@ mod tests {
     fn parse_list_option_rejects_prerelease_without_available() {
         let args = vec!["--include-prerelease".to_string()];
         assert!(parse_list_option(&args).is_err());
+    }
+
+    #[test]
+    fn parse_host_selector_supports_alias_name() {
+        let selector = parse_host_selector("pwsh-7.4").unwrap();
+        assert_eq!(selector, HostSelector::MajorMinor(MajorMinor { major: 7, minor: 4 }));
+    }
+
+    #[test]
+    fn parse_host_selector_supports_exact_version() {
+        let selector = parse_host_selector("7.4.13").unwrap();
+        assert_eq!(selector, HostSelector::Exact(Version::parse("7.4.13").unwrap()));
+    }
+
+    #[test]
+    fn detect_implicit_host_selector_accepts_alias_in_bin_dir() {
+        let bin_dir = PathBuf::from("C:/Users/test/.pwsh/bin");
+
+        let selector = detect_implicit_host_selector(&bin_dir, &bin_dir.join("pwsh-7.4.exe"));
+        assert_eq!(selector, Some("pwsh-7.4".to_string()));
+    }
+
+    #[test]
+    fn detect_implicit_host_selector_rejects_multi_pwsh_name() {
+        let bin_dir = PathBuf::from("C:/Users/test/.pwsh/bin");
+
+        let selector = detect_implicit_host_selector(&bin_dir, &bin_dir.join("multi-pwsh.exe"));
+        assert!(selector.is_none());
+    }
+
+    #[test]
+    fn detect_implicit_host_selector_rejects_outside_bin_dir() {
+        let bin_dir = PathBuf::from("C:/Users/test/.pwsh/bin");
+
+        let selector = detect_implicit_host_selector(&bin_dir, &PathBuf::from("C:/Users/test/other/pwsh-7.4.exe"));
+        assert!(selector.is_none());
     }
 
     #[test]

--- a/crates/pwsh-host-cli/Cargo.toml
+++ b/crates/pwsh-host-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host-cli"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "pwsh-compatible CLI backed by pwsh-host and hostfxr"

--- a/crates/pwsh-host-cli/src/main.rs
+++ b/crates/pwsh-host-cli/src/main.rs
@@ -1,8 +1,6 @@
-mod named_pipe_command;
-
 fn main() {
     let args: Vec<_> = std::env::args_os().skip(1).collect();
-    let args = match named_pipe_command::preprocess_named_pipe_command_args(args) {
+    let args = match pwsh_host::preprocess_named_pipe_command_args(args) {
         Ok(args) => args,
         Err(error) => {
             eprintln!("pwsh-host: {}", error);

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/crates/pwsh-host/src/hostfxr.rs
+++ b/crates/pwsh-host/src/hostfxr.rs
@@ -1,6 +1,7 @@
 use std::borrow::BorrowMut;
 use std::ffi::OsStr;
 use std::io;
+use std::path::Path;
 
 use dlopen::wrapper::{Container, WrapperApi};
 
@@ -247,7 +248,11 @@ impl Hostfxr {
 #[allow(dead_code)]
 pub fn load_hostfxr() -> Result<Hostfxr, Box<dyn std::error::Error>> {
     let pwsh_path = pwsh_host_detect()?;
-    Hostfxr::load_from_path(pwsh_path.join(if cfg!(target_os = "windows") {
+    load_hostfxr_from_pwsh_dir(pwsh_path)
+}
+
+pub fn load_hostfxr_from_pwsh_dir(pwsh_dir: impl AsRef<Path>) -> Result<Hostfxr, Box<dyn std::error::Error>> {
+    Hostfxr::load_from_path(pwsh_dir.as_ref().join(if cfg!(target_os = "windows") {
         "hostfxr.dll"
     } else if cfg!(target_os = "linux") {
         "libhostfxr.so"

--- a/crates/pwsh-host/src/lib.rs
+++ b/crates/pwsh-host/src/lib.rs
@@ -7,6 +7,7 @@ mod host_detect;
 mod host_exit_code;
 mod hostfxr;
 mod loader;
+mod named_pipe_command;
 mod pwsh_cli;
 mod tests;
 mod time;
@@ -23,4 +24,5 @@ extern crate quick_error;
 mod pdcstring;
 
 pub use bindings::PowerShell;
-pub use pwsh_cli::run_pwsh_command_line;
+pub use named_pipe_command::{preprocess_named_pipe_command_args, NamedPipeCommandError};
+pub use pwsh_cli::{run_pwsh_command_line, run_pwsh_command_line_for_pwsh_dir, run_pwsh_command_line_for_pwsh_exe};

--- a/crates/pwsh-host/src/named_pipe_command.rs
+++ b/crates/pwsh-host/src/named_pipe_command.rs
@@ -2,8 +2,6 @@ use std::error::Error;
 use std::ffi::{OsStr, OsString};
 use std::fmt::{Display, Formatter};
 
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
-
 const NAMED_PIPE_COMMAND_FLAG: &str = "-namedpipecommand";
 const ENCODED_COMMAND_FLAG: &str = "-EncodedCommand";
 #[cfg(windows)]
@@ -119,7 +117,7 @@ fn rewrite_with_encoded_command(args: &[OsString], named_pipe_index: usize, enco
 
 fn encode_utf16le_base64(command: &str) -> String {
     let bytes: Vec<u8> = command.encode_utf16().flat_map(|value| value.to_le_bytes()).collect();
-    BASE64_STANDARD.encode(bytes)
+    base64::encode(bytes)
 }
 
 #[cfg(windows)]

--- a/crates/pwsh-host/src/pwsh_cli.rs
+++ b/crates/pwsh-host/src/pwsh_cli.rs
@@ -1,7 +1,8 @@
 use std::ffi::OsStr;
+use std::path::Path;
 
 use crate::host_detect::pwsh_host_detect;
-use crate::hostfxr::load_hostfxr;
+use crate::hostfxr::load_hostfxr_from_pwsh_dir;
 use crate::pdcstring::PdCString;
 
 pub fn run_pwsh_command_line<I, A>(args: I) -> Result<i32, Box<dyn std::error::Error>>
@@ -10,14 +11,42 @@ where
     A: AsRef<OsStr>,
 {
     let pwsh_dir = pwsh_host_detect()?;
-    let pwsh_dll = pwsh_dir.join("pwsh.dll");
+    run_pwsh_command_line_for_pwsh_dir(&pwsh_dir, args)
+}
+
+pub fn run_pwsh_command_line_for_pwsh_exe<I, A>(
+    pwsh_exe_path: impl AsRef<Path>,
+    args: I,
+) -> Result<i32, Box<dyn std::error::Error>>
+where
+    I: IntoIterator<Item = A>,
+    A: AsRef<OsStr>,
+{
+    let pwsh_dir = pwsh_exe_path.as_ref().parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "pwsh executable has no parent directory",
+        )
+    })?;
+    run_pwsh_command_line_for_pwsh_dir(pwsh_dir, args)
+}
+
+pub fn run_pwsh_command_line_for_pwsh_dir<I, A>(
+    pwsh_dir: impl AsRef<Path>,
+    args: I,
+) -> Result<i32, Box<dyn std::error::Error>>
+where
+    I: IntoIterator<Item = A>,
+    A: AsRef<OsStr>,
+{
+    let pwsh_dll = pwsh_dir.as_ref().join("pwsh.dll");
 
     let mut host_args = vec![PdCString::from_os_str(pwsh_dll)?];
     for arg in args {
         host_args.push(PdCString::from_os_str(arg)?);
     }
 
-    let hostfxr = load_hostfxr()?;
+    let hostfxr = load_hostfxr_from_pwsh_dir(pwsh_dir)?;
     let context = hostfxr.initialize_for_dotnet_command_line_args(&host_args)?;
     Ok(context.run_app())
 }

--- a/scripts/Bump-CrateVersions.ps1
+++ b/scripts/Bump-CrateVersions.ps1
@@ -33,7 +33,7 @@ $workflowUpdated = $false
 foreach ($cargoFile in $cargoFiles) {
     $content = [System.IO.File]::ReadAllText($cargoFile)
 
-    $pattern = '(?ms)^(\[package\]\s*.*?^version\s*=\s*")(?<current>[^"]+)(")'
+    $pattern = '(?ms)^(\[package\]\s*.*?^version\s*=\s*")(?<current>[^"\r\n]+)(")'
     $match = [System.Text.RegularExpressions.Regex]::Match($content, $pattern)
     if (-not $match.Success) {
         throw "Could not find package version field in $cargoFile"


### PR DESCRIPTION
## Summary
- Add `multi-pwsh host` native hosting mode, reusing `pwsh-host`.
- Add implicit alias-name host mode for renamed executables under `~/.pwsh/bin`.
- Share `-NamedPipeCommand` preprocessing logic in `pwsh-host` and reuse it from `pwsh-host-cli` and `multi-pwsh`.
- Add hard-link host shim lifecycle with doctor relink checks:
  - Windows: `pwsh-*.exe` hard links alongside `.cmd` wrappers.
  - Linux/macOS: `pwsh-*` hard links.
- Bump crate versions to `0.6.0`.
- Fix `scripts/Bump-CrateVersions.ps1` regex to prevent malformed version strings.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build dotnet/Bindings.csproj`
- `dotnet test dotnet/Bindings.csproj --no-build`

## CI
- Branch/PR CI is green for this branch after the Linux cfg-gating fix.