### PR TITLE
Add multi-pwsh virtual environment management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,42 @@
-# pwsh-host-rs
+# multi-pwsh
 
-Rust PowerShell hosting library that loads .NET delegates and drives `System.Management.Automation.PowerShell` through unmanaged entry points.
-
-## multi-pwsh
-
-Install and manage side-by-side PowerShell versions from GitHub Releases.
+Install and manage side-by-side PowerShell versions with aliases and native hosting.
 
 ![multi-pwsh](docs/images/multi-pwsh.png)
 
-### Bootstrap
+## Bootstrap
 
 Latest release bootstrap scripts:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/install-multi-pwsh.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash
 ```
 
 ```powershell
-irm https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/install-multi-pwsh.ps1 | iex
+irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1 | iex
 ```
 
 Install a specific tag (example `v0.6.0`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.6.0
+curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.6.0
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.6.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.6.0
 ```
 
 Uninstall bootstrap scripts:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/uninstall-multi-pwsh.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/uninstall-multi-pwsh.sh | bash
 ```
 
 ```powershell
-irm https://raw.githubusercontent.com/Devolutions/pwsh-host-rs/refs/heads/master/tools/uninstall-multi-pwsh.ps1 | iex
+irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/uninstall-multi-pwsh.ps1 | iex
 ```
 
-### Install and verify aliases
+## Install and verify aliases
 
 ```powershell
 multi-pwsh install 7.4
@@ -55,7 +51,7 @@ pwsh-7.4 --version
 pwsh-7.5 --version
 ```
 
-### Manage installed lines
+## Manage installed lines
 
 ```powershell
 multi-pwsh install 7.4.x
@@ -71,7 +67,12 @@ multi-pwsh install 7.6.0-rc.1
 multi-pwsh update 7.6 --include-prerelease
 multi-pwsh alias set 7.4 7.4.11
 multi-pwsh alias unset 7.4
-multi-pwsh host 7.4 -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"
+multi-pwsh venv create msgraph
+multi-pwsh venv export msgraph msgraph.zip
+multi-pwsh venv import msgraph-copy msgraph.zip
+multi-pwsh venv delete msgraph
+multi-pwsh venv list
+multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile -Command "$env:PSModulePath"
 multi-pwsh doctor --repair-aliases
 ```
 
@@ -82,9 +83,14 @@ multi-pwsh install <version|major|major.minor|major.minor.x> [--arch <auto|x64|x
 multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]
 multi-pwsh uninstall <version> [--force]
 multi-pwsh list [--available] [--include-prerelease]
+multi-pwsh venv create <name>
+multi-pwsh venv delete <name>
+multi-pwsh venv export <name> <archive.zip>
+multi-pwsh venv import <name> <archive.zip>
+multi-pwsh venv list
 multi-pwsh alias set <major.minor> <version|latest>
 multi-pwsh alias unset <major.minor>
-multi-pwsh host <version|major|major.minor|pwsh-alias> [pwsh arguments...]
+multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]
 multi-pwsh doctor --repair-aliases
 ```
 
@@ -103,6 +109,7 @@ Native host mode:
 
 - `multi-pwsh host <selector> ...` runs PowerShell through native hosting (`pwsh-host` crate) instead of launching a `pwsh` subprocess.
 - `<selector>` supports `7`, `7.4`, `7.4.13`, or alias-form selectors such as `pwsh-7.4`.
+- `-VirtualEnvironment <name>` and `-venv <name>` are consumed by `multi-pwsh` before handing control to PowerShell and set `PSModulePath` to the selected venv root for that launch.
 - Alias lifecycle now maintains native host shims as hard links to `multi-pwsh` automatically during install/update/doctor alias repair.
 - On Windows, host shims are `pwsh-*.exe` files alongside `.cmd` wrappers in `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`).
 - On Linux/macOS, alias command paths (`pwsh-*`) are hard links to `multi-pwsh`.
@@ -110,11 +117,80 @@ Native host mode:
 - You can still manually copy/rename `multi-pwsh.exe` under `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`) to an alias-like name (for example `pwsh-7.4.exe`); it automatically enters host mode and resolves the target installation from that alias name.
 - `-NamedPipeCommand <pipeName>` is supported in host mode (Windows only), matching `pwsh-host` behavior.
 
+### Virtual environments
+
+`multi-pwsh` virtual environments provide isolated PowerShell module roots. They are conceptually similar to Python virtual environments, but in this first version the isolation is implemented by selecting a venv-specific `PSModulePath` root for hosted launches.
+
+By default, venvs live under `~/.pwsh/venv/<name>`. If `MULTI_PWSH_VENV_DIR` is set, they live under that directory instead.
+
+Available commands:
+
+- `multi-pwsh venv create <name>` creates a named venv.
+- `multi-pwsh venv delete <name>` removes a named venv.
+- `multi-pwsh venv export <name> <archive.zip>` exports a named venv to a zip archive.
+- `multi-pwsh venv import <name> <archive.zip>` imports a named venv from a zip archive.
+- `multi-pwsh venv list` shows the configured venv root and all known venvs.
+
+#### Create and use a venv
+
+Create a venv and launch a hosted PowerShell session that uses it:
+
+```powershell
+multi-pwsh venv create msgraph
+multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile
+```
+
+You can verify which module root is being used:
+
+```powershell
+multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile -Command "$env:PSModulePath"
+```
+
+Both `-venv <name>` and `-VirtualEnvironment <name>` are supported.
+
+#### Populate a venv with modules
+
+Venvs are module discovery roots, so modules should live directly under `<venv-root>/<ModuleName>`.
+
+For the current implementation, the safest way to place modules into a venv is to save them directly into that venv root:
+
+```powershell
+$venvRoot = Join-Path $HOME ".pwsh/venv/msgraph"
+Save-Module -Name Microsoft.Graph.Authentication -Repository PSGallery -Path $venvRoot -Force
+Save-Module -Name Microsoft.Graph.Users -Repository PSGallery -Path $venvRoot -Force
+```
+
+Then use the venv when launching PowerShell:
+
+```powershell
+multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile -Command "Get-Module -ListAvailable Microsoft.Graph.Authentication"
+```
+
+#### Export and import a venv
+
+You can package a venv as a zip archive and recreate it elsewhere:
+
+```powershell
+multi-pwsh venv export msgraph msgraph.zip
+multi-pwsh venv import msgraph-copy msgraph.zip
+multi-pwsh host 7.4 -venv msgraph-copy -NoLogo -NoProfile
+```
+
+Import is intentionally conservative: importing into an existing destination venv is rejected instead of merging archive contents.
+
+#### Current behavior and limitations
+
+- Venv selection changes module discovery and import precedence for hosted launches.
+- In this first version, `Install-Module` is not automatically redirected into the venv just because `-venv` is used.
+- PowerShell may still include some built-in or default module paths in the effective `PSModulePath`; the venv is intended to be the selected module root, not a perfect process-level sandbox.
+- The venv feature currently applies to `multi-pwsh host ...` and implicit host shims such as `pwsh-7.4.exe`, not to arbitrary external `pwsh` processes.
+
 Managed paths can be controlled with environment variables:
 
-- `MULTI_PWSH_HOME`: override the multi-pwsh home directory (default: `~/.pwsh`). Extracted PowerShell versions are stored under `MULTI_PWSH_HOME/multi`, and alias metadata is stored in `MULTI_PWSH_HOME/aliases.json`.
+- `MULTI_PWSH_HOME`: override the multi-pwsh home directory (default: `~/.pwsh`). Extracted PowerShell versions are stored under `MULTI_PWSH_HOME/multi`, virtual environments are stored under `MULTI_PWSH_HOME/venv` unless `MULTI_PWSH_VENV_DIR` is set, and alias metadata is stored in `MULTI_PWSH_HOME/aliases.json`.
 - `MULTI_PWSH_BIN_DIR`: override the shim and launcher directory (default: `MULTI_PWSH_HOME/bin`).
 - `MULTI_PWSH_CACHE_DIR`: override archive cache directory (default: `MULTI_PWSH_HOME/cache`).
+- `MULTI_PWSH_VENV_DIR`: override the virtual-environment root directory (default: `MULTI_PWSH_HOME/venv`).
 - `MULTI_PWSH_CACHE_KEEP`: keep downloaded archives after extraction when set to a truthy value (`1`, `true`, `yes`, or `on`).
 
 CI cache example:
@@ -123,6 +199,7 @@ CI cache example:
 $env:MULTI_PWSH_HOME = "$(Join-Path $HOME '.pwsh')"
 $env:MULTI_PWSH_BIN_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'bin')"
 $env:MULTI_PWSH_CACHE_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'cache')"
+$env:MULTI_PWSH_VENV_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'venv')"
 $env:MULTI_PWSH_CACHE_KEEP = "1"
 multi-pwsh install 7.4.x
 ```
@@ -140,7 +217,7 @@ For background on this approach, see [dotnet/runtime#46652: Native Host using ex
 
 Download the `pwsh-host-<os>-<arch>.zip` artifact for your platform from:
 
-- https://github.com/Devolutions/pwsh-host-rs/releases
+- https://github.com/Devolutions/multi-pwsh/releases
 
 Current artifact names:
 

--- a/crates/multi-pwsh/src/layout.rs
+++ b/crates/multi-pwsh/src/layout.rs
@@ -11,6 +11,7 @@ pub struct InstallLayout {
     home: PathBuf,
     bin_dir: PathBuf,
     cache_dir: PathBuf,
+    venvs_dir: PathBuf,
     os: HostOs,
 }
 
@@ -26,11 +27,15 @@ impl InstallLayout {
         let cache_dir = env::var_os("MULTI_PWSH_CACHE_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|| home.join("cache"));
+        let venvs_dir = env::var_os("MULTI_PWSH_VENV_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join("venv"));
 
         Ok(InstallLayout {
             home,
             bin_dir,
             cache_dir,
+            venvs_dir,
             os,
         })
     }
@@ -49,6 +54,14 @@ impl InstallLayout {
 
     pub fn cache_dir(&self) -> PathBuf {
         self.cache_dir.clone()
+    }
+
+    pub fn venvs_dir(&self) -> PathBuf {
+        self.venvs_dir.clone()
+    }
+
+    pub fn venv_dir(&self, name: &str) -> PathBuf {
+        self.venvs_dir().join(name)
     }
 
     pub fn versions_dir(&self) -> PathBuf {
@@ -106,6 +119,7 @@ impl InstallLayout {
         fs::create_dir_all(&self.home)?;
         fs::create_dir_all(self.bin_dir())?;
         fs::create_dir_all(self.cache_dir())?;
+        fs::create_dir_all(self.venvs_dir())?;
         fs::create_dir_all(self.versions_dir())?;
         Ok(())
     }
@@ -119,7 +133,7 @@ impl InstallLayout {
         collect_versions_from_dir(&self.versions_dir(), &[], self.executable_name(), &mut versions)?;
         collect_versions_from_dir(
             self.home(),
-            &["bin", "cache", "multi"],
+            &["bin", "cache", "multi", "venv"],
             self.executable_name(),
             &mut versions,
         )?;
@@ -197,13 +211,16 @@ mod tests {
         home: Option<&Path>,
         bin_dir: Option<&Path>,
         cache_dir: Option<&Path>,
+        venv_dir: Option<&Path>,
         action: impl FnOnce() -> T,
     ) -> T {
         let _guard = ENV_LOCK.lock().unwrap();
 
         with_env_var("MULTI_PWSH_HOME", home, || {
             with_env_var("MULTI_PWSH_BIN_DIR", bin_dir, || {
-                with_env_var("MULTI_PWSH_CACHE_DIR", cache_dir, action)
+                with_env_var("MULTI_PWSH_CACHE_DIR", cache_dir, || {
+                    with_env_var("MULTI_PWSH_VENV_DIR", venv_dir, action)
+                })
             })
         })
     }
@@ -213,11 +230,13 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let expected_home = temp_dir.path().join("pwsh-home");
 
-        with_layout_env(Some(&expected_home), None, None, || {
+        with_layout_env(Some(&expected_home), None, None, None, || {
             let layout = InstallLayout::new(HostOs::Windows).unwrap();
             assert_eq!(layout.home(), expected_home.as_path());
             assert_eq!(layout.bin_dir(), expected_home.join("bin"));
             assert_eq!(layout.cache_dir(), expected_home.join("cache"));
+            assert_eq!(layout.venvs_dir(), expected_home.join("venv"));
+            assert_eq!(layout.venv_dir("msgraph"), expected_home.join("venv").join("msgraph"));
             assert_eq!(layout.versions_dir(), expected_home.join("multi"));
             assert_eq!(layout.aliases_file(), expected_home.join("aliases.json"));
         });
@@ -230,11 +249,33 @@ mod tests {
         let expected_bin = temp_dir.path().join("shims");
         let expected_cache = temp_dir.path().join("cache-root");
 
-        with_layout_env(Some(&expected_home), Some(&expected_bin), Some(&expected_cache), || {
+        with_layout_env(
+            Some(&expected_home),
+            Some(&expected_bin),
+            Some(&expected_cache),
+            None,
+            || {
+                let layout = InstallLayout::new(HostOs::Linux).unwrap();
+                assert_eq!(layout.home(), expected_home.as_path());
+                assert_eq!(layout.bin_dir(), expected_bin);
+                assert_eq!(layout.cache_dir(), expected_cache);
+                assert_eq!(layout.venvs_dir(), expected_home.join("venv"));
+                assert_eq!(layout.versions_dir(), expected_home.join("multi"));
+            },
+        );
+    }
+
+    #[test]
+    fn layout_uses_explicit_venv_override() {
+        let temp_dir = TempDir::new().unwrap();
+        let expected_home = temp_dir.path().join("pwsh-home");
+        let expected_venv = temp_dir.path().join("venvs-root");
+
+        with_layout_env(Some(&expected_home), None, None, Some(&expected_venv), || {
             let layout = InstallLayout::new(HostOs::Linux).unwrap();
             assert_eq!(layout.home(), expected_home.as_path());
-            assert_eq!(layout.bin_dir(), expected_bin);
-            assert_eq!(layout.cache_dir(), expected_cache);
+            assert_eq!(layout.venvs_dir(), expected_venv);
+            assert_eq!(layout.venv_dir("msgraph"), expected_venv.join("msgraph"));
             assert_eq!(layout.versions_dir(), expected_home.join("multi"));
         });
     }
@@ -247,7 +288,7 @@ mod tests {
         let legacy_dir = expected_home.join(version.to_string());
         fs::create_dir_all(&legacy_dir).unwrap();
 
-        with_layout_env(Some(&expected_home), None, None, || {
+        with_layout_env(Some(&expected_home), None, None, None, || {
             let layout = InstallLayout::new(HostOs::Linux).unwrap();
             assert_eq!(layout.version_dir(&version), legacy_dir);
             assert_eq!(
@@ -271,7 +312,7 @@ mod tests {
         fs::write(new_dir.join("pwsh"), "").unwrap();
         fs::write(legacy_dir.join("pwsh"), "").unwrap();
 
-        with_layout_env(Some(&expected_home), None, None, || {
+        with_layout_env(Some(&expected_home), None, None, None, || {
             let layout = InstallLayout::new(HostOs::Linux).unwrap();
             assert_eq!(layout.installed_versions().unwrap(), vec![new_version, legacy_version]);
         });

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -28,6 +28,9 @@ use versions::{
     VersionSelector,
 };
 
+const POWERSHELL_UPDATECHECK_ENV_VAR: &str = "POWERSHELL_UPDATECHECK";
+const POWERSHELL_UPDATECHECK_OFF: &str = "Off";
+
 fn print_usage() {
     eprintln!(
         "Usage:\n  multi-pwsh install <version|major|major.minor|major.minor.x> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh uninstall <version> [--force]\n  multi-pwsh list [--available] [--include-prerelease]\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias unset <major.minor>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
@@ -125,6 +128,10 @@ fn preprocess_host_args(args: Vec<OsString>) -> Result<Vec<OsString>> {
         .map_err(|error| MultiPwshError::Host(format!("invalid host arguments: {}", error)))
 }
 
+fn disable_powershell_update_notifications() {
+    unsafe { env::set_var(POWERSHELL_UPDATECHECK_ENV_VAR, POWERSHELL_UPDATECHECK_OFF) };
+}
+
 fn run_host_mode(selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> {
     let os = HostOs::detect()?;
     let layout = InstallLayout::new(os)?;
@@ -132,6 +139,7 @@ fn run_host_mode(selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> 
 
     let (_version, executable) = resolve_host_executable(&layout, selector_input)?;
     let args = preprocess_host_args(pwsh_args)?;
+    disable_powershell_update_notifications();
 
     pwsh_host::run_pwsh_command_line_for_pwsh_exe(&executable, args).map_err(|error| {
         MultiPwshError::Host(format!(
@@ -899,6 +907,28 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env_var<T>(key: &str, value: Option<&str>, action: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = env::var_os(key);
+
+        match value {
+            Some(value) => unsafe { env::set_var(key, value) },
+            None => unsafe { env::remove_var(key) },
+        }
+
+        let result = action();
+
+        match previous {
+            Some(value) => unsafe { env::set_var(key, value) },
+            None => unsafe { env::remove_var(key) },
+        }
+
+        result
+    }
 
     #[test]
     fn parse_force_option_defaults_to_false() {
@@ -968,6 +998,14 @@ mod tests {
     fn parse_host_selector_supports_exact_version() {
         let selector = parse_host_selector("7.4.13").unwrap();
         assert_eq!(selector, HostSelector::Exact(Version::parse("7.4.13").unwrap()));
+    }
+
+    #[test]
+    fn disable_powershell_update_notifications_sets_off() {
+        with_env_var(POWERSHELL_UPDATECHECK_ENV_VAR, Some("LTS"), || {
+            disable_powershell_update_notifications();
+            assert_eq!(env::var(POWERSHELL_UPDATECHECK_ENV_VAR).unwrap(), POWERSHELL_UPDATECHECK_OFF);
+        });
     }
 
     #[test]

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -7,9 +7,10 @@ mod release;
 mod versions;
 
 use std::env;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::io;
+use std::path::{Component, Path, PathBuf};
 use std::process;
 
 use semver::Version;
@@ -30,10 +31,13 @@ use versions::{
 
 const POWERSHELL_UPDATECHECK_ENV_VAR: &str = "POWERSHELL_UPDATECHECK";
 const POWERSHELL_UPDATECHECK_OFF: &str = "Off";
+const PSMODULEPATH_ENV_VAR: &str = "PSModulePath";
+const VIRTUAL_ENVIRONMENT_FLAG: &str = "-virtualenvironment";
+const VIRTUAL_ENVIRONMENT_SHORT_FLAG: &str = "-venv";
 
 fn print_usage() {
     eprintln!(
-        "Usage:\n  multi-pwsh install <version|major|major.minor|major.minor.x> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh uninstall <version> [--force]\n  multi-pwsh list [--available] [--include-prerelease]\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias unset <major.minor>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
+        "Usage:\n  multi-pwsh install <version|major|major.minor|major.minor.x> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh uninstall <version> [--force]\n  multi-pwsh list [--available] [--include-prerelease]\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias unset <major.minor>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
     );
 }
 
@@ -45,6 +49,34 @@ struct ReleaseSelectionOptions {
 enum ListOption {
     Installed,
     Available { include_prerelease: bool },
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+struct HostLaunchOptions {
+    pwsh_args: Vec<OsString>,
+    virtual_environment: Option<String>,
+}
+
+struct ProcessEnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl ProcessEnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let previous = env::var_os(key);
+        unsafe { env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for ProcessEnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => unsafe { env::set_var(self.key, value) },
+            None => unsafe { env::remove_var(self.key) },
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -123,13 +155,257 @@ fn resolve_host_executable(layout: &InstallLayout, selector_input: &str) -> Resu
     Ok((version, executable))
 }
 
-fn preprocess_host_args(args: Vec<OsString>) -> Result<Vec<OsString>> {
-    pwsh_host::preprocess_named_pipe_command_args(args)
-        .map_err(|error| MultiPwshError::Host(format!("invalid host arguments: {}", error)))
+fn validate_venv_name(value: &str) -> Result<&str> {
+    if value.is_empty() {
+        return Err(MultiPwshError::InvalidArguments(
+            "virtual environment name cannot be empty".to_string(),
+        ));
+    }
+
+    if value == "." || value == ".." {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "virtual environment name '{}' is reserved",
+            value
+        )));
+    }
+
+    if value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        return Ok(value);
+    }
+
+    Err(MultiPwshError::InvalidArguments(format!(
+        "virtual environment name '{}' is invalid; expected only ASCII letters, digits, '.', '-', or '_'",
+        value
+    )))
+}
+
+fn normalize_host_flag(arg: &OsStr) -> String {
+    arg.to_string_lossy().to_ascii_lowercase()
+}
+
+fn is_virtual_environment_flag(arg: &OsStr) -> bool {
+    matches!(
+        normalize_host_flag(arg).as_str(),
+        VIRTUAL_ENVIRONMENT_FLAG | VIRTUAL_ENVIRONMENT_SHORT_FLAG
+    )
+}
+
+fn is_option_like(arg: &OsStr) -> bool {
+    let text = arg.to_string_lossy();
+    text.starts_with('-') || text.starts_with('/')
+}
+
+fn extract_virtual_environment_arg(args: Vec<OsString>) -> Result<(Vec<OsString>, Option<String>)> {
+    let mut virtual_environment_index = None;
+    let mut virtual_environment_name = None;
+
+    for (index, arg) in args.iter().enumerate() {
+        if !is_virtual_environment_flag(arg.as_os_str()) {
+            continue;
+        }
+
+        if virtual_environment_index.is_some() {
+            return Err(MultiPwshError::InvalidArguments(
+                "-VirtualEnvironment can only be specified once".to_string(),
+            ));
+        }
+
+        let value = args.get(index + 1).ok_or_else(|| {
+            MultiPwshError::InvalidArguments("-VirtualEnvironment requires a virtual environment name".to_string())
+        })?;
+
+        if is_option_like(value.as_os_str()) {
+            return Err(MultiPwshError::InvalidArguments(
+                "-VirtualEnvironment requires a virtual environment name".to_string(),
+            ));
+        }
+
+        let value = value.to_string_lossy().into_owned();
+        validate_venv_name(&value)?;
+
+        virtual_environment_index = Some(index);
+        virtual_environment_name = Some(value);
+    }
+
+    let Some(index) = virtual_environment_index else {
+        return Ok((args, None));
+    };
+
+    let mut rewritten = Vec::with_capacity(args.len().saturating_sub(2));
+    rewritten.extend_from_slice(&args[..index]);
+    rewritten.extend_from_slice(&args[index + 2..]);
+
+    Ok((rewritten, virtual_environment_name))
+}
+
+fn preprocess_host_args(args: Vec<OsString>) -> Result<HostLaunchOptions> {
+    let (args, virtual_environment) = extract_virtual_environment_arg(args)?;
+    let pwsh_args = pwsh_host::preprocess_named_pipe_command_args(args)
+        .map_err(|error| MultiPwshError::Host(format!("invalid host arguments: {}", error)))?;
+
+    Ok(HostLaunchOptions {
+        pwsh_args,
+        virtual_environment,
+    })
 }
 
 fn disable_powershell_update_notifications() {
     unsafe { env::set_var(POWERSHELL_UPDATECHECK_ENV_VAR, POWERSHELL_UPDATECHECK_OFF) };
+}
+
+fn resolve_virtual_environment_dir(layout: &InstallLayout, name: &str) -> Result<PathBuf> {
+    let name = validate_venv_name(name)?;
+    let venv_dir = layout.venv_dir(name);
+
+    if !venv_dir.is_dir() {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "virtual environment '{}' was not found at {}; create it with: multi-pwsh venv create {}",
+            name,
+            venv_dir.display(),
+            name
+        )));
+    }
+
+    Ok(venv_dir)
+}
+
+fn zip_file_options() -> zip::write::FileOptions {
+    zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated)
+}
+
+fn format_archive_entry_name(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(value.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn append_directory_to_zip<W: io::Write + io::Seek>(
+    writer: &mut zip::ZipWriter<W>,
+    root_dir: &Path,
+    current_dir: &Path,
+) -> Result<()> {
+    let mut entries: Vec<_> = fs::read_dir(current_dir)?.collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let entry_path = entry.path();
+        let relative_path = entry_path.strip_prefix(root_dir).map_err(|error| {
+            MultiPwshError::Archive(format!(
+                "failed to strip archive root '{}' from '{}': {}",
+                root_dir.display(),
+                entry_path.display(),
+                error
+            ))
+        })?;
+        let archive_name = format_archive_entry_name(relative_path);
+
+        if entry_path.is_dir() {
+            writer.add_directory(format!("{}/", archive_name), zip_file_options())?;
+            append_directory_to_zip(writer, root_dir, &entry_path)?;
+            continue;
+        }
+
+        writer.start_file(archive_name, zip_file_options())?;
+        let mut source = fs::File::open(&entry_path)?;
+        io::copy(&mut source, writer)?;
+    }
+
+    Ok(())
+}
+
+fn export_virtual_environment_to_archive(venv_dir: &Path, archive_path: &Path) -> Result<()> {
+    if let Some(parent) = archive_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    let archive_file = fs::File::create(archive_path)?;
+    let mut writer = zip::ZipWriter::new(archive_file);
+    append_directory_to_zip(&mut writer, venv_dir, venv_dir)?;
+    writer.finish()?;
+    Ok(())
+}
+
+fn sanitize_archive_entry_path(name: &str) -> Result<PathBuf> {
+    let mut sanitized = PathBuf::new();
+
+    for component in Path::new(name).components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(value) => sanitized.push(value),
+            Component::Prefix(_) | Component::RootDir | Component::ParentDir => {
+                return Err(MultiPwshError::Archive(format!(
+                    "archive entry '{}' contains an invalid path",
+                    name
+                )));
+            }
+        }
+    }
+
+    Ok(sanitized)
+}
+
+fn import_virtual_environment_from_archive(venv_dir: &Path, archive_path: &Path) -> Result<()> {
+    if !archive_path.is_file() {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "archive '{}' was not found",
+            archive_path.display()
+        )));
+    }
+
+    if venv_dir.exists() {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "virtual environment destination '{}' already exists",
+            venv_dir.display()
+        )));
+    }
+
+    fs::create_dir_all(venv_dir)?;
+
+    let import_result = (|| -> Result<()> {
+        let archive_file = fs::File::open(archive_path)?;
+        let mut archive = zip::ZipArchive::new(archive_file)?;
+
+        for index in 0..archive.len() {
+            let mut entry = archive.by_index(index)?;
+            let relative_path = sanitize_archive_entry_path(entry.name())?;
+
+            if relative_path.as_os_str().is_empty() {
+                continue;
+            }
+
+            let destination_path = venv_dir.join(relative_path);
+
+            if entry.is_dir() {
+                fs::create_dir_all(&destination_path)?;
+                continue;
+            }
+
+            if let Some(parent) = destination_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+
+            let mut destination = fs::File::create(&destination_path)?;
+            io::copy(&mut entry, &mut destination)?;
+        }
+
+        Ok(())
+    })();
+
+    if let Err(error) = import_result {
+        let _ = fs::remove_dir_all(venv_dir);
+        return Err(error);
+    }
+
+    Ok(())
 }
 
 fn run_host_mode(selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> {
@@ -138,10 +414,19 @@ fn run_host_mode(selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> 
     layout.ensure_base_dirs()?;
 
     let (_version, executable) = resolve_host_executable(&layout, selector_input)?;
-    let args = preprocess_host_args(pwsh_args)?;
+    let HostLaunchOptions {
+        pwsh_args,
+        virtual_environment,
+    } = preprocess_host_args(pwsh_args)?;
     disable_powershell_update_notifications();
 
-    pwsh_host::run_pwsh_command_line_for_pwsh_exe(&executable, args).map_err(|error| {
+    let _virtual_environment_guard = virtual_environment
+        .as_deref()
+        .map(|name| resolve_virtual_environment_dir(&layout, name))
+        .transpose()?
+        .map(|venv_dir| ProcessEnvVarGuard::set(PSMODULEPATH_ENV_VAR, venv_dir.as_os_str()));
+
+    pwsh_host::run_pwsh_command_line_for_pwsh_exe(&executable, pwsh_args).map_err(|error| {
         MultiPwshError::Host(format!(
             "failed to start native host for selector '{}': {}",
             selector_input, error
@@ -152,7 +437,8 @@ fn run_host_mode(selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> 
 fn run_host_command(args: &[String]) -> Result<i32> {
     if args.is_empty() {
         return Err(MultiPwshError::InvalidArguments(
-            "host requires: <version|major|major.minor|pwsh-alias> [pwsh arguments...]".to_string(),
+            "host requires: <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]"
+                .to_string(),
         ));
     }
 
@@ -261,6 +547,133 @@ fn parse_alias_set_target(target: &str) -> Result<Option<Version>> {
 
     let version = parse_exact_version(target)?;
     Ok(Some(version))
+}
+
+fn run_venv(args: &[String]) -> Result<()> {
+    if args.is_empty() {
+        return Err(MultiPwshError::InvalidArguments(
+            "venv requires: create <name>, delete <name>, export <name> <archive.zip>, import <name> <archive.zip>, or list"
+                .to_string(),
+        ));
+    }
+
+    let os = HostOs::detect()?;
+    let layout = InstallLayout::new(os)?;
+    layout.ensure_base_dirs()?;
+
+    match args[0].as_str() {
+        "create" => {
+            if args.len() != 2 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "venv create requires: <name>".to_string(),
+                ));
+            }
+
+            let name = validate_venv_name(&args[1])?;
+            let venv_dir = layout.venv_dir(name);
+            fs::create_dir_all(&venv_dir)?;
+
+            println!("Virtual environment: {}", name);
+            println!("Path: {}", venv_dir.display());
+            Ok(())
+        }
+        "delete" => {
+            if args.len() != 2 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "venv delete requires: <name>".to_string(),
+                ));
+            }
+
+            let name = validate_venv_name(&args[1])?;
+            let venv_dir = layout.venv_dir(name);
+
+            if !venv_dir.is_dir() {
+                return Err(MultiPwshError::InvalidArguments(format!(
+                    "virtual environment '{}' was not found at {}",
+                    name,
+                    venv_dir.display()
+                )));
+            }
+
+            fs::remove_dir_all(&venv_dir)?;
+
+            println!("Deleted virtual environment: {}", name);
+            println!("Path: {}", venv_dir.display());
+            Ok(())
+        }
+        "export" => {
+            if args.len() != 3 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "venv export requires: <name> <archive.zip>".to_string(),
+                ));
+            }
+
+            let name = validate_venv_name(&args[1])?;
+            let venv_dir = resolve_virtual_environment_dir(&layout, name)?;
+            let archive_path = PathBuf::from(&args[2]);
+
+            export_virtual_environment_to_archive(&venv_dir, &archive_path)?;
+
+            println!("Exported virtual environment: {}", name);
+            println!("Archive: {}", archive_path.display());
+            Ok(())
+        }
+        "import" => {
+            if args.len() != 3 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "venv import requires: <name> <archive.zip>".to_string(),
+                ));
+            }
+
+            let name = validate_venv_name(&args[1])?;
+            let venv_dir = layout.venv_dir(name);
+            let archive_path = PathBuf::from(&args[2]);
+
+            import_virtual_environment_from_archive(&venv_dir, &archive_path)?;
+
+            println!("Imported virtual environment: {}", name);
+            println!("Path: {}", venv_dir.display());
+            println!("Archive: {}", archive_path.display());
+            Ok(())
+        }
+        "list" => {
+            if args.len() != 1 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "venv list does not accept additional arguments".to_string(),
+                ));
+            }
+
+            let venvs_dir = layout.venvs_dir();
+            println!("Venv root: {}", venvs_dir.display());
+
+            let mut entries: Vec<String> = fs::read_dir(&venvs_dir)?
+                .filter_map(|entry| {
+                    let entry = entry.ok()?;
+                    if !entry.path().is_dir() {
+                        return None;
+                    }
+
+                    entry.file_name().into_string().ok()
+                })
+                .collect();
+            entries.sort();
+
+            if entries.is_empty() {
+                println!("Virtual environments: (none)");
+            } else {
+                println!("Virtual environments:");
+                for entry in entries {
+                    println!("  - {}", entry);
+                }
+            }
+
+            Ok(())
+        }
+        _ => Err(MultiPwshError::InvalidArguments(
+            "venv requires: create <name>, delete <name>, export <name> <archive.zip>, import <name> <archive.zip>, or list"
+                .to_string(),
+        )),
+    }
 }
 
 fn run_alias(args: &[String]) -> Result<()> {
@@ -685,6 +1098,7 @@ fn run_list(option: ListOption) -> Result<()> {
             println!("Home: {}", layout.home().display());
             println!("Alias bin: {}", layout.bin_dir().display());
             println!("Versions dir: {}", layout.versions_dir().display());
+            println!("Venv dir: {}", layout.venvs_dir().display());
             println!("Cache dir: {}", layout.cache_dir().display());
             println!();
 
@@ -872,6 +1286,7 @@ fn run() -> Result<()> {
             let list_option = parse_list_option(&args[1..])?;
             run_list(list_option)
         }
+        "venv" => run_venv(&args[1..]),
         "alias" => run_alias(&args[1..]),
         "host" => {
             let exit_code = run_host_command(&args[1..])?;
@@ -883,7 +1298,7 @@ fn run() -> Result<()> {
             Ok(())
         }
         command => Err(MultiPwshError::InvalidArguments(format!(
-            "unknown command '{}'. expected: install, update, uninstall, list, alias, host, doctor",
+            "unknown command '{}'. expected: install, update, uninstall, list, venv, alias, host, doctor",
             command
         ))),
     }
@@ -1004,7 +1419,10 @@ mod tests {
     fn disable_powershell_update_notifications_sets_off() {
         with_env_var(POWERSHELL_UPDATECHECK_ENV_VAR, Some("LTS"), || {
             disable_powershell_update_notifications();
-            assert_eq!(env::var(POWERSHELL_UPDATECHECK_ENV_VAR).unwrap(), POWERSHELL_UPDATECHECK_OFF);
+            assert_eq!(
+                env::var(POWERSHELL_UPDATECHECK_ENV_VAR).unwrap(),
+                POWERSHELL_UPDATECHECK_OFF
+            );
         });
     }
 
@@ -1078,5 +1496,105 @@ mod tests {
     fn parse_alias_set_target_accepts_exact_version() {
         let version = parse_alias_set_target("7.4.11").unwrap().unwrap();
         assert_eq!(version, Version::parse("7.4.11").unwrap());
+    }
+
+    #[test]
+    fn validate_venv_name_accepts_simple_name() {
+        assert_eq!(validate_venv_name("msgraph").unwrap(), "msgraph");
+        assert_eq!(validate_venv_name("graph-sdk_1.0").unwrap(), "graph-sdk_1.0");
+    }
+
+    #[test]
+    fn validate_venv_name_rejects_reserved_or_path_like_values() {
+        assert!(validate_venv_name("").is_err());
+        assert!(validate_venv_name("..").is_err());
+        assert!(validate_venv_name("msgraph/tools").is_err());
+    }
+
+    #[test]
+    fn extract_virtual_environment_arg_removes_host_only_pair() {
+        let args = vec![
+            OsString::from("-NoProfile"),
+            OsString::from("-VirtualEnvironment"),
+            OsString::from("msgraph"),
+            OsString::from("-Command"),
+            OsString::from("$env:PSModulePath"),
+        ];
+
+        let (rewritten, virtual_environment) = extract_virtual_environment_arg(args).unwrap();
+
+        assert_eq!(virtual_environment, Some("msgraph".to_string()));
+        assert_eq!(
+            rewritten,
+            vec![
+                OsString::from("-NoProfile"),
+                OsString::from("-Command"),
+                OsString::from("$env:PSModulePath"),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_virtual_environment_arg_rejects_duplicate_flag() {
+        let args = vec![
+            OsString::from("-VirtualEnvironment"),
+            OsString::from("one"),
+            OsString::from("-venv"),
+            OsString::from("two"),
+        ];
+
+        assert!(extract_virtual_environment_arg(args).is_err());
+    }
+
+    #[test]
+    fn extract_virtual_environment_arg_accepts_short_flag() {
+        let args = vec![
+            OsString::from("-venv"),
+            OsString::from("msgraph"),
+            OsString::from("-NoProfile"),
+        ];
+
+        let (rewritten, virtual_environment) = extract_virtual_environment_arg(args).unwrap();
+
+        assert_eq!(virtual_environment, Some("msgraph".to_string()));
+        assert_eq!(rewritten, vec![OsString::from("-NoProfile")]);
+    }
+
+    #[test]
+    fn preprocess_host_args_combines_virtual_environment_and_named_pipe_processing() {
+        let args = vec![
+            OsString::from("-VirtualEnvironment"),
+            OsString::from("msgraph"),
+            OsString::from("-NoProfile"),
+        ];
+
+        let options = preprocess_host_args(args).unwrap();
+        assert_eq!(options.virtual_environment, Some("msgraph".to_string()));
+        assert_eq!(options.pwsh_args, vec![OsString::from("-NoProfile")]);
+    }
+
+    #[test]
+    fn process_env_var_guard_restores_previous_value() {
+        with_env_var(PSMODULEPATH_ENV_VAR, Some("original"), || {
+            {
+                let _guard = ProcessEnvVarGuard::set(PSMODULEPATH_ENV_VAR, "override");
+                assert_eq!(env::var(PSMODULEPATH_ENV_VAR).unwrap(), "override");
+            }
+
+            assert_eq!(env::var(PSMODULEPATH_ENV_VAR).unwrap(), "original");
+        });
+    }
+
+    #[test]
+    fn sanitize_archive_entry_path_accepts_normal_relative_paths() {
+        assert_eq!(
+            sanitize_archive_entry_path("Module/1.0.0/Module.psm1").unwrap(),
+            PathBuf::from("Module").join("1.0.0").join("Module.psm1")
+        );
+    }
+
+    #[test]
+    fn sanitize_archive_entry_path_rejects_parent_segments() {
+        assert!(sanitize_archive_entry_path("../escape.txt").is_err());
     }
 }

--- a/crates/multi-pwsh/tests/cli_args.rs
+++ b/crates/multi-pwsh/tests/cli_args.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Output};
 
 use serde_json::Value;
@@ -186,14 +186,44 @@ fn json_strings(value: &Value, key: &str) -> Vec<String> {
 }
 
 fn normalize_path_for_compare(path: &Path) -> String {
-    path.to_string_lossy().replace('/', "\\").to_ascii_lowercase()
+    let mut normalized = String::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => {
+                normalized.push_str(
+                    &prefix
+                        .as_os_str()
+                        .to_string_lossy()
+                        .replace('/', "\\")
+                        .to_ascii_lowercase(),
+                );
+            }
+            Component::RootDir => normalized.push('\\'),
+            Component::Normal(part) => {
+                if !normalized.is_empty() && !normalized.ends_with('\\') {
+                    normalized.push('\\');
+                }
+                normalized.push_str(&part.to_string_lossy().to_ascii_lowercase());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.is_empty() && !normalized.ends_with('\\') {
+                    normalized.push('\\');
+                }
+                normalized.push_str("..");
+            }
+        }
+    }
+
+    normalized
 }
 
 fn output_contains_module_base_under(paths: &[String], root: &Path) -> bool {
     let root = normalize_path_for_compare(root);
     paths
         .iter()
-        .map(|path| path.replace('/', "\\").to_ascii_lowercase())
+        .map(|path| normalize_path_for_compare(Path::new(path)))
         .any(|path| path.starts_with(&root))
 }
 

--- a/crates/multi-pwsh/tests/cli_args.rs
+++ b/crates/multi-pwsh/tests/cli_args.rs
@@ -186,7 +186,10 @@ fn json_strings(value: &Value, key: &str) -> Vec<String> {
 }
 
 fn normalize_path_for_compare(path: &Path) -> String {
-    normalize_path_text(&path.to_string_lossy())
+    match std::fs::canonicalize(path) {
+        Ok(canonical_path) => normalize_path_text(&canonical_path.to_string_lossy()),
+        Err(_) => normalize_path_text(&path.to_string_lossy()),
+    }
 }
 
 fn normalize_path_text(path: &str) -> String {

--- a/crates/multi-pwsh/tests/cli_args.rs
+++ b/crates/multi-pwsh/tests/cli_args.rs
@@ -1,5 +1,8 @@
-use std::path::PathBuf;
-use std::process::Command;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use tempfile::TempDir;
 
 fn find_multi_pwsh_binary() -> PathBuf {
     if let Some(path) = std::env::var_os("CARGO_BIN_EXE_multi-pwsh") {
@@ -21,8 +24,7 @@ fn find_multi_pwsh_binary() -> PathBuf {
     path
 }
 
-#[test]
-fn update_accepts_include_prerelease_flag() {
+fn run_multi_pwsh(args: &[&str], home: &std::path::Path) -> std::process::Output {
     let exe = find_multi_pwsh_binary();
     assert!(
         exe.exists(),
@@ -30,10 +32,183 @@ fn update_accepts_include_prerelease_flag() {
         exe.display()
     );
 
-    let output = Command::new(exe)
-        .args(["update", "not-a-line", "--include-prerelease"])
+    Command::new(exe)
+        .env("MULTI_PWSH_HOME", home)
+        .args(args)
         .output()
-        .expect("failed to run multi-pwsh test binary");
+        .expect("failed to run multi-pwsh test binary")
+}
+
+fn normalize_output(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).replace("\r\n", "\n").trim().to_string()
+}
+
+fn quote_pwsh_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn run_pwsh(script: &str) -> Output {
+    Command::new("pwsh")
+        .args(["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script])
+        .output()
+        .expect("failed to run pwsh")
+}
+
+fn discover_pwsh_install() -> (String, PathBuf) {
+    let output = run_pwsh(
+        "$exe = (Get-Command pwsh).Source; Write-Output \"$($PSVersionTable.PSVersion.ToString())|$(Split-Path -Parent $exe)\"",
+    );
+    assert!(
+        output.status.success(),
+        "failed to discover pwsh install: {}",
+        normalize_output(&output.stderr)
+    );
+
+    let line = normalize_output(&output.stdout);
+    let (version, install_dir) = line
+        .split_once('|')
+        .expect("expected version and install dir from pwsh discovery");
+
+    (version.to_string(), PathBuf::from(install_dir))
+}
+
+#[cfg(windows)]
+fn link_directory(link_path: &Path, target_path: &Path) {
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; New-Item -ItemType Junction -Path {} -Target {} | Out-Null",
+        quote_pwsh_literal(&link_path.display().to_string()),
+        quote_pwsh_literal(&target_path.display().to_string())
+    );
+    let output = run_pwsh(&script);
+
+    assert!(
+        output.status.success(),
+        "failed to create directory junction: {}",
+        normalize_output(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+fn link_directory(link_path: &Path, target_path: &Path) {
+    std::os::unix::fs::symlink(target_path, link_path).expect("failed to create directory symlink");
+}
+
+fn save_gallery_module(module_name: &str, destination: &Path) {
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         $ProgressPreference = 'SilentlyContinue'; \
+         Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; \
+         Save-Module -Name {} -Repository PSGallery -Path {} -Force",
+        quote_pwsh_literal(module_name),
+        quote_pwsh_literal(&destination.display().to_string())
+    );
+
+    let output = run_pwsh(&script);
+    assert!(
+        output.status.success(),
+        "failed to save module {} from PSGallery: {}",
+        module_name,
+        normalize_output(&output.stderr)
+    );
+}
+
+fn query_module_bases(home: &Path, selector: &str, venv: &str) -> Value {
+    let command = "$result = [ordered]@{ \
+            Yayaml = @(Get-Module -ListAvailable Yayaml | Select-Object -ExpandProperty ModuleBase); \
+            PSToml = @(Get-Module -ListAvailable PSToml | Select-Object -ExpandProperty ModuleBase) \
+        }; \
+        $result | ConvertTo-Json -Compress";
+
+    let output = run_multi_pwsh(
+        &[
+            "host",
+            selector,
+            "-venv",
+            venv,
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            command,
+        ],
+        home,
+    );
+
+    assert!(
+        output.status.success(),
+        "failed to query module bases through multi-pwsh host: {}",
+        normalize_output(&output.stderr)
+    );
+
+    serde_json::from_str(&normalize_output(&output.stdout)).expect("failed to parse module base JSON")
+}
+
+fn query_single_module_bases(home: &Path, selector: &str, venv: &str, module_name: &str) -> Vec<String> {
+    let command = format!(
+        "$result = [ordered]@{{ ModuleBases = @(Get-Module -ListAvailable {} | Select-Object -ExpandProperty ModuleBase) }}; \
+         $result | ConvertTo-Json -Compress",
+        quote_pwsh_literal(module_name)
+    );
+
+    let output = run_multi_pwsh(
+        &[
+            "host",
+            selector,
+            "-venv",
+            venv,
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            &command,
+        ],
+        home,
+    );
+
+    assert!(
+        output.status.success(),
+        "failed to query module bases through multi-pwsh host: {}",
+        normalize_output(&output.stderr)
+    );
+
+    let parsed: Value =
+        serde_json::from_str(&normalize_output(&output.stdout)).expect("failed to parse module base JSON");
+    json_strings(&parsed, "ModuleBases")
+}
+
+fn json_strings(value: &Value, key: &str) -> Vec<String> {
+    value[key]
+        .as_array()
+        .expect("expected JSON array")
+        .iter()
+        .filter_map(|item| item.as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+fn normalize_path_for_compare(path: &Path) -> String {
+    path.to_string_lossy().replace('/', "\\").to_ascii_lowercase()
+}
+
+fn output_contains_module_base_under(paths: &[String], root: &Path) -> bool {
+    let root = normalize_path_for_compare(root);
+    paths
+        .iter()
+        .map(|path| path.replace('/', "\\").to_ascii_lowercase())
+        .any(|path| path.starts_with(&root))
+}
+
+fn pwsh_executable_name() -> &'static str {
+    if cfg!(windows) {
+        "pwsh.exe"
+    } else {
+        "pwsh"
+    }
+}
+
+#[test]
+fn update_accepts_include_prerelease_flag() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let output = run_multi_pwsh(&["update", "not-a-line", "--include-prerelease"], temp_dir.path());
 
     assert!(
         !output.status.success(),
@@ -45,5 +220,265 @@ fn update_accepts_include_prerelease_flag() {
         stderr.contains("not a major.minor selector"),
         "expected selector parse error, got stderr: {}",
         stderr
+    );
+}
+
+#[test]
+fn venv_create_and_list_use_multi_pwsh_home() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let create_output = run_multi_pwsh(&["venv", "create", "msgraph"], temp_dir.path());
+    assert!(
+        create_output.status.success(),
+        "expected venv create to succeed: {}",
+        String::from_utf8_lossy(&create_output.stderr)
+    );
+
+    let expected_venv = temp_dir.path().join("venv").join("msgraph");
+    assert!(
+        expected_venv.is_dir(),
+        "expected venv dir at {}",
+        expected_venv.display()
+    );
+
+    let list_output = run_multi_pwsh(&["venv", "list"], temp_dir.path());
+    assert!(
+        list_output.status.success(),
+        "expected venv list to succeed: {}",
+        String::from_utf8_lossy(&list_output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&list_output.stdout);
+    assert!(
+        stdout.contains("Virtual environments:"),
+        "unexpected stdout: {}",
+        stdout
+    );
+    assert!(stdout.contains("msgraph"), "unexpected stdout: {}", stdout);
+
+    let delete_output = run_multi_pwsh(&["venv", "delete", "msgraph"], temp_dir.path());
+    assert!(
+        delete_output.status.success(),
+        "expected venv delete to succeed: {}",
+        String::from_utf8_lossy(&delete_output.stderr)
+    );
+    assert!(
+        !expected_venv.exists(),
+        "expected venv dir to be removed at {}",
+        expected_venv.display()
+    );
+
+    let list_after_delete = run_multi_pwsh(&["venv", "list"], temp_dir.path());
+    assert!(
+        list_after_delete.status.success(),
+        "expected venv list after delete to succeed: {}",
+        String::from_utf8_lossy(&list_after_delete.stderr)
+    );
+
+    let stdout_after_delete = String::from_utf8_lossy(&list_after_delete.stdout);
+    assert!(
+        stdout_after_delete.contains("Virtual environments: (none)"),
+        "unexpected stdout after delete: {}",
+        stdout_after_delete
+    );
+}
+
+#[test]
+fn venv_delete_reports_missing_name() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let output = run_multi_pwsh(&["venv", "delete", "missing"], temp_dir.path());
+
+    assert!(
+        !output.status.success(),
+        "expected venv delete to fail for missing name"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("virtual environment 'missing' was not found"),
+        "unexpected stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn venv_export_and_import_round_trip_module_contents() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let create_output = run_multi_pwsh(&["venv", "create", "roundtrip"], temp_dir.path());
+    assert!(
+        create_output.status.success(),
+        "expected venv create to succeed: {}",
+        normalize_output(&create_output.stderr)
+    );
+
+    let original_venv = temp_dir.path().join("venv").join("roundtrip");
+    let module_dir = original_venv.join("RoundTripModule");
+    std::fs::create_dir_all(&module_dir).expect("failed to create test module dir");
+    std::fs::write(
+        module_dir.join("RoundTripModule.psm1"),
+        "function Get-RoundTripValue { 'roundtrip-ok' }\n",
+    )
+    .expect("failed to write test module");
+    std::fs::write(module_dir.join("data.txt"), "roundtrip-data").expect("failed to write test data");
+
+    let archive_path = temp_dir.path().join("roundtrip.zip");
+    let archive_text = archive_path.display().to_string();
+
+    let export_output = run_multi_pwsh(&["venv", "export", "roundtrip", &archive_text], temp_dir.path());
+    assert!(
+        export_output.status.success(),
+        "expected venv export to succeed: {}",
+        normalize_output(&export_output.stderr)
+    );
+    assert!(archive_path.is_file(), "expected archive at {}", archive_path.display());
+
+    let delete_output = run_multi_pwsh(&["venv", "delete", "roundtrip"], temp_dir.path());
+    assert!(
+        delete_output.status.success(),
+        "expected venv delete after export to succeed: {}",
+        normalize_output(&delete_output.stderr)
+    );
+
+    let import_output = run_multi_pwsh(&["venv", "import", "roundtrip-copy", &archive_text], temp_dir.path());
+    assert!(
+        import_output.status.success(),
+        "expected venv import to succeed: {}",
+        normalize_output(&import_output.stderr)
+    );
+
+    let imported_venv = temp_dir.path().join("venv").join("roundtrip-copy");
+    let imported_data = imported_venv.join("RoundTripModule").join("data.txt");
+    assert!(
+        imported_data.is_file(),
+        "expected imported data at {}",
+        imported_data.display()
+    );
+    assert_eq!(
+        std::fs::read_to_string(&imported_data).expect("failed to read imported data"),
+        "roundtrip-data"
+    );
+
+    let (version, pwsh_install_dir) = discover_pwsh_install();
+    let managed_version_dir = temp_dir.path().join("multi").join(&version);
+    std::fs::create_dir_all(managed_version_dir.parent().expect("missing version dir parent"))
+        .expect("failed to create managed multi dir");
+    link_directory(&managed_version_dir, &pwsh_install_dir);
+
+    let module_bases = query_single_module_bases(temp_dir.path(), &version, "roundtrip-copy", "RoundTripModule");
+    assert!(
+        output_contains_module_base_under(&module_bases, &imported_venv),
+        "expected imported module to be discoverable from imported venv, got {:?}",
+        module_bases
+    );
+}
+
+#[test]
+fn venv_import_rejects_existing_destination() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let source_output = run_multi_pwsh(&["venv", "create", "source"], temp_dir.path());
+    assert!(
+        source_output.status.success(),
+        "expected source venv create to succeed: {}",
+        normalize_output(&source_output.stderr)
+    );
+
+    let archive_path = temp_dir.path().join("source.zip");
+    let archive_text = archive_path.display().to_string();
+    let export_output = run_multi_pwsh(&["venv", "export", "source", &archive_text], temp_dir.path());
+    assert!(
+        export_output.status.success(),
+        "expected source export to succeed: {}",
+        normalize_output(&export_output.stderr)
+    );
+
+    let existing_output = run_multi_pwsh(&["venv", "create", "existing"], temp_dir.path());
+    assert!(
+        existing_output.status.success(),
+        "expected destination venv create to succeed: {}",
+        normalize_output(&existing_output.stderr)
+    );
+
+    let import_output = run_multi_pwsh(&["venv", "import", "existing", &archive_text], temp_dir.path());
+    assert!(
+        !import_output.status.success(),
+        "expected import into existing venv to fail"
+    );
+
+    let stderr = String::from_utf8_lossy(&import_output.stderr);
+    assert!(stderr.contains("already exists"), "unexpected stderr: {}", stderr);
+}
+
+#[test]
+fn host_reports_missing_virtual_environment_before_launching_pwsh() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let fake_pwsh_dir = temp_dir.path().join("multi").join("7.4.13");
+    std::fs::create_dir_all(&fake_pwsh_dir).expect("failed to create fake pwsh dir");
+    std::fs::write(fake_pwsh_dir.join(pwsh_executable_name()), b"").expect("failed to create fake pwsh exe");
+
+    let output = run_multi_pwsh(&["host", "7.4.13", "-venv", "missing", "-NoProfile"], temp_dir.path());
+
+    assert!(!output.status.success(), "expected host command to fail");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("virtual environment 'missing' was not found"),
+        "unexpected stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn host_venv_isolates_psgallery_modules() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let (version, pwsh_install_dir) = discover_pwsh_install();
+
+    let managed_version_dir = temp_dir.path().join("multi").join(&version);
+    std::fs::create_dir_all(managed_version_dir.parent().expect("missing version dir parent"))
+        .expect("failed to create managed multi dir");
+    link_directory(&managed_version_dir, &pwsh_install_dir);
+
+    for venv_name in ["yaml", "toml"] {
+        let output = run_multi_pwsh(&["venv", "create", venv_name], temp_dir.path());
+        assert!(
+            output.status.success(),
+            "failed to create venv {}: {}",
+            venv_name,
+            normalize_output(&output.stderr)
+        );
+    }
+
+    let yaml_root = temp_dir.path().join("venv").join("yaml");
+    let toml_root = temp_dir.path().join("venv").join("toml");
+
+    save_gallery_module("Yayaml", &yaml_root);
+    save_gallery_module("PSToml", &toml_root);
+
+    let yaml_result = query_module_bases(temp_dir.path(), &version, "yaml");
+    let yaml_bases = json_strings(&yaml_result, "Yayaml");
+    let toml_bases_from_yaml = json_strings(&yaml_result, "PSToml");
+
+    assert!(
+        output_contains_module_base_under(&yaml_bases, &yaml_root),
+        "expected Yayaml to be discovered from yaml venv, got {:?}",
+        yaml_bases
+    );
+    assert!(
+        !output_contains_module_base_under(&toml_bases_from_yaml, &toml_root),
+        "did not expect PSToml from toml venv to leak into yaml venv, got {:?}",
+        toml_bases_from_yaml
+    );
+
+    let toml_result = query_module_bases(temp_dir.path(), &version, "toml");
+    let toml_bases = json_strings(&toml_result, "PSToml");
+    let yaml_bases_from_toml = json_strings(&toml_result, "Yayaml");
+
+    assert!(
+        output_contains_module_base_under(&toml_bases, &toml_root),
+        "expected PSToml to be discovered from toml venv, got {:?}",
+        toml_bases
+    );
+    assert!(
+        !output_contains_module_base_under(&yaml_bases_from_toml, &yaml_root),
+        "did not expect Yayaml from yaml venv to leak into toml venv, got {:?}",
+        yaml_bases_from_toml
     );
 }

--- a/crates/multi-pwsh/tests/cli_args.rs
+++ b/crates/multi-pwsh/tests/cli_args.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use serde_json::Value;
@@ -186,34 +186,18 @@ fn json_strings(value: &Value, key: &str) -> Vec<String> {
 }
 
 fn normalize_path_for_compare(path: &Path) -> String {
-    let mut normalized = String::new();
+    normalize_path_text(&path.to_string_lossy())
+}
 
-    for component in path.components() {
-        match component {
-            Component::Prefix(prefix) => {
-                normalized.push_str(
-                    &prefix
-                        .as_os_str()
-                        .to_string_lossy()
-                        .replace('/', "\\")
-                        .to_ascii_lowercase(),
-                );
-            }
-            Component::RootDir => normalized.push('\\'),
-            Component::Normal(part) => {
-                if !normalized.is_empty() && !normalized.ends_with('\\') {
-                    normalized.push('\\');
-                }
-                normalized.push_str(&part.to_string_lossy().to_ascii_lowercase());
-            }
-            Component::CurDir => {}
-            Component::ParentDir => {
-                if !normalized.is_empty() && !normalized.ends_with('\\') {
-                    normalized.push('\\');
-                }
-                normalized.push_str("..");
-            }
-        }
+fn normalize_path_text(path: &str) -> String {
+    let mut normalized = path.replace('/', "\\").to_ascii_lowercase();
+
+    if let Some(stripped) = normalized.strip_prefix("\\\\?\\unc\\") {
+        normalized = format!("\\\\{}", stripped);
+    } else if let Some(stripped) = normalized.strip_prefix("\\\\?\\") {
+        normalized = stripped.to_string();
+    } else if let Some(stripped) = normalized.strip_prefix("\\\\.\\") {
+        normalized = stripped.to_string();
     }
 
     normalized

--- a/tools/install-multi-pwsh.ps1
+++ b/tools/install-multi-pwsh.ps1
@@ -7,7 +7,7 @@ param(
     [string]$Owner = 'Devolutions',
 
     [Parameter(Mandatory = $false)]
-    [string]$Repository = 'pwsh-host-rs'
+    [string]$Repository = 'multi-pwsh'
 )
 
 $ErrorActionPreference = 'Stop'

--- a/tools/install-multi-pwsh.sh
+++ b/tools/install-multi-pwsh.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 repo_owner="Devolutions"
-repo_name="pwsh-host-rs"
+repo_name="multi-pwsh"
 
 version="${1:-latest}"
 install_home="${MULTI_PWSH_HOME:-${HOME}/.pwsh}"


### PR DESCRIPTION
## Summary
- add multi-pwsh virtual environment management commands for creating, listing, deleting, exporting, and importing named module environments
- allow `multi-pwsh host` to consume `-VirtualEnvironment` and `-venv`, validate the selected environment, and temporarily set `PSModulePath` before handing control to `pwsh`
- add `MULTI_PWSH_VENV_DIR`, expand CLI and integration coverage, refresh the README for the renamed `Devolutions/multi-pwsh` repository, and disable PowerShell update checks in host launches

## Verification
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets` (existing `result_large_err` warnings only)
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build dotnet/Bindings.csproj`
- `dotnet test dotnet/Bindings.csproj --no-build -v minimal`