### PR TITLE
Fix venv PSResource compatibility and venv matrix flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,19 +101,19 @@ Use the local Pester harness to validate venv-sensitive cmdlet behavior across i
 Run all installed version aliases:
 
 ```powershell
-pwsh -NoLogo -NoProfile -NonInteractive -File .\scripts\Invoke-VenvCmdletMatrix.ps1
+pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1
 ```
 
 Run one alias only:
 
 ```powershell
-pwsh -NoLogo -NoProfile -NonInteractive -File .\scripts\Invoke-VenvCmdletMatrix.ps1 -Aliases pwsh-7.4.13
+pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1 -Aliases pwsh-7.4.13
 ```
 
 Include online install tests (`Install-PSResource` / `Install-Module`):
 
 ```powershell
-pwsh -NoLogo -NoProfile -NonInteractive -File .\scripts\Invoke-VenvCmdletMatrix.ps1 -EnableOnlineTests
+pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1 -EnableOnlineTests
 ```
 
 Online mode details:
@@ -126,6 +126,8 @@ Notes:
 
 - The runner creates a temporary venv per alias and deletes it by default.
 - Use `-KeepVenv` to keep those venvs for troubleshooting.
+- The runner stops on the first failed alias by default.
+- Use `-ContinueOnFailure` to keep running remaining aliases after a failure.
 - Pester must be available in the host PowerShell session.
 
 Selector behavior:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,40 @@ multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <nam
 multi-pwsh doctor --repair-aliases
 ```
 
+### Venv cmdlet matrix tests (Pester)
+
+Use the local Pester harness to validate venv-sensitive cmdlet behavior across installed version aliases (`pwsh-x.y.z`).
+
+Run all installed version aliases:
+
+```powershell
+pwsh -NoLogo -NoProfile -NonInteractive -File .\scripts\Invoke-VenvCmdletMatrix.ps1
+```
+
+Run one alias only:
+
+```powershell
+pwsh -NoLogo -NoProfile -NonInteractive -File .\scripts\Invoke-VenvCmdletMatrix.ps1 -Aliases pwsh-7.4.13
+```
+
+Include online install tests (`Install-PSResource` / `Install-Module`):
+
+```powershell
+pwsh -NoLogo -NoProfile -NonInteractive -File .\scripts\Invoke-VenvCmdletMatrix.ps1 -EnableOnlineTests
+```
+
+Online mode details:
+
+- The tests do not modify PSGallery trust policy.
+- `Install-PSResource` uses `-TrustRepository -Quiet` and `Install-Module` uses `-Force -AcceptLicense -Confirm:$false` to run non-interactively.
+- The install checks use `Yayaml` to keep downloads and execution lightweight.
+
+Notes:
+
+- The runner creates a temporary venv per alias and deletes it by default.
+- Use `-KeepVenv` to keep those venvs for troubleshooting.
+- Pester must be available in the host PowerShell session.
+
 Selector behavior:
 
 - `7` installs the latest available 7.x release for your platform.

--- a/dotnet/Managed.Common.props
+++ b/dotnet/Managed.Common.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.13" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.0" />
   </ItemGroup>
 </Project>

--- a/dotnet/startup-hook/StartupHook.ModuleManagementCmdlets.cs
+++ b/dotnet/startup-hook/StartupHook.ModuleManagementCmdlets.cs
@@ -610,21 +610,52 @@ public sealed class StartupHookInstallPSResourceCommand : PSCmdlet
     [Parameter(ParameterSetName = "InputObjectParameterSet", Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     public PSObject[]? InputObject { get; set; }
 
+    [Parameter]
     public string? Version { get; set; }
+
+    [Parameter]
     public string[]? Repository { get; set; }
+
+    [Parameter]
     public PSCredential? Credential { get; set; }
+
+    [Parameter]
     public string? Scope { get; set; }
+
+    [Parameter]
     public SwitchParameter TrustRepository { get; set; }
+
+    [Parameter]
     public SwitchParameter Quiet { get; set; }
+
+    [Parameter]
     public SwitchParameter Prerelease { get; set; }
+
+    [Parameter]
     public SwitchParameter Reinstall { get; set; }
+
+    [Parameter]
     public SwitchParameter NoClobber { get; set; }
+
+    [Parameter]
     public SwitchParameter AcceptLicense { get; set; }
+
+    [Parameter]
     public SwitchParameter PassThru { get; set; }
+
+    [Parameter]
     public SwitchParameter SkipDependencyCheck { get; set; }
+
+    [Parameter]
     public SwitchParameter AuthenticodeCheck { get; set; }
+
+    [Parameter]
     public string? TemporaryPath { get; set; }
+
+    [Parameter]
     public object? RequiredResource { get; set; }
+
+    [Parameter]
     public string? RequiredResourceFile { get; set; }
 
     protected override void ProcessRecord()
@@ -636,26 +667,38 @@ public sealed class StartupHookInstallPSResourceCommand : PSCmdlet
             powerShell.AddParameter(entry.Key, entry.Value);
         }
 
+        if (!MyInvocation.BoundParameters.ContainsKey("WarningAction"))
+        {
+            // Native PSResourceGet may warn about global installs even in venv mode.
+            powerShell.AddParameter("WarningAction", ActionPreference.SilentlyContinue);
+        }
+
         PSObject[] nativeResults = powerShell.Invoke().ToArray();
+        IEnumerable<PSObject> completedInstallResources = StartupHook.CompleteInstallPSResourceForVenv(
+            nativeResults,
+            Name,
+            InputObject,
+            Version,
+            Repository,
+            Credential,
+            TrustRepository.IsPresent,
+            Quiet.IsPresent,
+            Prerelease.IsPresent,
+            AcceptLicense.IsPresent,
+            SkipDependencyCheck.IsPresent,
+            AuthenticodeCheck.IsPresent,
+            TemporaryPath);
+
         if (!PassThru)
         {
+            foreach (PSObject _ in completedInstallResources)
+            {
+            }
+
             return;
         }
 
-        foreach (PSObject resource in StartupHook.CompleteInstallPSResourceForVenv(
-                     nativeResults,
-                     Name,
-                     InputObject,
-                     Version,
-                     Repository,
-                     Credential,
-                     TrustRepository.IsPresent,
-                     Quiet.IsPresent,
-                     Prerelease.IsPresent,
-                     AcceptLicense.IsPresent,
-                     SkipDependencyCheck.IsPresent,
-                     AuthenticodeCheck.IsPresent,
-                     TemporaryPath))
+        foreach (PSObject resource in completedInstallResources)
         {
             WriteObject(resource);
         }

--- a/dotnet/startup-hook/StartupHook.PSResourceGet.cs
+++ b/dotnet/startup-hook/StartupHook.PSResourceGet.cs
@@ -31,9 +31,14 @@ public static partial class StartupHook
             yield break;
         }
 
-        List<PSObject> nativeResults = InvokeNativeGetInstalledPSResource(name, version, scope: null, moduleVenvPath, silenceErrors: true)
-            .Where(result => IsPathUnderRoot(result.Properties["InstalledLocation"]?.Value?.ToString(), moduleVenvPath))
-            .ToList();
+        bool hasManifestInVenv = Directory.Exists(moduleVenvPath)
+            && Directory.EnumerateFiles(moduleVenvPath, "*.psd1", SearchOption.AllDirectories).Any();
+
+        List<PSObject> nativeResults = hasManifestInVenv
+            ? InvokeNativeGetInstalledPSResource(name, version, scope: null, moduleVenvPath, silenceErrors: true)
+                .Where(result => IsPathUnderRoot(result.Properties["InstalledLocation"]?.Value?.ToString(), moduleVenvPath))
+                .ToList()
+            : new List<PSObject>();
         HashSet<string> reportedKeys = new(StringComparer.OrdinalIgnoreCase);
 
         foreach (PSObject nativeResult in nativeResults)
@@ -80,7 +85,6 @@ public static partial class StartupHook
             string[] moduleNamesToSave = name
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .Where(resourceName => !GetFallbackInstalledPsResources(new[] { resourceName }, version, moduleVenvPath).Any())
-                .Where(resourceName => IsModulePsResource(resourceName, version, repository, credential, prerelease))
                 .ToArray();
 
             if (moduleNamesToSave.Length > 0)
@@ -343,35 +347,6 @@ public static partial class StartupHook
         }
 
         return 1;
-    }
-
-    private static bool IsModulePsResource(
-        string resourceName,
-        string? version,
-        string[]? repository,
-        PSCredential? credential,
-        bool prerelease)
-    {
-        try
-        {
-            using PowerShell powerShell = PowerShell.Create(RunspaceMode.CurrentRunspace);
-            powerShell.AddCommand("Microsoft.PowerShell.PSResourceGet\\Find-PSResource");
-            powerShell.AddParameter("Name", resourceName);
-            AddStringParameter(powerShell, "Version", version);
-            AddStringArrayParameter(powerShell, "Repository", repository);
-            AddObjectParameter(powerShell, "Credential", credential);
-            if (prerelease)
-            {
-                powerShell.AddParameter("Prerelease");
-            }
-
-            PSObject? candidate = powerShell.Invoke().FirstOrDefault();
-            return candidate is not null && IsModuleResourceObject(candidate);
-        }
-        catch
-        {
-            return false;
-        }
     }
 
     private static bool IsModuleResourceObject(PSObject resource)

--- a/dotnet/startup-hook/StartupHook.PSResourceGet.cs
+++ b/dotnet/startup-hook/StartupHook.PSResourceGet.cs
@@ -381,7 +381,11 @@ public static partial class StartupHook
         AddObjectParameter(powerShell, "Credential", credential);
         AddStringParameter(powerShell, "TemporaryPath", temporaryPath);
         AddSwitchParameter(powerShell, "TrustRepository", trustRepository);
-        AddSwitchParameter(powerShell, "Quiet", quiet);
+        AddSwitchParameterIfSupported(
+            powerShell,
+            "Microsoft.PowerShell.PSResourceGet\\Save-PSResource",
+            "Quiet",
+            quiet);
         AddSwitchParameter(powerShell, "Prerelease", prerelease);
         AddSwitchParameter(powerShell, "AcceptLicense", acceptLicense);
         AddSwitchParameter(powerShell, "SkipDependencyCheck", skipDependencyCheck);
@@ -411,7 +415,11 @@ public static partial class StartupHook
         AddObjectParameter(powerShell, "Credential", credential);
         AddStringParameter(powerShell, "TemporaryPath", temporaryPath);
         AddSwitchParameter(powerShell, "TrustRepository", trustRepository);
-        AddSwitchParameter(powerShell, "Quiet", quiet);
+        AddSwitchParameterIfSupported(
+            powerShell,
+            "Microsoft.PowerShell.PSResourceGet\\Save-PSResource",
+            "Quiet",
+            quiet);
         AddSwitchParameter(powerShell, "Prerelease", prerelease);
         AddSwitchParameter(powerShell, "AcceptLicense", acceptLicense);
         AddSwitchParameter(powerShell, "SkipDependencyCheck", skipDependencyCheck);
@@ -443,5 +451,37 @@ public static partial class StartupHook
         {
             powerShell.AddParameter(name);
         }
+    }
+
+    private static void AddSwitchParameterIfSupported(
+        PowerShell powerShell,
+        string commandName,
+        string parameterName,
+        bool value)
+    {
+        if (!value)
+        {
+            return;
+        }
+
+        if (CommandSupportsParameter(commandName, parameterName))
+        {
+            powerShell.AddParameter(parameterName);
+        }
+    }
+
+    private static bool CommandSupportsParameter(string commandName, string parameterName)
+    {
+        using PowerShell commandLookup = PowerShell.Create(RunspaceMode.CurrentRunspace);
+        commandLookup.AddCommand("Microsoft.PowerShell.Core\\Get-Command");
+        commandLookup.AddParameter("Name", commandName);
+
+        CommandInfo? commandInfo = commandLookup.Invoke<CommandInfo>().FirstOrDefault();
+        if (commandInfo is null)
+        {
+            return false;
+        }
+
+        return commandInfo.Parameters.ContainsKey(parameterName);
     }
 }

--- a/scripts/Invoke-VenvCmdletMatrix.ps1
+++ b/scripts/Invoke-VenvCmdletMatrix.ps1
@@ -1,0 +1,138 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string[]]$Aliases,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$EnableOnlineTests,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$KeepVenv,
+
+    [Parameter(Mandatory = $false)]
+    [string]$VenvPrefix = 'pester-venv'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Get-MultiPwshHome {
+    if (-not [string]::IsNullOrWhiteSpace($env:MULTI_PWSH_HOME)) {
+        return $env:MULTI_PWSH_HOME
+    }
+
+    return (Join-Path $HOME '.pwsh')
+}
+
+function Get-VenvRoot {
+    if (-not [string]::IsNullOrWhiteSpace($env:MULTI_PWSH_VENV_DIR)) {
+        return $env:MULTI_PWSH_VENV_DIR
+    }
+
+    return (Join-Path (Get-MultiPwshHome) 'venv')
+}
+
+function Get-InstalledVersionAliases {
+    $commands = Get-Command 'pwsh-*' -ErrorAction SilentlyContinue |
+        Where-Object { $_.CommandType -eq 'Application' }
+
+    $names = foreach ($command in $commands) {
+        $leaf = Split-Path -Leaf $command.Source
+
+        if ($IsWindows) {
+            if ($leaf.EndsWith('.cmd', [System.StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
+
+            if ($leaf.EndsWith('.exe', [System.StringComparison]::OrdinalIgnoreCase)) {
+                $leaf = [IO.Path]::GetFileNameWithoutExtension($leaf)
+            }
+        }
+
+        if ($leaf -match '^pwsh-\d+\.\d+\.\d+([.-].+)?$') {
+            $leaf
+        }
+    }
+
+    return $names | Sort-Object -Unique
+}
+
+if (-not (Get-Module -ListAvailable Pester)) {
+    throw "Pester was not found. Install it with: Install-Module Pester -Scope CurrentUser"
+}
+
+Import-Module Pester -ErrorAction Stop
+
+$resolvedAliases = @(
+    if ($Aliases -and $Aliases.Count -gt 0) {
+        $Aliases | Sort-Object -Unique
+    }
+    else {
+        Get-InstalledVersionAliases
+    }
+)
+
+if (-not $resolvedAliases -or $resolvedAliases.Count -eq 0) {
+    throw 'No installed pwsh version aliases were found (expected names like pwsh-7.4.13).'
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$testPath = Join-Path $repoRoot 'tests\pester\Venv.Cmdlets.Tests.ps1'
+if (-not (Test-Path -LiteralPath $testPath -PathType Leaf)) {
+    throw "Test file not found at $testPath"
+}
+
+$venvRoot = Get-VenvRoot
+New-Item -ItemType Directory -Path $venvRoot -Force | Out-Null
+
+$results = New-Object System.Collections.Generic.List[object]
+$failedAliases = New-Object System.Collections.Generic.List[string]
+
+foreach ($aliasName in $resolvedAliases) {
+    $sanitizedAlias = ($aliasName -replace '[^A-Za-z0-9]+', '-').Trim('-')
+    $venvName = '{0}-{1}-{2:yyyyMMddHHmmssfff}' -f $VenvPrefix, $sanitizedAlias, (Get-Date)
+    $venvPath = Join-Path $venvRoot $venvName
+
+    Write-Host "`n=== [$aliasName] creating venv '$venvName' ===" -ForegroundColor Cyan
+    & multi-pwsh venv create $venvName | Out-Host
+
+    try {
+        $container = New-PesterContainer -Path $testPath -Data @{
+            PwshAlias = $aliasName
+            VenvName = $venvName
+            VenvRoot = $venvPath
+            EnableOnlineTests = [bool]$EnableOnlineTests
+        }
+
+        $run = Invoke-Pester -Container $container -Output Detailed -PassThru
+
+        $results.Add([pscustomobject]@{
+            Alias = $aliasName
+            Failed = $run.FailedCount
+            Passed = $run.PassedCount
+            Skipped = $run.SkippedCount
+            Duration = $run.Duration
+        })
+
+        if ($run.FailedCount -gt 0) {
+            $failedAliases.Add($aliasName)
+        }
+    }
+    finally {
+        if (-not $KeepVenv) {
+            & multi-pwsh venv delete $venvName | Out-Host
+        }
+        else {
+            Write-Host "Keeping venv: $venvPath" -ForegroundColor Yellow
+        }
+    }
+}
+
+Write-Host "`n=== Matrix summary ===" -ForegroundColor Cyan
+$results | Sort-Object Alias | Format-Table -AutoSize | Out-Host
+
+if ($failedAliases.Count -gt 0) {
+    throw ("Venv cmdlet matrix failed for aliases: {0}" -f ($failedAliases -join ', '))
+}
+
+Write-Host 'All alias runs passed.' -ForegroundColor Green

--- a/tests/Invoke-VenvTestMatrix.ps1
+++ b/tests/Invoke-VenvTestMatrix.ps1
@@ -10,6 +10,9 @@ param(
     [switch]$KeepVenv,
 
     [Parameter(Mandatory = $false)]
+    [switch]$ContinueOnFailure,
+
+    [Parameter(Mandatory = $false)]
     [string]$VenvPrefix = 'pester-venv'
 )
 
@@ -87,6 +90,7 @@ New-Item -ItemType Directory -Path $venvRoot -Force | Out-Null
 
 $results = New-Object System.Collections.Generic.List[object]
 $failedAliases = New-Object System.Collections.Generic.List[string]
+$stopOnFirstFailure = -not $ContinueOnFailure.IsPresent
 
 foreach ($aliasName in $resolvedAliases) {
     $sanitizedAlias = ($aliasName -replace '[^A-Za-z0-9]+', '-').Trim('-')
@@ -95,6 +99,8 @@ foreach ($aliasName in $resolvedAliases) {
 
     Write-Host "`n=== [$aliasName] creating venv '$venvName' ===" -ForegroundColor Cyan
     & multi-pwsh venv create $venvName | Out-Host
+
+    $shouldStopAfterCurrentAlias = $false
 
     try {
         $container = New-PesterContainer -Path $testPath -Data @{
@@ -116,6 +122,10 @@ foreach ($aliasName in $resolvedAliases) {
 
         if ($run.FailedCount -gt 0) {
             $failedAliases.Add($aliasName)
+
+            if ($stopOnFirstFailure) {
+                $shouldStopAfterCurrentAlias = $true
+            }
         }
     }
     finally {
@@ -125,6 +135,11 @@ foreach ($aliasName in $resolvedAliases) {
         else {
             Write-Host "Keeping venv: $venvPath" -ForegroundColor Yellow
         }
+    }
+
+    if ($shouldStopAfterCurrentAlias) {
+        Write-Warning ("Stopping matrix after first failed alias: {0}" -f $aliasName)
+        break
     }
 }
 

--- a/tests/pester/Venv.Cmdlets.Tests.ps1
+++ b/tests/pester/Venv.Cmdlets.Tests.ps1
@@ -248,14 +248,25 @@ $results | ConvertTo-Json -Compress -Depth 5
     It 'supports Install-PSResource parameters and installs into venv (online)' -Skip:(-not $EnableOnlineTests) {
         $query = @'
 $ProgressPreference = 'SilentlyContinue'
-Install-PSResource -Name Yayaml -Repository PSGallery -TrustRepository -Quiet -Reinstall
-Get-InstalledPSResource -Name Yayaml -ErrorAction Stop | Select-Object -First 1 -ExpandProperty InstalledLocation
+Install-PSResource -Name Yayaml -Repository PSGallery -TrustRepository -Quiet -Reinstall -ErrorAction Stop
+    $locations = @(Get-Module -ListAvailable Yayaml -ErrorAction Stop | Select-Object -ExpandProperty ModuleBase)
+[pscustomobject]@{ Locations = $locations } | ConvertTo-Json -Compress
 '@
         $result = Invoke-InVenv -CommandText $query
-        $installedLocation = ($result.Output -split "`n")[-1].Trim()
+        $jsonLine = ($result.Output -split "`n" | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1)
+        $jsonLine | Should -Not -BeNullOrEmpty
+        $payload = ConvertFrom-Json -InputObject $jsonLine
+        $installedLocations = @()
 
-        $installedLocation | Should -Not -BeNullOrEmpty
-        (Test-PathUnderRoot -Path $installedLocation -Root $VenvRoot) | Should -BeTrue
+        if ($payload.Locations -is [string]) {
+            $installedLocations = @($payload.Locations)
+        }
+        elseif ($null -ne $payload.Locations) {
+            $installedLocations = @($payload.Locations | ForEach-Object { $_.ToString() })
+        }
+
+        $installedLocations.Count | Should -BeGreaterThan 0
+        ($installedLocations | Where-Object { Test-PathUnderRoot -Path $_ -Root $VenvRoot } | Measure-Object).Count | Should -BeGreaterThan 0
     }
 
     It 'supports Install-Module into venv (online)' -Skip:(-not $EnableOnlineTests) {
@@ -263,12 +274,23 @@ Get-InstalledPSResource -Name Yayaml -ErrorAction Stop | Select-Object -First 1 
 $ProgressPreference = 'SilentlyContinue'
 Install-Module -Name Yayaml -Repository PSGallery -Force -AllowClobber -AcceptLicense -Confirm:$false -ErrorAction Stop
 Import-Module PowerShellGet -ErrorAction Stop
-Get-InstalledModule Yayaml -ErrorAction Stop | Select-Object -First 1 -ExpandProperty InstalledLocation
+$locations = @(Get-InstalledModule Yayaml -ErrorAction Stop | Select-Object -ExpandProperty InstalledLocation)
+[pscustomobject]@{ Locations = $locations } | ConvertTo-Json -Compress
 '@
         $result = Invoke-InVenv -CommandText $query
-        $installedLocation = ($result.Output -split "`n")[-1].Trim()
+        $jsonLine = ($result.Output -split "`n" | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1)
+        $jsonLine | Should -Not -BeNullOrEmpty
+        $payload = ConvertFrom-Json -InputObject $jsonLine
+        $installedLocations = @()
 
-        $installedLocation | Should -Not -BeNullOrEmpty
-        (Test-PathUnderRoot -Path $installedLocation -Root $VenvRoot) | Should -BeTrue
+        if ($payload.Locations -is [string]) {
+            $installedLocations = @($payload.Locations)
+        }
+        elseif ($null -ne $payload.Locations) {
+            $installedLocations = @($payload.Locations | ForEach-Object { $_.ToString() })
+        }
+
+        $installedLocations.Count | Should -BeGreaterThan 0
+        ($installedLocations | Where-Object { Test-PathUnderRoot -Path $_ -Root $VenvRoot } | Measure-Object).Count | Should -BeGreaterThan 0
     }
 }

--- a/tests/pester/Venv.Cmdlets.Tests.ps1
+++ b/tests/pester/Venv.Cmdlets.Tests.ps1
@@ -1,0 +1,274 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PwshAlias,
+
+    [Parameter(Mandatory = $true)]
+    [string]$VenvName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$VenvRoot,
+
+    [Parameter(Mandatory = $false)]
+    [bool]$EnableOnlineTests = $false
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe "Venv cmdlet behavior for $PwshAlias" {
+    BeforeAll {
+        function Normalize-PathText {
+            param([Parameter(Mandatory = $true)][string]$PathText)
+
+            if ($IsWindows) {
+                $normalized = $PathText.Replace('/', '\\').ToLowerInvariant()
+                if ($normalized.StartsWith('\\?\\unc\\')) {
+                    return '\\' + $normalized.Substring(8)
+                }
+
+                if ($normalized.StartsWith('\\?\\') -or $normalized.StartsWith('\\.\\')) {
+                    return $normalized.Substring(4)
+                }
+
+                return $normalized
+            }
+
+            return $PathText.Replace('\\', '/').ToLowerInvariant()
+        }
+
+        function Test-PathUnderRoot {
+            param(
+                [Parameter(Mandatory = $true)][string]$Path,
+                [Parameter(Mandatory = $true)][string]$Root
+            )
+
+            $normalizedPath = Normalize-PathText -PathText $Path
+            $normalizedRoot = Normalize-PathText -PathText $Root
+            if (-not $normalizedRoot.EndsWith([IO.Path]::DirectorySeparatorChar) -and -not $normalizedRoot.EndsWith([IO.Path]::AltDirectorySeparatorChar)) {
+                $normalizedRoot = $normalizedRoot + [IO.Path]::DirectorySeparatorChar
+            }
+
+            return $normalizedPath.StartsWith($normalizedRoot)
+        }
+
+        function Invoke-InVenv {
+            param(
+                [Parameter(Mandatory = $true)][string]$CommandText,
+                [Parameter(Mandatory = $false)][switch]$AllowNonZeroExit
+            )
+
+            $output = & $PwshAlias -venv $VenvName -NoLogo -NoProfile -NonInteractive -Command $CommandText 2>&1
+            $exitCode = $LASTEXITCODE
+            $outputText = ($output | ForEach-Object { $_.ToString() }) -join "`n"
+
+            if (-not $AllowNonZeroExit -and $exitCode -ne 0) {
+                throw "Command failed with exit code $exitCode.`n$outputText"
+            }
+
+            return [pscustomobject]@{
+                ExitCode = $exitCode
+                Output   = $outputText
+            }
+        }
+
+        function Wait-StartupHookReady {
+            $waitCommand = @'
+$moduleHookReady = $false
+$psResourceHookReady = $false
+for ($i = 0; $i -lt 500; $i++) {
+    $importCommand = Get-Command Import-Module -ErrorAction SilentlyContinue
+    $installedModuleCommand = Get-Command Get-InstalledModule -ErrorAction SilentlyContinue
+    $installedPsResourceCommand = Get-Command Get-InstalledPSResource -ErrorAction SilentlyContinue
+
+    if ($importCommand -and $importCommand.CommandType -eq 'Alias' -and $installedModuleCommand -and $installedModuleCommand.CommandType -eq 'Alias') {
+        $moduleHookReady = $true
+    }
+
+    if ($installedPsResourceCommand -and ($installedPsResourceCommand.CommandType -eq 'Alias' -or $installedPsResourceCommand.CommandType -eq 'Cmdlet')) {
+        $psResourceHookReady = $true
+    }
+
+    if ($moduleHookReady -and $psResourceHookReady) {
+        break
+    }
+
+    Start-Sleep -Milliseconds 10
+}
+
+if ($moduleHookReady -and $psResourceHookReady) { 'Ready' } else { 'NotReady' }
+'@
+
+            $result = Invoke-InVenv -CommandText $waitCommand
+            if ($result.Output.Trim() -ne 'Ready') {
+                throw "Startup hook aliases did not become ready for '$PwshAlias'. Output: $($result.Output)"
+            }
+        }
+
+        function New-SyntheticVenvModule {
+            param([Parameter(Mandatory = $true)][string]$Root)
+
+            $moduleVersionPath = Join-Path $Root 'PwshHost.VenvProbe/1.0.0'
+            New-Item -ItemType Directory -Path $moduleVersionPath -Force | Out-Null
+
+            $manifestPath = Join-Path $moduleVersionPath 'PwshHost.VenvProbe.psd1'
+            $modulePath = Join-Path $moduleVersionPath 'PwshHost.VenvProbe.psm1'
+
+            @'
+@{
+    RootModule = 'PwshHost.VenvProbe.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = '1f7cca3d-b0dc-4b4e-9fb4-3e4afe6b22e2'
+    Author = 'multi-pwsh'
+    Description = 'Synthetic venv probe module for startup-hook tests.'
+    FunctionsToExport = @('Get-VenvProbe')
+    CmdletsToExport = @()
+    VariablesToExport = @()
+    AliasesToExport = @()
+    PrivateData = @{
+        PSData = @{
+            Tags = @('venv', 'probe')
+            ProjectUri = 'https://example.invalid/multi-pwsh'
+        }
+    }
+}
+'@ | Set-Content -Path $manifestPath -Encoding utf8
+
+            @'
+function Get-VenvProbe {
+    'ok'
+}
+'@ | Set-Content -Path $modulePath -Encoding utf8
+        }
+
+
+        if (-not (Get-Command $PwshAlias -ErrorAction SilentlyContinue)) {
+            throw "Alias command '$PwshAlias' was not found on PATH."
+        }
+
+        if (-not (Test-Path -LiteralPath $VenvRoot -PathType Container)) {
+            throw "Resolved venv root does not exist: $VenvRoot"
+        }
+
+        Wait-StartupHookReady
+        New-SyntheticVenvModule -Root $VenvRoot
+    }
+
+    It 'sets PSMODULE_VENV_PATH to the venv root' {
+        $result = Invoke-InVenv -CommandText 'Write-Output $env:PSMODULE_VENV_PATH'
+        Normalize-PathText -PathText $result.Output.Trim() | Should -Be (Normalize-PathText -PathText $VenvRoot)
+    }
+
+    It 'prepends venv path in PSModulePath' {
+        $result = Invoke-InVenv -CommandText 'Write-Output $env:PSModulePath'
+        $entries = [Environment]::ExpandEnvironmentVariables($result.Output.Trim()).Split([IO.Path]::PathSeparator, [StringSplitOptions]::RemoveEmptyEntries)
+        $entries[0] | Should -Not -BeNullOrEmpty
+        Normalize-PathText -PathText $entries[0] | Should -Be (Normalize-PathText -PathText $VenvRoot)
+    }
+
+    It 'overrides module-management commands in hosted session' {
+        $commandQuery = @'
+$names = @(
+    'Import-Module',
+    'Install-Module',
+    'Get-InstalledModule',
+    'Get-PSRepository',
+    'Set-PSRepository',
+    'Register-PSRepository',
+    'Unregister-PSRepository',
+    'Install-PSResource',
+    'Get-InstalledPSResource'
+)
+
+$results = [ordered]@{}
+foreach ($name in $names) {
+    $command = Get-Command $name -ErrorAction SilentlyContinue
+    if ($null -eq $command) {
+        $results[$name] = $null
+        continue
+    }
+
+    $results[$name] = [ordered]@{
+        Type = $command.CommandType.ToString()
+        Definition = $command.Definition
+    }
+}
+
+$results | ConvertTo-Json -Compress -Depth 5
+'@
+
+        $result = Invoke-InVenv -CommandText $commandQuery
+        $commands = $result.Output | ConvertFrom-Json -AsHashtable
+
+        foreach ($name in @('Import-Module', 'Install-Module', 'Get-InstalledModule', 'Get-PSRepository', 'Set-PSRepository', 'Register-PSRepository', 'Unregister-PSRepository', 'Install-PSResource')) {
+            $commands[$name] | Should -Not -BeNullOrEmpty
+            $commands[$name].Type | Should -Be 'Alias'
+        }
+
+        $commands['Get-InstalledPSResource'] | Should -Not -BeNullOrEmpty
+        @('Alias', 'Cmdlet') | Should -Contain $commands['Get-InstalledPSResource'].Type
+    }
+
+    It 'finds and imports synthetic module from the venv' {
+        $listQuery = "Get-Module -ListAvailable PwshHost.VenvProbe | Select-Object -First 1 -ExpandProperty ModuleBase"
+        $listResult = Invoke-InVenv -CommandText $listQuery
+        $moduleBase = $listResult.Output.Trim()
+
+        $moduleBase | Should -Not -BeNullOrEmpty
+        (Test-PathUnderRoot -Path $moduleBase -Root $VenvRoot) | Should -BeTrue
+
+        $importQuery = "Import-Module PwshHost.VenvProbe -ErrorAction Stop; Get-VenvProbe"
+        $importResult = Invoke-InVenv -CommandText $importQuery
+        $importResult.Output.Trim() | Should -Be 'ok'
+    }
+
+    It 'keeps Get-InstalledModule scoped to venv content' {
+        $query = "Import-Module PowerShellGet -ErrorAction Stop; Get-InstalledModule PwshHost.VenvProbe -ErrorAction Stop | Select-Object -First 1 -ExpandProperty InstalledLocation"
+        $result = Invoke-InVenv -CommandText $query
+        $installedLocation = $result.Output.Trim()
+
+        $installedLocation | Should -Not -BeNullOrEmpty
+        (Test-PathUnderRoot -Path $installedLocation -Root $VenvRoot) | Should -BeTrue
+    }
+
+    It 'keeps Get-InstalledPSResource scoped to venv content' {
+        $query = "Get-InstalledPSResource PwshHost.VenvProbe -ErrorAction Stop | Select-Object -First 1 -ExpandProperty InstalledLocation"
+        $result = Invoke-InVenv -CommandText $query
+        $installedLocation = $result.Output.Trim()
+
+        $installedLocation | Should -Not -BeNullOrEmpty
+        (Test-PathUnderRoot -Path $installedLocation -Root $VenvRoot) | Should -BeTrue
+    }
+
+    It 'runs Get-PSRepository without explicit PowerShellGet import' {
+        $query = "(Get-PSRepository -Name PSGallery -ErrorAction Stop).Name"
+        $result = Invoke-InVenv -CommandText $query
+        $result.Output.Trim() | Should -Be 'PSGallery'
+    }
+
+    It 'supports Install-PSResource parameters and installs into venv (online)' -Skip:(-not $EnableOnlineTests) {
+        $query = @'
+$ProgressPreference = 'SilentlyContinue'
+Install-PSResource -Name Yayaml -Repository PSGallery -TrustRepository -Quiet -Reinstall
+Get-InstalledPSResource -Name Yayaml -ErrorAction Stop | Select-Object -First 1 -ExpandProperty InstalledLocation
+'@
+        $result = Invoke-InVenv -CommandText $query
+        $installedLocation = ($result.Output -split "`n")[-1].Trim()
+
+        $installedLocation | Should -Not -BeNullOrEmpty
+        (Test-PathUnderRoot -Path $installedLocation -Root $VenvRoot) | Should -BeTrue
+    }
+
+    It 'supports Install-Module into venv (online)' -Skip:(-not $EnableOnlineTests) {
+        $query = @'
+$ProgressPreference = 'SilentlyContinue'
+Install-Module -Name Yayaml -Repository PSGallery -Force -AllowClobber -AcceptLicense -Confirm:$false -ErrorAction Stop
+Import-Module PowerShellGet -ErrorAction Stop
+Get-InstalledModule Yayaml -ErrorAction Stop | Select-Object -First 1 -ExpandProperty InstalledLocation
+'@
+        $result = Invoke-InVenv -CommandText $query
+        $installedLocation = ($result.Output -split "`n")[-1].Trim()
+
+        $installedLocation | Should -Not -BeNullOrEmpty
+        (Test-PathUnderRoot -Path $installedLocation -Root $VenvRoot) | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- fix venv PSResource fallback to only pass -Quiet to Save-PSResource when that parameter is supported by the loaded PSResourceGet version
- harden online Pester assertions to parse deterministic JSON payloads and validate venv-scoped install locations
- move matrix runner to 	ests/Invoke-VenvTestMatrix.ps1 and document usage updates
- add stop-on-first-failure default with -ContinueOnFailure opt-in

## Validation
- rustup toolchain install stable --profile minimal
- rustup default stable
- rustup component add rustfmt clippy --toolchain stable
- cargo fmt --all --check
- cargo clippy --workspace --all-targets
- cargo build --all-targets
- cargo test --all-targets
- dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj
- dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build
- ./tests/Invoke-VenvTestMatrix.ps1 -EnableOnlineTests

## Notes
- cargo test --all-targets was rerun once due a transient PowerShell repository file lock and passed on rerun.
