### PR TITLE
Add configurable multi-pwsh home layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,16 @@ jobs:
   lint:
     name: Lint (Ubuntu)
     runs-on: ubuntu-latest
-    env:
-      MULTI_PWSH_HOME: ${{ runner.temp }}/multi-pwsh-home
-      MULTI_PWSH_CACHE_DIR: ${{ runner.temp }}/multi-pwsh-cache
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Resolve multi-pwsh paths
+        shell: bash
+        run: |
+          echo "MULTI_PWSH_HOME=${RUNNER_TEMP}/multi-pwsh-home" >> "$GITHUB_ENV"
+          echo "MULTI_PWSH_CACHE_DIR=${RUNNER_TEMP}/multi-pwsh-cache" >> "$GITHUB_ENV"
 
       - name: Install multi-pwsh bootstrap
         run: bash ./tools/install-multi-pwsh.sh
@@ -75,9 +78,6 @@ jobs:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: lint
-    env:
-      MULTI_PWSH_HOME: ${{ runner.temp }}/multi-pwsh-home
-      MULTI_PWSH_CACHE_DIR: ${{ runner.temp }}/multi-pwsh-cache
     strategy:
       fail-fast: false
       matrix:
@@ -89,6 +89,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Resolve multi-pwsh paths (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          "MULTI_PWSH_HOME=$env:RUNNER_TEMP\multi-pwsh-home" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "MULTI_PWSH_CACHE_DIR=$env:RUNNER_TEMP\multi-pwsh-cache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Resolve multi-pwsh paths (Unix)
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          echo "MULTI_PWSH_HOME=${RUNNER_TEMP}/multi-pwsh-home" >> "$GITHUB_ENV"
+          echo "MULTI_PWSH_CACHE_DIR=${RUNNER_TEMP}/multi-pwsh-cache" >> "$GITHUB_ENV"
 
       - name: Install multi-pwsh bootstrap (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Resolve multi-pwsh paths
-        shell: bash
-        run: |
-          echo "MULTI_PWSH_HOME=${RUNNER_TEMP}/multi-pwsh-home" >> "$GITHUB_ENV"
-          echo "MULTI_PWSH_CACHE_DIR=${RUNNER_TEMP}/multi-pwsh-cache" >> "$GITHUB_ENV"
-
       - name: Install multi-pwsh bootstrap
         run: bash ./tools/install-multi-pwsh.sh
 
@@ -89,20 +83,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Resolve multi-pwsh paths (Windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          "MULTI_PWSH_HOME=$env:RUNNER_TEMP\multi-pwsh-home" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "MULTI_PWSH_CACHE_DIR=$env:RUNNER_TEMP\multi-pwsh-cache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Resolve multi-pwsh paths (Unix)
-        if: matrix.os != 'windows-latest'
-        shell: bash
-        run: |
-          echo "MULTI_PWSH_HOME=${RUNNER_TEMP}/multi-pwsh-home" >> "$GITHUB_ENV"
-          echo "MULTI_PWSH_CACHE_DIR=${RUNNER_TEMP}/multi-pwsh-cache" >> "$GITHUB_ENV"
 
       - name: Install multi-pwsh bootstrap (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
   lint:
     name: Lint (Ubuntu)
     runs-on: ubuntu-latest
+    env:
+      MULTI_PWSH_HOME: ${{ runner.temp }}/multi-pwsh-home
+      MULTI_PWSH_CACHE_DIR: ${{ runner.temp }}/multi-pwsh-cache
 
     steps:
       - name: Checkout
@@ -24,7 +27,11 @@ jobs:
         run: bash ./tools/install-multi-pwsh.sh
 
       - name: Add multi-pwsh bin to PATH
-        run: echo "$HOME/.pwsh/bin" >> "$GITHUB_PATH"
+        shell: bash
+        run: |
+          multi_pwsh_home="${MULTI_PWSH_HOME:-$HOME/.pwsh}"
+          multi_pwsh_bin="${MULTI_PWSH_BIN_DIR:-${multi_pwsh_home}/bin}"
+          echo "$multi_pwsh_bin" >> "$GITHUB_PATH"
 
       - name: Cache multi-pwsh downloads
         uses: actions/cache@v4
@@ -38,8 +45,6 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MULTI_PWSH_CACHE_DIR: ${{ runner.temp }}/multi-pwsh-cache
-          MULTI_PWSH_CACHE_KEEP_KEEP: '1'
           MULTI_PWSH_CACHE_KEEP: '1'
         run: |
           multi-pwsh install 7.4
@@ -70,6 +75,9 @@ jobs:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: lint
+    env:
+      MULTI_PWSH_HOME: ${{ runner.temp }}/multi-pwsh-home
+      MULTI_PWSH_CACHE_DIR: ${{ runner.temp }}/multi-pwsh-cache
     strategy:
       fail-fast: false
       matrix:
@@ -95,11 +103,17 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          "$HOME\.pwsh\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $multiPwshHome = if ($env:MULTI_PWSH_HOME) { $env:MULTI_PWSH_HOME } else { Join-Path $HOME '.pwsh' }
+          $multiPwshBin = if ($env:MULTI_PWSH_BIN_DIR) { $env:MULTI_PWSH_BIN_DIR } else { Join-Path $multiPwshHome 'bin' }
+          $multiPwshBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Add multi-pwsh bin to PATH (Unix)
         if: matrix.os != 'windows-latest'
-        run: echo "$HOME/.pwsh/bin" >> "$GITHUB_PATH"
+        shell: bash
+        run: |
+          multi_pwsh_home="${MULTI_PWSH_HOME:-$HOME/.pwsh}"
+          multi_pwsh_bin="${MULTI_PWSH_BIN_DIR:-${multi_pwsh_home}/bin}"
+          echo "$multi_pwsh_bin" >> "$GITHUB_PATH"
 
       - name: Cache multi-pwsh downloads
         uses: actions/cache@v4
@@ -113,8 +127,6 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MULTI_PWSH_CACHE_DIR: ${{ runner.temp }}/multi-pwsh-cache
-          MULTI_PWSH_CACHE_KEEP_KEEP: '1'
           MULTI_PWSH_CACHE_KEEP: '1'
         run: |
           multi-pwsh install 7.4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ dotnet list dotnet/Bindings.csproj package --vulnerable --include-transitive
 
 - Tests and runtime behavior expect `pwsh` to be resolvable from `PATH`.
 - CI installs PowerShell `stable`/`lts` (7.4.x) and that matches `Discover-Bindings.ps1` requirements.
-- If your default `pwsh` is not 7.4.x, set `PwshExePath` before verification commands, for example:
+- If your default `pwsh` is not 7.4.x, set `PwshExePath` before verification commands. With the default multi-pwsh layout, for example:
 
 ```powershell
 $env:PwshExePath = "$HOME/.pwsh/bin/pwsh-7.4"

--- a/README.md
+++ b/README.md
@@ -104,26 +104,30 @@ Native host mode:
 - `multi-pwsh host <selector> ...` runs PowerShell through native hosting (`pwsh-host` crate) instead of launching a `pwsh` subprocess.
 - `<selector>` supports `7`, `7.4`, `7.4.13`, or alias-form selectors such as `pwsh-7.4`.
 - Alias lifecycle now maintains native host shims as hard links to `multi-pwsh` automatically during install/update/doctor alias repair.
-- On Windows, host shims are `pwsh-*.exe` files alongside `.cmd` wrappers in `~/.pwsh/bin`.
+- On Windows, host shims are `pwsh-*.exe` files alongside `.cmd` wrappers in `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`).
 - On Linux/macOS, alias command paths (`pwsh-*`) are hard links to `multi-pwsh`.
 - `multi-pwsh doctor --repair-aliases` performs a shim health check and re-links broken hard links automatically.
-- You can still manually copy/rename `multi-pwsh.exe` under `~/.pwsh/bin` to an alias-like name (for example `pwsh-7.4.exe`); it automatically enters host mode and resolves the target installation from that alias name.
+- You can still manually copy/rename `multi-pwsh.exe` under `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`) to an alias-like name (for example `pwsh-7.4.exe`); it automatically enters host mode and resolves the target installation from that alias name.
 - `-NamedPipeCommand <pipeName>` is supported in host mode (Windows only), matching `pwsh-host` behavior.
 
-Download cache behavior can be controlled with environment variables:
+Managed paths can be controlled with environment variables:
 
-- `MULTI_PWSH_CACHE_DIR`: override archive cache directory (default: `~/.pwsh/cache`).
+- `MULTI_PWSH_HOME`: override the multi-pwsh home directory (default: `~/.pwsh`). Extracted PowerShell versions are stored under `MULTI_PWSH_HOME/multi`, and alias metadata is stored in `MULTI_PWSH_HOME/aliases.json`.
+- `MULTI_PWSH_BIN_DIR`: override the shim and launcher directory (default: `MULTI_PWSH_HOME/bin`).
+- `MULTI_PWSH_CACHE_DIR`: override archive cache directory (default: `MULTI_PWSH_HOME/cache`).
 - `MULTI_PWSH_CACHE_KEEP`: keep downloaded archives after extraction when set to a truthy value (`1`, `true`, `yes`, or `on`).
 
 CI cache example:
 
 ```powershell
-$env:MULTI_PWSH_CACHE_DIR = "$(Join-Path $HOME '.pwsh\cache')"
+$env:MULTI_PWSH_HOME = "$(Join-Path $HOME '.pwsh')"
+$env:MULTI_PWSH_BIN_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'bin')"
+$env:MULTI_PWSH_CACHE_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'cache')"
 $env:MULTI_PWSH_CACHE_KEEP = "1"
 multi-pwsh install 7.4.x
 ```
 
-When installed via bootstrap scripts, `~/.pwsh/bin` is added to PATH automatically if needed.
+When installed via bootstrap scripts, `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`) is added to PATH automatically if needed.
 
 ## pwsh-host
 

--- a/crates/multi-pwsh/src/aliases.rs
+++ b/crates/multi-pwsh/src/aliases.rs
@@ -274,14 +274,7 @@ fn create_or_update_windows_host_shim(layout: &InstallLayout, alias_command: &st
         fs::remove_file(&alias_exe_path)?;
     }
 
-    fs::hard_link(&source_exe, &alias_exe_path).map_err(|error| {
-        MultiPwshError::AliasCreation(format!(
-            "failed to create windows host shim hard link '{}' from '{}': {}",
-            alias_exe_path.display(),
-            source_exe.display(),
-            error
-        ))
-    })?;
+    create_host_shim_link_or_copy(&source_exe, &alias_exe_path, true)?;
 
     Ok(true)
 }
@@ -310,14 +303,7 @@ fn create_or_update_posix_host_shim(layout: &InstallLayout, alias_command: &str)
         fs::remove_file(&alias_path)?;
     }
 
-    fs::hard_link(&source_exe, &alias_path).map_err(|error| {
-        MultiPwshError::AliasCreation(format!(
-            "failed to create host shim hard link '{}' from '{}': {}",
-            alias_path.display(),
-            source_exe.display(),
-            error
-        ))
-    })?;
+    create_host_shim_link_or_copy(&source_exe, &alias_path, false)?;
 
     Ok(true)
 }
@@ -366,6 +352,24 @@ fn strip_drive_prefix(path: &str) -> String {
     }
 
     path.to_string()
+}
+
+fn create_host_shim_link_or_copy(source_exe: &Path, alias_path: &Path, windows: bool) -> Result<()> {
+    if let Err(link_error) = fs::hard_link(source_exe, alias_path) {
+        fs::copy(source_exe, alias_path).map_err(|copy_error| {
+            let kind = if windows { "windows host shim" } else { "host shim" };
+            MultiPwshError::AliasCreation(format!(
+                "failed to create {} '{}' from '{}' via hard link ({}) or copy ({} )",
+                kind,
+                alias_path.display(),
+                source_exe.display(),
+                link_error,
+                copy_error
+            ))
+        })?;
+    }
+
+    Ok(())
 }
 
 fn resolve_host_shim_source(layout: &InstallLayout) -> Result<PathBuf> {

--- a/crates/multi-pwsh/src/install.rs
+++ b/crates/multi-pwsh/src/install.rs
@@ -187,28 +187,55 @@ fn ensure_executable_bit(_executable: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_cache_keep<T>(value: Option<&str>, action: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os("MULTI_PWSH_CACHE_KEEP");
+
+        match value {
+            Some(value) => unsafe { std::env::set_var("MULTI_PWSH_CACHE_KEEP", value) },
+            None => unsafe { std::env::remove_var("MULTI_PWSH_CACHE_KEEP") },
+        }
+
+        let result = action();
+
+        match previous {
+            Some(value) => unsafe { std::env::set_var("MULTI_PWSH_CACHE_KEEP", value) },
+            None => unsafe { std::env::remove_var("MULTI_PWSH_CACHE_KEEP") },
+        }
+
+        result
+    }
 
     #[test]
     fn cache_keep_defaults_to_false() {
-        unsafe { std::env::remove_var("MULTI_PWSH_CACHE_KEEP") };
-        assert!(!cache_keep_archives());
+        with_cache_keep(None, || {
+            assert!(!cache_keep_archives());
+        });
     }
 
     #[test]
     fn cache_keep_parses_truthy_values() {
-        unsafe { std::env::set_var("MULTI_PWSH_CACHE_KEEP", "true") };
-        assert!(cache_keep_archives());
+        with_cache_keep(Some("true"), || {
+            assert!(cache_keep_archives());
+        });
 
-        unsafe { std::env::set_var("MULTI_PWSH_CACHE_KEEP", "1") };
-        assert!(cache_keep_archives());
+        with_cache_keep(Some("1"), || {
+            assert!(cache_keep_archives());
+        });
 
-        unsafe { std::env::set_var("MULTI_PWSH_CACHE_KEEP", "on") };
-        assert!(cache_keep_archives());
+        with_cache_keep(Some("on"), || {
+            assert!(cache_keep_archives());
+        });
     }
 
     #[test]
     fn cache_keep_parses_falsey_values() {
-        unsafe { std::env::set_var("MULTI_PWSH_CACHE_KEEP", "false") };
-        assert!(!cache_keep_archives());
+        with_cache_keep(Some("false"), || {
+            assert!(!cache_keep_archives());
+        });
     }
 }

--- a/crates/multi-pwsh/src/install.rs
+++ b/crates/multi-pwsh/src/install.rs
@@ -24,7 +24,7 @@ pub fn ensure_installed(
         return Ok(executable);
     }
 
-    let install_dir = layout.version_dir(&release.version);
+    let install_dir = layout.version_install_dir(&release.version);
     if install_dir.exists() {
         fs::remove_dir_all(&install_dir)?;
     }

--- a/crates/multi-pwsh/src/layout.rs
+++ b/crates/multi-pwsh/src/layout.rs
@@ -8,36 +8,59 @@ use crate::error::{MultiPwshError, Result};
 use crate::platform::HostOs;
 
 pub struct InstallLayout {
-    root: PathBuf,
+    home: PathBuf,
+    bin_dir: PathBuf,
+    cache_dir: PathBuf,
     os: HostOs,
 }
 
 impl InstallLayout {
     pub fn new(os: HostOs) -> Result<Self> {
-        let home = home::home_dir().ok_or(MultiPwshError::HomeDirectoryNotFound)?;
+        let user_home = home::home_dir().ok_or(MultiPwshError::HomeDirectoryNotFound)?;
+        let home = env::var_os("MULTI_PWSH_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| user_home.join(".pwsh"));
+        let bin_dir = env::var_os("MULTI_PWSH_BIN_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join("bin"));
+        let cache_dir = env::var_os("MULTI_PWSH_CACHE_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join("cache"));
+
         Ok(InstallLayout {
-            root: home.join(".pwsh"),
+            home,
+            bin_dir,
+            cache_dir,
             os,
         })
     }
 
-    pub fn root(&self) -> &Path {
-        &self.root
+    pub fn home(&self) -> &Path {
+        &self.home
     }
 
     pub fn bin_dir(&self) -> PathBuf {
-        self.root.join("bin")
+        self.bin_dir.clone()
     }
 
     pub fn aliases_file(&self) -> PathBuf {
-        self.root.join("aliases.json")
+        self.home.join("aliases.json")
     }
 
     pub fn cache_dir(&self) -> PathBuf {
-        match env::var_os("MULTI_PWSH_CACHE_DIR") {
-            Some(value) => PathBuf::from(value),
-            None => self.root.join("cache"),
-        }
+        self.cache_dir.clone()
+    }
+
+    pub fn versions_dir(&self) -> PathBuf {
+        self.home.join("multi")
+    }
+
+    pub fn preferred_version_dir(&self, version: &Version) -> PathBuf {
+        self.versions_dir().join(version.to_string())
+    }
+
+    fn legacy_version_dir(&self, version: &Version) -> PathBuf {
+        self.home.join(version.to_string())
     }
 
     pub fn executable_name(&self) -> &'static str {
@@ -45,52 +68,212 @@ impl InstallLayout {
     }
 
     pub fn version_dir(&self, version: &Version) -> PathBuf {
-        self.root.join(version.to_string())
+        let preferred = self.preferred_version_dir(version);
+        if preferred.exists() {
+            return preferred;
+        }
+
+        let legacy = self.legacy_version_dir(version);
+        if legacy.exists() {
+            return legacy;
+        }
+
+        preferred
     }
 
     pub fn version_executable(&self, version: &Version) -> PathBuf {
         self.version_dir(version).join(self.executable_name())
     }
 
+    pub fn version_install_dir(&self, version: &Version) -> PathBuf {
+        self.preferred_version_dir(version)
+    }
+
+    pub fn remove_version_dirs(&self, version: &Version) -> Result<bool> {
+        let mut removed = false;
+
+        for path in [self.preferred_version_dir(version), self.legacy_version_dir(version)] {
+            if path.exists() {
+                fs::remove_dir_all(path)?;
+                removed = true;
+            }
+        }
+
+        Ok(removed)
+    }
+
     pub fn ensure_base_dirs(&self) -> Result<()> {
-        fs::create_dir_all(&self.root)?;
+        fs::create_dir_all(&self.home)?;
         fs::create_dir_all(self.bin_dir())?;
         fs::create_dir_all(self.cache_dir())?;
+        fs::create_dir_all(self.versions_dir())?;
         Ok(())
     }
 
     pub fn installed_versions(&self) -> Result<Vec<Version>> {
-        if !self.root.exists() {
+        if !self.home.exists() {
             return Ok(Vec::new());
         }
 
         let mut versions = Vec::new();
-        for entry in fs::read_dir(&self.root)? {
-            let entry = entry?;
-            let path = entry.path();
-
-            if !path.is_dir() {
-                continue;
-            }
-
-            let file_name = entry.file_name();
-            let file_name = file_name.to_string_lossy();
-            if file_name == "bin" || file_name == "cache" {
-                continue;
-            }
-
-            let version = match Version::parse(file_name.as_ref()) {
-                Ok(version) => version,
-                Err(_) => continue,
-            };
-
-            let executable = path.join(self.executable_name());
-            if executable.exists() {
-                versions.push(version);
-            }
-        }
+        collect_versions_from_dir(&self.versions_dir(), &[], self.executable_name(), &mut versions)?;
+        collect_versions_from_dir(
+            self.home(),
+            &["bin", "cache", "multi"],
+            self.executable_name(),
+            &mut versions,
+        )?;
 
         versions.sort_by(|a, b| b.cmp(a));
         Ok(versions)
+    }
+}
+
+fn collect_versions_from_dir(
+    base_dir: &Path,
+    excluded_names: &[&str],
+    executable_name: &str,
+    versions: &mut Vec<Version>,
+) -> Result<()> {
+    if !base_dir.exists() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(base_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if !path.is_dir() {
+            continue;
+        }
+
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if excluded_names.iter().any(|name| *name == file_name) {
+            continue;
+        }
+
+        let version = match Version::parse(file_name.as_ref()) {
+            Ok(version) => version,
+            Err(_) => continue,
+        };
+
+        let executable = path.join(executable_name);
+        if executable.exists() && !versions.contains(&version) {
+            versions.push(version);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env_var<T>(key: &str, value: Option<&Path>, action: impl FnOnce() -> T) -> T {
+        let previous = env::var_os(key);
+
+        match value {
+            Some(value) => unsafe { env::set_var(key, value) },
+            None => unsafe { env::remove_var(key) },
+        }
+
+        let result = action();
+
+        match previous {
+            Some(value) => unsafe { env::set_var(key, value) },
+            None => unsafe { env::remove_var(key) },
+        }
+
+        result
+    }
+
+    fn with_layout_env<T>(
+        home: Option<&Path>,
+        bin_dir: Option<&Path>,
+        cache_dir: Option<&Path>,
+        action: impl FnOnce() -> T,
+    ) -> T {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        with_env_var("MULTI_PWSH_HOME", home, || {
+            with_env_var("MULTI_PWSH_BIN_DIR", bin_dir, || {
+                with_env_var("MULTI_PWSH_CACHE_DIR", cache_dir, action)
+            })
+        })
+    }
+
+    #[test]
+    fn layout_uses_home_override_and_derived_defaults() {
+        let temp_dir = TempDir::new().unwrap();
+        let expected_home = temp_dir.path().join("pwsh-home");
+
+        with_layout_env(Some(&expected_home), None, None, || {
+            let layout = InstallLayout::new(HostOs::Windows).unwrap();
+            assert_eq!(layout.home(), expected_home.as_path());
+            assert_eq!(layout.bin_dir(), expected_home.join("bin"));
+            assert_eq!(layout.cache_dir(), expected_home.join("cache"));
+            assert_eq!(layout.versions_dir(), expected_home.join("multi"));
+            assert_eq!(layout.aliases_file(), expected_home.join("aliases.json"));
+        });
+    }
+
+    #[test]
+    fn layout_uses_explicit_bin_and_cache_overrides() {
+        let temp_dir = TempDir::new().unwrap();
+        let expected_home = temp_dir.path().join("pwsh-home");
+        let expected_bin = temp_dir.path().join("shims");
+        let expected_cache = temp_dir.path().join("cache-root");
+
+        with_layout_env(Some(&expected_home), Some(&expected_bin), Some(&expected_cache), || {
+            let layout = InstallLayout::new(HostOs::Linux).unwrap();
+            assert_eq!(layout.home(), expected_home.as_path());
+            assert_eq!(layout.bin_dir(), expected_bin);
+            assert_eq!(layout.cache_dir(), expected_cache);
+            assert_eq!(layout.versions_dir(), expected_home.join("multi"));
+        });
+    }
+
+    #[test]
+    fn version_dir_falls_back_to_legacy_location() {
+        let temp_dir = TempDir::new().unwrap();
+        let expected_home = temp_dir.path().join("pwsh-home");
+        let version = Version::parse("7.4.13").unwrap();
+        let legacy_dir = expected_home.join(version.to_string());
+        fs::create_dir_all(&legacy_dir).unwrap();
+
+        with_layout_env(Some(&expected_home), None, None, || {
+            let layout = InstallLayout::new(HostOs::Linux).unwrap();
+            assert_eq!(layout.version_dir(&version), legacy_dir);
+            assert_eq!(
+                layout.version_install_dir(&version),
+                expected_home.join("multi").join("7.4.13")
+            );
+        });
+    }
+
+    #[test]
+    fn installed_versions_include_new_and_legacy_locations() {
+        let temp_dir = TempDir::new().unwrap();
+        let expected_home = temp_dir.path().join("pwsh-home");
+        let new_version = Version::parse("7.5.0").unwrap();
+        let legacy_version = Version::parse("7.4.13").unwrap();
+
+        let new_dir = expected_home.join("multi").join(new_version.to_string());
+        let legacy_dir = expected_home.join(legacy_version.to_string());
+        fs::create_dir_all(&new_dir).unwrap();
+        fs::create_dir_all(&legacy_dir).unwrap();
+        fs::write(new_dir.join("pwsh"), "").unwrap();
+        fs::write(legacy_dir.join("pwsh"), "").unwrap();
+
+        with_layout_env(Some(&expected_home), None, None, || {
+            let layout = InstallLayout::new(HostOs::Linux).unwrap();
+            assert_eq!(layout.installed_versions().unwrap(), vec![new_version, legacy_version]);
+        });
     }
 }

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -414,9 +414,10 @@ fn run_install(selector_input: &str, arch: Option<HostArch>, include_prerelease:
     for release in releases {
         let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release)?;
         let patch_alias = create_or_update_patch_alias(&layout, os, &release.version, &executable_path)?;
+        let version_path = executable_path.parent().unwrap_or_else(|| Path::new(""));
 
         println!("Installed PowerShell {}", release.version);
-        println!("Version path: {}", layout.version_dir(&release.version).display());
+        println!("Version path: {}", version_path.display());
         println!("Updated patch alias: {}", patch_alias.display());
 
         let line = release.version_line();
@@ -477,6 +478,7 @@ fn run_update(line_input: &str, arch: Option<HostArch>, include_prerelease: bool
     let release = release_client.resolve_latest_in_line(line, os, arch, include_prerelease)?;
     let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release)?;
     let patch_alias_path = create_or_update_patch_alias(&layout, os, &release.version, &executable_path)?;
+    let version_path = executable_path.parent().unwrap_or_else(|| Path::new(""));
 
     let alias_path = sync_minor_alias(&layout, os, line)?;
     let major_alias_path = latest_installed_in_major(&layout, release.version.major)?
@@ -487,7 +489,7 @@ fn run_update(line_input: &str, arch: Option<HostArch>, include_prerelease: bool
         .transpose()?;
 
     println!("Updated line {} to {}", line, release.version);
-    println!("Version path: {}", layout.version_dir(&release.version).display());
+    println!("Version path: {}", version_path.display());
     println!("Updated patch alias: {}", patch_alias_path.display());
     if let Some(path) = alias_path {
         println!("Updated alias: {}", path.display());
@@ -565,9 +567,7 @@ fn run_uninstall(version_input: &str, force: bool) -> Result<()> {
     let layout = InstallLayout::new(os)?;
     layout.ensure_base_dirs()?;
 
-    let version_dir = layout.version_dir(&version);
-    if version_dir.exists() {
-        fs::remove_dir_all(&version_dir)?;
+    if layout.remove_version_dirs(&version)? {
         println!("Removed PowerShell {}", version);
     } else if force {
         println!(
@@ -674,8 +674,10 @@ fn run_list(option: ListOption) -> Result<()> {
             let aliases = aliases::read_alias_metadata(&layout)?;
             let pins = read_minor_pins(&layout)?;
 
-            println!("Install root: {}", layout.root().display());
+            println!("Home: {}", layout.home().display());
             println!("Alias bin: {}", layout.bin_dir().display());
+            println!("Versions dir: {}", layout.versions_dir().display());
+            println!("Cache dir: {}", layout.cache_dir().display());
             println!();
 
             if versions.is_empty() {
@@ -982,6 +984,14 @@ mod tests {
 
         let selector = detect_implicit_host_selector(&bin_dir, &bin_dir.join("pwsh-7.4"));
         assert_eq!(selector, Some("pwsh-7.4".to_string()));
+    }
+
+    #[test]
+    fn detect_implicit_host_selector_accepts_alias_in_overridden_bin_dir() {
+        let bin_dir = PathBuf::from("D:/tools/multi-pwsh/bin");
+
+        let selector = detect_implicit_host_selector(&bin_dir, &bin_dir.join("pwsh-7.5.exe"));
+        assert_eq!(selector, Some("pwsh-7.5".to_string()));
     }
 
     #[test]

--- a/tools/install-multi-pwsh.ps1
+++ b/tools/install-multi-pwsh.ps1
@@ -51,6 +51,22 @@ function Test-PathContainsEntry {
     return $false
 }
 
+function Get-MultiPwshHome {
+    if (-not [string]::IsNullOrWhiteSpace($env:MULTI_PWSH_HOME)) {
+        return $env:MULTI_PWSH_HOME
+    }
+
+    return (Join-Path $HOME '.pwsh')
+}
+
+function Get-MultiPwshBinDir {
+    if (-not [string]::IsNullOrWhiteSpace($env:MULTI_PWSH_BIN_DIR)) {
+        return $env:MULTI_PWSH_BIN_DIR
+    }
+
+    return (Join-Path (Get-MultiPwshHome) 'bin')
+}
+
 $arch = Get-ReleaseArch
 $assetName = "multi-pwsh-windows-$arch.zip"
 
@@ -68,8 +84,8 @@ else {
 }
 
 $downloadUrl = "https://github.com/$Owner/$Repository/releases/$releasePath/$assetName"
-$installRoot = Join-Path $HOME '.pwsh'
-$binDir = Join-Path $installRoot 'bin'
+$installHome = Get-MultiPwshHome
+$binDir = Get-MultiPwshBinDir
 $targetExe = Join-Path $binDir 'multi-pwsh.exe'
 
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("multi-pwsh-install-" + [System.Guid]::NewGuid().ToString('N'))

--- a/tools/install-multi-pwsh.sh
+++ b/tools/install-multi-pwsh.sh
@@ -5,8 +5,8 @@ repo_owner="Devolutions"
 repo_name="pwsh-host-rs"
 
 version="${1:-latest}"
-install_root="${HOME}/.pwsh"
-bin_dir="${install_root}/bin"
+install_home="${MULTI_PWSH_HOME:-${HOME}/.pwsh}"
+bin_dir="${MULTI_PWSH_BIN_DIR:-${install_home}/bin}"
 
 if [[ "${version}" == "latest" ]]; then
   release_path="latest/download"
@@ -106,14 +106,19 @@ if [[ -z "${profile_file}" ]]; then
   profile_file="${profile_candidates[0]}"
 fi
 
+escaped_bin_dir="${bin_dir//\\/\\\\}"
+escaped_bin_dir="${escaped_bin_dir//\"/\\\"}"
+escaped_bin_dir="${escaped_bin_dir//\$/\\$}"
+profile_line="export PATH=\"${escaped_bin_dir}:\$PATH\""
+
 touch "${profile_file}"
-if grep -Fq '.pwsh/bin' "${profile_file}"; then
+if grep -Fq "${profile_line}" "${profile_file}"; then
   path_status="PATH already contains ${bin_dir} in ${profile_file}"
 else
   {
     echo ""
     echo "# Added by multi-pwsh installer"
-    echo 'export PATH="$HOME/.pwsh/bin:$PATH"'
+    echo "${profile_line}"
   } >>"${profile_file}"
   path_status="Added ${bin_dir} to PATH in ${profile_file}"
 fi

--- a/tools/uninstall-multi-pwsh.ps1
+++ b/tools/uninstall-multi-pwsh.ps1
@@ -23,8 +23,24 @@ function Remove-PathEntry {
     return ($filtered -join ';')
 }
 
-$installRoot = Join-Path $HOME '.pwsh'
-$binDir = Join-Path $installRoot 'bin'
+function Get-MultiPwshHome {
+    if (-not [string]::IsNullOrWhiteSpace($env:MULTI_PWSH_HOME)) {
+        return $env:MULTI_PWSH_HOME
+    }
+
+    return (Join-Path $HOME '.pwsh')
+}
+
+function Get-MultiPwshBinDir {
+    if (-not [string]::IsNullOrWhiteSpace($env:MULTI_PWSH_BIN_DIR)) {
+        return $env:MULTI_PWSH_BIN_DIR
+    }
+
+    return (Join-Path (Get-MultiPwshHome) 'bin')
+}
+
+$installHome = Get-MultiPwshHome
+$binDir = Get-MultiPwshBinDir
 $targetExe = Join-Path $binDir 'multi-pwsh.exe'
 
 if (Test-Path -Path $targetExe -PathType Leaf) {

--- a/tools/uninstall-multi-pwsh.sh
+++ b/tools/uninstall-multi-pwsh.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-install_root="${HOME}/.pwsh"
-bin_dir="${install_root}/bin"
+install_home="${MULTI_PWSH_HOME:-${HOME}/.pwsh}"
+bin_dir="${MULTI_PWSH_BIN_DIR:-${install_home}/bin}"
 binary_path="${bin_dir}/multi-pwsh"
 
 remove_profile_entries() {
@@ -13,8 +13,9 @@ remove_profile_entries() {
   local temp_file
   temp_file="$(mktemp)"
 
-  awk '
+  awk -v bin_dir="${bin_dir}" '
     $0 == "# Added by multi-pwsh installer" { changed = 1; next }
+    $0 == "export PATH=\"" bin_dir ":$PATH\"" { changed = 1; next }
     $0 == "export PATH=\"$HOME/.pwsh/bin:$PATH\"" { changed = 1; next }
     { print }
   ' "${profile_file}" > "${temp_file}"


### PR DESCRIPTION
## Summary
- add MULTI_PWSH_HOME as the base multi-pwsh layout root and keep MULTI_PWSH_BIN_DIR plus MULTI_PWSH_CACHE_DIR as the supported path overrides
- move extracted PowerShell installs under MULTI_PWSH_HOME/multi while keeping alias metadata in MULTI_PWSH_HOME and preserving legacy install discovery for compatibility
- update bootstrap scripts, uninstall scripts, documentation, and CI to use the resolved multi-pwsh layout instead of hardcoded ~/.pwsh/bin paths
- fall back from hard link to copy when creating host shims so aliases still work when MULTI_PWSH_HOME is on a different drive or filesystem

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets
- cargo build --all-targets
- cargo test --all-targets
- dotnet build dotnet/Bindings.csproj
- dotnet test dotnet/Bindings.csproj --no-build
- local smoke test with temp-scoped MULTI_PWSH_HOME on a different drive than the repo