### PR TITLE
Implement scoped archive installs across platforms

### DIFF
--- a/.github/workflows/scoped-install-smoke.yml
+++ b/.github/workflows/scoped-install-smoke.yml
@@ -1,0 +1,77 @@
+name: Smoke tests
+
+on:
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scoped-install-smoke:
+    name: Smoke tests (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: windows
+            os: windows-latest
+          - name: macos
+            os: macos-14
+          - name: linux
+            os: ubuntu-latest
+
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      MULTI_PWSH_CACHE_KEEP: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install Rust toolchain
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2.8.2
+
+      - name: Cache multi-pwsh downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/multi-pwsh-cache
+          key: multi-pwsh-scope-smoke-${{ runner.os }}-${{ hashFiles('crates/multi-pwsh/Cargo.toml', '.github/workflows/scoped-install-smoke.yml', 'tests/Invoke-ScopedInstallSmokeTest.ps1') }}
+          restore-keys: |
+            multi-pwsh-scope-smoke-${{ runner.os }}-
+
+      - name: Install multi-pwsh from source
+        shell: pwsh
+        run: |
+          cargo install --locked --path crates/multi-pwsh --force
+
+      - name: Add cargo bin to PATH
+        shell: pwsh
+        run: |
+          $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $HOME '.cargo' }
+          $cargoBin = Join-Path $cargoHome 'bin'
+          $cargoBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Run smoke tests
+        shell: pwsh
+        env:
+          MULTI_PWSH_CACHE_DIR: ${{ runner.temp }}/multi-pwsh-cache
+        run: ./tests/Invoke-ScopedInstallSmokeTest.ps1

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ runner.temp }}/multi-pwsh-cache
-          key: multi-pwsh-scope-smoke-${{ runner.os }}-${{ hashFiles('crates/multi-pwsh/Cargo.toml', '.github/workflows/scoped-install-smoke.yml', 'tests/Invoke-ScopedInstallSmokeTest.ps1') }}
+          key: multi-pwsh-scope-smoke-${{ runner.os }}-${{ hashFiles('crates/multi-pwsh/Cargo.toml', '.github/workflows/smoke-tests.yml', 'tests/Invoke-ScopedInstallSmokeTest.ps1') }}
           restore-keys: |
             multi-pwsh-scope-smoke-${{ runner.os }}-
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,57 @@ pwsh-7.4 --version
 pwsh-7.5 --version
 ```
 
+## Scoped installs
+
+`multi-pwsh install`, `update`, `uninstall`, and `list` now support `--scope <user|machine>` across Windows, macOS, and Linux.
+
+That means:
+
+- extracted versions stay side-by-side under the selected install root
+- aliases continue to live in one stable bin directory
+- PATH only needs one entry per scope
+- `user` is the default scope when `--scope` is omitted
+
+Platform behavior:
+
+- Windows uses the GitHub ZIP archives with MSI-like install roots and selected installer-style integrations that still make sense for archive installs.
+- macOS `machine` installs use the official `.tar.gz` archives under `/usr/local/microsoft/powershell` with aliases published to `/usr/local/bin`.
+- Linux `machine` installs use the official `.tar.gz` archives under `/opt/microsoft/powershell` with aliases published to `/usr/local/bin`.
+- Unix `machine` installs expect you to provide elevation yourself; `multi-pwsh` does not invoke `sudo`.
+
+Examples:
+
+```powershell
+multi-pwsh install 7.4
+multi-pwsh install 7.5 --scope machine --enable-psremoting --add-explorer-context-menu
+multi-pwsh install 7.5 --scope machine
+multi-pwsh list --scope all
+multi-pwsh uninstall 7.4.13 --scope machine
+```
+
+Windows scoped-install flags mirror the most useful MSI-style options:
+
+- `--add-path` / `--no-add-path`
+- `--register-manifest` / `--no-register-manifest`
+- `--enable-psremoting`
+- `--disable-telemetry`
+- `--add-explorer-context-menu`
+- `--add-file-context-menu`
+- `--scope <user|machine>`
+- `--root <path>`
+
+Microsoft Update registration is intentionally out of scope for archive installs at the moment, even on Windows.
+
+On macOS and Linux, scoped installs support:
+
+- `--scope <user|machine>`
+- `--root <path>`
+- `--arch <auto|x64|x86|arm64|arm32>`
+- `--include-prerelease`
+- `--add-path` / `--no-add-path`
+
+The Windows-only integration flags above currently return an error on macOS/Linux.
+
 ## Manage installed lines
 
 ```powershell
@@ -79,10 +130,10 @@ multi-pwsh doctor --repair-aliases
 `multi-pwsh` usage reference:
 
 ```text
-multi-pwsh install <version|major|major.minor|major.minor.x> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]
-multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]
-multi-pwsh uninstall <version> [--force]
-multi-pwsh list [--available] [--include-prerelease]
+multi-pwsh install <version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
+multi-pwsh update <major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
+multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]
+multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease]
 multi-pwsh venv create <name>
 multi-pwsh venv delete <name>
 multi-pwsh venv export <name> <archive.zip>
@@ -93,6 +144,8 @@ multi-pwsh alias unset <major.minor>
 multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]
 multi-pwsh doctor --repair-aliases
 ```
+
+The Windows integration flags in the `install` and `update` forms are limited to archive-friendly behaviors; on macOS/Linux, use `--scope`, `--root`, `--arch`, `--include-prerelease`, and `--add-path` controls. Legacy scope aliases such as `current-user` and `all-users` are still accepted for compatibility.
 
 ### Venv cmdlet matrix tests (Pester)
 
@@ -148,7 +201,7 @@ Native host mode:
 - `-VirtualEnvironment <name>` and `-venv <name>` are consumed by `multi-pwsh` before handing control to PowerShell and set `PSModulePath` to the selected venv root for that launch.
 - `PSMODULE_VENV_PATH` can also be used as an explicit path-based venv selector for hosted launches. If it is already set in the environment, `multi-pwsh host` treats it as an intentional venv opt-in.
 - Alias lifecycle now maintains native host shims as hard links to `multi-pwsh` automatically during install/update/doctor alias repair.
-- On Windows, host shims are `pwsh-*.exe` files alongside `.cmd` wrappers in `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`).
+- On Windows, alias command paths are `pwsh-*.exe` host shims in `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`).
 - On Linux/macOS, alias command paths (`pwsh-*`) are hard links to `multi-pwsh`.
 - `multi-pwsh doctor --repair-aliases` performs a shim health check and re-links broken hard links automatically.
 - You can still manually copy/rename `multi-pwsh.exe` under `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`) to an alias-like name (for example `pwsh-7.4.exe`); it automatically enters host mode and resolves the target installation from that alias name.

--- a/crates/multi-pwsh/src/aliases.rs
+++ b/crates/multi-pwsh/src/aliases.rs
@@ -13,6 +13,8 @@ use crate::layout::InstallLayout;
 use crate::platform::HostOs;
 use crate::versions::MajorMinor;
 
+const LAYOUT_HINT_FILE: &str = "multi-pwsh-layout.json";
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AliasSelector {
     Major(u64),
@@ -57,6 +59,8 @@ fn create_or_update_alias_with_selector(
     target: &Path,
 ) -> Result<PathBuf> {
     fs::create_dir_all(layout.bin_dir())?;
+    write_layout_hint(layout)?;
+    let _ = target;
 
     let alias_command = alias_command_name(&selector);
     let alias_file = alias_file_name(&selector, os);
@@ -64,10 +68,6 @@ fn create_or_update_alias_with_selector(
 
     match os {
         HostOs::Windows => {
-            if alias_path.exists() {
-                fs::remove_file(&alias_path)?;
-            }
-            create_windows_cmd_alias(target, &alias_path)?;
             create_or_update_windows_host_shim(layout, &alias_command)?;
         }
         HostOs::Linux | HostOs::Macos => {
@@ -82,6 +82,24 @@ fn create_or_update_alias_with_selector(
     Ok(alias_path)
 }
 
+pub fn read_layout_hint(bin_dir: &Path, os: HostOs) -> Result<Option<InstallLayout>> {
+    let path = layout_hint_path(bin_dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(path)?;
+    let hint: LayoutHint = serde_json::from_str(&content)?;
+    Ok(Some(InstallLayout::from_parts(
+        os,
+        PathBuf::from(hint.home),
+        PathBuf::from(hint.bin_dir),
+        PathBuf::from(hint.cache_dir),
+        PathBuf::from(hint.venvs_dir),
+        PathBuf::from(hint.versions_dir),
+    )?))
+}
+
 pub fn remove_alias(layout: &InstallLayout, os: HostOs, alias_command: &str) -> Result<bool> {
     let alias_path = layout.bin_dir().join(alias_file_name_from_command(alias_command, os));
     let mut removed = false;
@@ -92,9 +110,9 @@ pub fn remove_alias(layout: &InstallLayout, os: HostOs, alias_command: &str) -> 
     }
 
     if os == HostOs::Windows {
-        let host_shim_path = layout.bin_dir().join(format!("{}.exe", alias_command));
-        if host_shim_path.exists() {
-            fs::remove_file(host_shim_path)?;
+        let legacy_cmd_path = layout.bin_dir().join(format!("{}.cmd", alias_command));
+        if legacy_cmd_path.exists() {
+            fs::remove_file(legacy_cmd_path)?;
             removed = true;
         }
     }
@@ -224,7 +242,7 @@ fn alias_file_name(selector: &AliasSelector, os: HostOs) -> String {
 
 fn alias_file_name_from_command(alias_command: &str, os: HostOs) -> String {
     match os {
-        HostOs::Windows => format!("{}.cmd", alias_command),
+        HostOs::Windows => format!("{}.exe", alias_command),
         HostOs::Linux | HostOs::Macos => alias_command.to_string(),
     }
 }
@@ -235,26 +253,6 @@ fn alias_command_name(selector: &AliasSelector) -> String {
         AliasSelector::MajorMinor(line) => format!("pwsh-{}.{}", line.major, line.minor),
         AliasSelector::Exact(version) => format!("pwsh-{}", version),
     }
-}
-
-#[cfg(windows)]
-fn create_windows_cmd_alias(target: &Path, alias_path: &Path) -> Result<()> {
-    let target_string = target
-        .to_str()
-        .ok_or_else(|| MultiPwshError::AliasCreation("target path is not valid UTF-8".to_string()))?;
-
-    let script = format!("@echo off\r\n\"{}\" %*\r\nexit /b %ERRORLEVEL%\r\n", target_string);
-
-    fs::write(alias_path, script).map_err(|error| {
-        MultiPwshError::AliasCreation(format!(
-            "failed to write windows command alias '{}' -> '{}': {}",
-            alias_path.display(),
-            target.display(),
-            error
-        ))
-    })?;
-
-    Ok(())
 }
 
 #[cfg(windows)]
@@ -390,11 +388,21 @@ fn resolve_host_shim_source(layout: &InstallLayout) -> Result<PathBuf> {
     ))
 }
 
-#[cfg(not(windows))]
-fn create_windows_cmd_alias(_target: &Path, _alias_path: &Path) -> Result<()> {
-    Err(MultiPwshError::AliasCreation(
-        "windows command alias is not available on this platform".to_string(),
-    ))
+fn write_layout_hint(layout: &InstallLayout) -> Result<()> {
+    let hint = LayoutHint {
+        home: layout.home().display().to_string(),
+        bin_dir: layout.bin_dir().display().to_string(),
+        cache_dir: layout.cache_dir().display().to_string(),
+        venvs_dir: layout.venvs_dir().display().to_string(),
+        versions_dir: layout.versions_dir().display().to_string(),
+    };
+    let payload = serde_json::to_string_pretty(&hint)?;
+    fs::write(layout_hint_path(&layout.bin_dir()), payload)?;
+    Ok(())
+}
+
+fn layout_hint_path(bin_dir: &Path) -> PathBuf {
+    bin_dir.join(LAYOUT_HINT_FILE)
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -405,9 +413,19 @@ struct AliasMetadata {
     pins: HashMap<String, String>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct LayoutHint {
+    home: String,
+    bin_dir: String,
+    cache_dir: String,
+    venvs_dir: String,
+    versions_dir: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn alias_name_uses_major_minor() {
@@ -419,7 +437,7 @@ mod tests {
         );
         assert_eq!(
             alias_file_name(&AliasSelector::MajorMinor(line), HostOs::Windows),
-            "pwsh-7.4.cmd"
+            "pwsh-7.4.exe"
         );
     }
 
@@ -427,7 +445,7 @@ mod tests {
     fn alias_name_supports_major() {
         assert_eq!(alias_command_name(&AliasSelector::Major(7)), "pwsh-7");
         assert_eq!(alias_file_name(&AliasSelector::Major(7), HostOs::Linux), "pwsh-7");
-        assert_eq!(alias_file_name(&AliasSelector::Major(7), HostOs::Windows), "pwsh-7.cmd");
+        assert_eq!(alias_file_name(&AliasSelector::Major(7), HostOs::Windows), "pwsh-7.exe");
     }
 
     #[test]
@@ -452,5 +470,34 @@ mod tests {
     fn rejects_invalid_alias_selector() {
         assert!(parse_alias_command_selector("pwsh").is_none());
         assert!(parse_alias_command_selector("not-pwsh-7.5").is_none());
+    }
+
+    #[test]
+    fn layout_hint_round_trips_shared_bin_layout() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().join("payload-root");
+        let bin_dir = temp_dir.path().join("shared-bin");
+        let cache_dir = temp_dir.path().join("cache-root");
+        let venvs_dir = temp_dir.path().join("venv-root");
+        let versions_dir = temp_dir.path().join("versions-root");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let layout = InstallLayout::from_parts(
+            HostOs::Linux,
+            home.clone(),
+            bin_dir.clone(),
+            cache_dir.clone(),
+            venvs_dir.clone(),
+            versions_dir.clone(),
+        )
+        .unwrap();
+
+        write_layout_hint(&layout).unwrap();
+        let loaded = read_layout_hint(&bin_dir, HostOs::Linux).unwrap().unwrap();
+
+        assert_eq!(loaded.home(), home.as_path());
+        assert_eq!(loaded.bin_dir(), bin_dir);
+        assert_eq!(loaded.cache_dir(), cache_dir);
+        assert_eq!(loaded.venvs_dir(), venvs_dir);
+        assert_eq!(loaded.versions_dir(), versions_dir);
     }
 }

--- a/crates/multi-pwsh/src/layout.rs
+++ b/crates/multi-pwsh/src/layout.rs
@@ -12,6 +12,7 @@ pub struct InstallLayout {
     bin_dir: PathBuf,
     cache_dir: PathBuf,
     venvs_dir: PathBuf,
+    versions_dir: PathBuf,
     os: HostOs,
 }
 
@@ -23,19 +24,54 @@ impl InstallLayout {
             .unwrap_or_else(|| user_home.join(".pwsh"));
         let bin_dir = env::var_os("MULTI_PWSH_BIN_DIR")
             .map(PathBuf::from)
-            .unwrap_or_else(|| home.join("bin"));
+            .unwrap_or_else(|| join_layout_path(&home, "bin"));
         let cache_dir = env::var_os("MULTI_PWSH_CACHE_DIR")
             .map(PathBuf::from)
-            .unwrap_or_else(|| home.join("cache"));
+            .unwrap_or_else(|| join_layout_path(&home, "cache"));
         let venvs_dir = env::var_os("MULTI_PWSH_VENV_DIR")
             .map(PathBuf::from)
-            .unwrap_or_else(|| home.join("venv"));
+            .unwrap_or_else(|| join_layout_path(&home, "venv"));
+        let versions_dir = join_layout_path(&home, "multi");
 
         Ok(InstallLayout {
             home,
             bin_dir,
             cache_dir,
             venvs_dir,
+            versions_dir,
+            os,
+        })
+    }
+
+    pub fn from_root(os: HostOs, home: PathBuf) -> Result<Self> {
+        Self::from_root_with_versions_dir(os, home.clone(), home.join("multi"))
+    }
+
+    pub fn from_root_with_versions_dir(os: HostOs, home: PathBuf, versions_dir: PathBuf) -> Result<Self> {
+        Self::from_parts(
+            os,
+            home.clone(),
+            join_layout_path(&home, "bin"),
+            join_layout_path(&home, "cache"),
+            join_layout_path(&home, "venv"),
+            versions_dir,
+        )
+    }
+
+    pub fn from_parts(
+        os: HostOs,
+        home: PathBuf,
+        bin_dir: PathBuf,
+        cache_dir: PathBuf,
+        venvs_dir: PathBuf,
+        versions_dir: PathBuf,
+    ) -> Result<Self> {
+        Ok(InstallLayout {
+            home,
+            bin_dir,
+            cache_dir,
+            venvs_dir,
+            versions_dir,
             os,
         })
     }
@@ -49,7 +85,7 @@ impl InstallLayout {
     }
 
     pub fn aliases_file(&self) -> PathBuf {
-        self.home.join("aliases.json")
+        join_layout_path(&self.home, "aliases.json")
     }
 
     pub fn cache_dir(&self) -> PathBuf {
@@ -61,23 +97,27 @@ impl InstallLayout {
     }
 
     pub fn venv_dir(&self, name: &str) -> PathBuf {
-        self.venvs_dir().join(name)
+        join_layout_path(&self.venvs_dir(), name)
     }
 
     pub fn versions_dir(&self) -> PathBuf {
-        self.home.join("multi")
+        self.versions_dir.clone()
     }
 
     pub fn preferred_version_dir(&self, version: &Version) -> PathBuf {
-        self.versions_dir().join(version.to_string())
+        join_layout_path(&self.versions_dir(), &version.to_string())
     }
 
     fn legacy_version_dir(&self, version: &Version) -> PathBuf {
-        self.home.join(version.to_string())
+        join_layout_path(&self.home, &version.to_string())
     }
 
     pub fn executable_name(&self) -> &'static str {
         self.os.executable_name()
+    }
+
+    pub fn os(&self) -> HostOs {
+        self.os
     }
 
     pub fn version_dir(&self, version: &Version) -> PathBuf {
@@ -141,6 +181,25 @@ impl InstallLayout {
         versions.sort_by(|a, b| b.cmp(a));
         Ok(versions)
     }
+}
+
+fn join_layout_path(base: &Path, child: &str) -> PathBuf {
+    let base_text = base.to_string_lossy();
+    if !looks_like_windows_path(base_text.as_ref()) {
+        return base.join(child);
+    }
+
+    let separator = if base_text.contains('\\') { '\\' } else { '/' };
+    let mut path = base_text.to_string();
+    if !path.ends_with('\\') && !path.ends_with('/') {
+        path.push(separator);
+    }
+    path.push_str(child);
+    PathBuf::from(path)
+}
+
+fn looks_like_windows_path(path: &str) -> bool {
+    path.starts_with(r"\\") || path.starts_with("//") || (path.len() >= 2 && path.as_bytes()[1] == b':')
 }
 
 fn collect_versions_from_dir(
@@ -316,5 +375,72 @@ mod tests {
             let layout = InstallLayout::new(HostOs::Linux).unwrap();
             assert_eq!(layout.installed_versions().unwrap(), vec![new_version, legacy_version]);
         });
+    }
+
+    #[test]
+    fn from_root_ignores_multi_pwsh_env_overrides() {
+        let temp_dir = TempDir::new().unwrap();
+        let explicit_home = temp_dir.path().join("package-root");
+        let ignored_home = temp_dir.path().join("ignored-home");
+        let overridden_bin = temp_dir.path().join("override-bin");
+        let overridden_cache = temp_dir.path().join("override-cache");
+        let overridden_venv = temp_dir.path().join("override-venv");
+
+        with_layout_env(
+            Some(&ignored_home),
+            Some(&overridden_bin),
+            Some(&overridden_cache),
+            Some(&overridden_venv),
+            || {
+                let layout = InstallLayout::from_root(HostOs::Windows, explicit_home.clone()).unwrap();
+                assert_eq!(layout.home(), explicit_home.as_path());
+                assert_eq!(layout.bin_dir(), explicit_home.join("bin"));
+                assert_eq!(layout.cache_dir(), explicit_home.join("cache"));
+                assert_eq!(layout.venvs_dir(), explicit_home.join("venv"));
+                assert_eq!(layout.versions_dir(), explicit_home.join("multi"));
+            },
+        );
+    }
+
+    #[test]
+    fn from_root_with_versions_dir_supports_direct_version_roots() {
+        let temp_dir = TempDir::new().unwrap();
+        let explicit_home = temp_dir.path().join("package-root");
+
+        let layout =
+            InstallLayout::from_root_with_versions_dir(HostOs::Windows, explicit_home.clone(), explicit_home.clone())
+                .unwrap();
+
+        assert_eq!(layout.home(), explicit_home.as_path());
+        assert_eq!(layout.bin_dir(), explicit_home.join("bin"));
+        assert_eq!(layout.cache_dir(), explicit_home.join("cache"));
+        assert_eq!(layout.venvs_dir(), explicit_home.join("venv"));
+        assert_eq!(layout.versions_dir(), explicit_home);
+    }
+
+    #[test]
+    fn from_parts_supports_custom_bin_and_versions_dirs() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().join("state-root");
+        let bin_dir = temp_dir.path().join("shared-bin");
+        let cache_dir = temp_dir.path().join("cache-root");
+        let venvs_dir = temp_dir.path().join("venv-root");
+        let versions_dir = temp_dir.path().join("payload-root");
+
+        let layout = InstallLayout::from_parts(
+            HostOs::Linux,
+            home.clone(),
+            bin_dir.clone(),
+            cache_dir.clone(),
+            venvs_dir.clone(),
+            versions_dir.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(layout.home(), home.as_path());
+        assert_eq!(layout.bin_dir(), bin_dir);
+        assert_eq!(layout.cache_dir(), cache_dir);
+        assert_eq!(layout.venvs_dir(), venvs_dir);
+        assert_eq!(layout.versions_dir(), versions_dir);
     }
 }

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -2,6 +2,7 @@ mod aliases;
 mod error;
 mod install;
 mod layout;
+mod package;
 mod platform;
 mod release;
 mod versions;
@@ -17,11 +18,16 @@ use semver::Version;
 
 use aliases::{
     create_or_update_alias, create_or_update_major_alias, create_or_update_patch_alias, parse_alias_command_selector,
-    read_minor_pin, read_minor_pins, remove_alias, set_minor_pin, AliasSelector,
+    read_layout_hint, read_minor_pin, read_minor_pins, remove_alias, set_minor_pin, AliasSelector,
 };
 use error::{MultiPwshError, Result};
 use install::ensure_installed;
 use layout::InstallLayout;
+use package::{
+    load_package_metadata, package_layout, persist_installed_version_registration, persist_installer_properties,
+    reconcile_shared_integrations, remove_installed_version_registration, run_install_time_actions,
+    save_package_metadata, PackageInstallOptions, PackageScope, PACKAGE_METADATA_FILE,
+};
 use platform::{HostArch, HostOs};
 use release::ReleaseClient;
 use versions::{
@@ -36,7 +42,7 @@ const VIRTUAL_ENVIRONMENT_SHORT_FLAG: &str = "-venv";
 
 fn print_usage() {
     eprintln!(
-        "Usage:\n  multi-pwsh install <version|major|major.minor|major.minor.x> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh update <major.minor> [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease]\n  multi-pwsh uninstall <version> [--force]\n  multi-pwsh list [--available] [--include-prerelease]\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias unset <major.minor>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
+        "Usage:\n  multi-pwsh install <version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh update <major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]\n  multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease]\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias unset <major.minor>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
     );
 }
 
@@ -45,9 +51,45 @@ struct ReleaseSelectionOptions {
     include_prerelease: bool,
 }
 
+#[derive(Clone, Debug)]
+struct PackageLayoutOptions {
+    scope: PackageScope,
+    root: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WindowsListScope {
+    CurrentUser,
+    AllUsers,
+    All,
+}
+
+impl WindowsListScope {
+    fn parse(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "currentuser" | "current-user" | "user" => Some(WindowsListScope::CurrentUser),
+            "allusers" | "all-users" | "machine" | "system" => Some(WindowsListScope::AllUsers),
+            "all" => Some(WindowsListScope::All),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct WindowsUninstallOptions {
+    scope: Option<PackageScope>,
+    root: Option<PathBuf>,
+    force: bool,
+}
+
 enum ListOption {
-    Installed,
-    Available { include_prerelease: bool },
+    Installed {
+        scope: Option<WindowsListScope>,
+        root: Option<PathBuf>,
+    },
+    Available {
+        include_prerelease: bool,
+    },
 }
 
 #[derive(Debug, Default, Eq, PartialEq)]
@@ -519,9 +561,8 @@ fn import_virtual_environment_from_archive(venv_dir: &Path, archive_path: &Path)
     Ok(())
 }
 
-fn run_host_mode(selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> {
+fn run_host_mode_with_layout(layout: InstallLayout, selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> {
     let os = HostOs::detect()?;
-    let layout = InstallLayout::new(os)?;
     layout.ensure_base_dirs()?;
 
     let (_version, executable) = resolve_host_executable(&layout, selector_input)?;
@@ -549,6 +590,12 @@ fn run_host_mode(selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> 
             selector_input, error
         ))
     })
+}
+
+fn run_host_mode(selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> {
+    let os = HostOs::detect()?;
+    let layout = InstallLayout::new(os)?;
+    run_host_mode_with_layout(layout, selector_input, pwsh_args)
 }
 
 fn run_host_command(args: &[String]) -> Result<i32> {
@@ -597,6 +644,41 @@ fn detect_implicit_host_selector(bin_dir: &Path, executable_path: &Path) -> Opti
     Some(selector)
 }
 
+fn infer_layout_from_host_shim(os: HostOs, executable_path: &Path) -> Option<InstallLayout> {
+    let selector = executable_selector_name(executable_path)?;
+    if selector.eq_ignore_ascii_case("multi-pwsh") || parse_alias_command_selector(&selector).is_none() {
+        return None;
+    }
+
+    let bin_dir = executable_path.parent()?;
+    if let Some(layout) = read_layout_hint(bin_dir, os).ok().flatten() {
+        if detect_implicit_host_selector(&layout.bin_dir(), executable_path).is_some() {
+            return Some(layout);
+        }
+    }
+
+    if !bin_dir
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(|value| value.eq_ignore_ascii_case("bin"))
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let home = bin_dir.parent()?.to_path_buf();
+    let layout = if home.join(PACKAGE_METADATA_FILE).exists() {
+        InstallLayout::from_root_with_versions_dir(os, home.clone(), home.clone()).ok()?
+    } else {
+        InstallLayout::from_root(os, home).ok()?
+    };
+    if detect_implicit_host_selector(&layout.bin_dir(), executable_path).is_none() {
+        return None;
+    }
+
+    Some(layout)
+}
+
 fn run_implicit_host_mode_if_needed() -> Result<Option<i32>> {
     let executable_path = env::current_exe()?;
 
@@ -609,15 +691,13 @@ fn run_implicit_host_mode_if_needed() -> Result<Option<i32>> {
     }
 
     let os = HostOs::detect()?;
-    let layout = InstallLayout::new(os)?;
-
-    let bin_dir = layout.bin_dir();
-    let Some(selector) = detect_implicit_host_selector(&bin_dir, &executable_path) else {
+    let Some(layout) = infer_layout_from_host_shim(os, &executable_path) else {
         return Ok(None);
     };
+    let selector = selector_name;
 
     let args: Vec<OsString> = env::args_os().skip(1).collect();
-    let exit_code = run_host_mode(&selector, args)?;
+    let exit_code = run_host_mode_with_layout(layout, &selector, args)?;
     Ok(Some(exit_code))
 }
 
@@ -927,6 +1007,704 @@ fn parse_release_selection_options(args: &[String]) -> Result<ReleaseSelectionOp
     })
 }
 
+fn parse_package_layout_options(args: &[String]) -> Result<PackageLayoutOptions> {
+    let mut scope = PackageScope::CurrentUser;
+    let mut scope_specified = false;
+    let mut root = None;
+    let mut index = 0usize;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--scope" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --scope".to_string(),
+                    ));
+                }
+
+                if scope_specified {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--scope can only be specified once".to_string(),
+                    ));
+                }
+
+                scope = PackageScope::parse(&args[index + 1]).ok_or_else(|| {
+                    MultiPwshError::InvalidArguments(format!(
+                        "unsupported scope '{}', expected one of: user, machine",
+                        args[index + 1]
+                    ))
+                })?;
+                scope_specified = true;
+                index += 2;
+            }
+            "--root" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --root".to_string(),
+                    ));
+                }
+
+                if root.is_some() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--root can only be specified once".to_string(),
+                    ));
+                }
+
+                root = Some(PathBuf::from(&args[index + 1]));
+                index += 2;
+            }
+            _ => {
+                return Err(MultiPwshError::InvalidArguments(
+                    "expected optional --scope <user|machine> and/or --root <path>".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(PackageLayoutOptions { scope, root })
+}
+
+fn parse_package_install_options(args: &[String]) -> Result<PackageInstallOptions> {
+    let os = HostOs::detect()?;
+    let mut options = PackageInstallOptions::with_platform_defaults(PackageScope::CurrentUser, os);
+    let mut scope_specified = false;
+    let mut root_specified = false;
+    let mut arch_specified = false;
+    let mut index = 0usize;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--scope" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --scope".to_string(),
+                    ));
+                }
+
+                if scope_specified {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--scope can only be specified once".to_string(),
+                    ));
+                }
+
+                let scope = PackageScope::parse(&args[index + 1]).ok_or_else(|| {
+                    MultiPwshError::InvalidArguments(format!(
+                        "unsupported scope '{}', expected one of: user, machine",
+                        args[index + 1]
+                    ))
+                })?;
+                let arch = options.arch;
+                let include_prerelease = options.include_prerelease;
+                let install_root = options.install_root.clone();
+                options = PackageInstallOptions::with_platform_defaults(scope, os);
+                options.arch = arch;
+                options.include_prerelease = include_prerelease;
+                options.install_root = install_root;
+                scope_specified = true;
+                index += 2;
+            }
+            "--root" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --root".to_string(),
+                    ));
+                }
+
+                if root_specified {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--root can only be specified once".to_string(),
+                    ));
+                }
+
+                options.install_root = Some(PathBuf::from(&args[index + 1]));
+                root_specified = true;
+                index += 2;
+            }
+            "--arch" | "-a" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --arch".to_string(),
+                    ));
+                }
+
+                if arch_specified {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--arch can only be specified once".to_string(),
+                    ));
+                }
+
+                options.arch = if args[index + 1] == "auto" {
+                    None
+                } else {
+                    Some(HostArch::parse(&args[index + 1]).ok_or_else(|| {
+                        MultiPwshError::InvalidArguments(format!(
+                            "unsupported architecture '{}', expected one of: auto, x64, x86, arm64, arm32",
+                            args[index + 1]
+                        ))
+                    })?)
+                };
+                arch_specified = true;
+                index += 2;
+            }
+            "--include-prerelease" | "--prerelease" => {
+                options.include_prerelease = true;
+                index += 1;
+            }
+            "--add-path" => {
+                options.add_path = true;
+                index += 1;
+            }
+            "--no-add-path" => {
+                options.add_path = false;
+                index += 1;
+            }
+            "--register-manifest" => {
+                options.register_manifest = true;
+                index += 1;
+            }
+            "--no-register-manifest" => {
+                options.register_manifest = false;
+                index += 1;
+            }
+            "--enable-psremoting" => {
+                options.enable_psremoting = true;
+                index += 1;
+            }
+            "--disable-telemetry" => {
+                options.disable_telemetry = true;
+                index += 1;
+            }
+            "--add-explorer-context-menu" => {
+                options.add_explorer_context_menu = true;
+                index += 1;
+            }
+            "--add-file-context-menu" => {
+                options.add_file_context_menu = true;
+                index += 1;
+            }
+            "--use-mu" => {
+                options.use_mu = true;
+                index += 1;
+            }
+            "--no-use-mu" => {
+                options.use_mu = false;
+                index += 1;
+            }
+            "--enable-mu" => {
+                options.enable_mu = true;
+                index += 1;
+            }
+            "--no-enable-mu" => {
+                options.enable_mu = false;
+                index += 1;
+            }
+            _ => {
+                return Err(MultiPwshError::InvalidArguments(
+                    "unexpected install options; expected scope/root/arch/include-prerelease and Windows integration flags"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+
+    options.validate(os)?;
+    Ok(options)
+}
+
+fn requires_scoped_install_backend(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "--scope"
+                | "--root"
+                | "--add-path"
+                | "--no-add-path"
+                | "--register-manifest"
+                | "--no-register-manifest"
+                | "--enable-psremoting"
+                | "--disable-telemetry"
+                | "--add-explorer-context-menu"
+                | "--add-file-context-menu"
+                | "--use-mu"
+                | "--no-use-mu"
+                | "--enable-mu"
+                | "--no-enable-mu"
+        )
+    })
+}
+
+fn parse_package_uninstall_options(args: &[String]) -> Result<(PackageLayoutOptions, bool)> {
+    let mut scope = PackageScope::CurrentUser;
+    let mut scope_specified = false;
+    let mut root = None;
+    let mut force = false;
+    let mut index = 0usize;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--scope" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --scope".to_string(),
+                    ));
+                }
+
+                if scope_specified {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--scope can only be specified once".to_string(),
+                    ));
+                }
+
+                scope = PackageScope::parse(&args[index + 1]).ok_or_else(|| {
+                    MultiPwshError::InvalidArguments(format!(
+                        "unsupported scope '{}', expected one of: user, machine",
+                        args[index + 1]
+                    ))
+                })?;
+                scope_specified = true;
+                index += 2;
+            }
+            "--root" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --root".to_string(),
+                    ));
+                }
+
+                if root.is_some() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--root can only be specified once".to_string(),
+                    ));
+                }
+
+                root = Some(PathBuf::from(&args[index + 1]));
+                index += 2;
+            }
+            "--force" => {
+                force = true;
+                index += 1;
+            }
+            _ => {
+                return Err(MultiPwshError::InvalidArguments(
+                    "expected optional --scope <user|machine>, --root <path>, and/or --force".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok((PackageLayoutOptions { scope, root }, force))
+}
+
+fn parse_windows_uninstall_options(args: &[String]) -> Result<WindowsUninstallOptions> {
+    let mut scope = None;
+    let mut root = None;
+    let mut force = false;
+    let mut index = 0usize;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--scope" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --scope".to_string(),
+                    ));
+                }
+
+                if scope.is_some() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--scope can only be specified once".to_string(),
+                    ));
+                }
+
+                scope = Some(PackageScope::parse(&args[index + 1]).ok_or_else(|| {
+                    MultiPwshError::InvalidArguments(format!(
+                        "unsupported scope '{}', expected one of: user, machine",
+                        args[index + 1]
+                    ))
+                })?);
+                index += 2;
+            }
+            "--root" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --root".to_string(),
+                    ));
+                }
+
+                if root.is_some() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--root can only be specified once".to_string(),
+                    ));
+                }
+
+                root = Some(PathBuf::from(&args[index + 1]));
+                index += 2;
+            }
+            "--force" => {
+                force = true;
+                index += 1;
+            }
+            _ => {
+                return Err(MultiPwshError::InvalidArguments(
+                    "expected optional --scope <user|machine>, --root <path>, and/or --force".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(WindowsUninstallOptions { scope, root, force })
+}
+
+fn run_package_install(selector_input: &str, options: PackageInstallOptions) -> Result<()> {
+    let selector = parse_install_selector(selector_input)?;
+    let os = HostOs::detect()?;
+    let arch = options.arch.unwrap_or_else(HostArch::detect);
+    let layout = package_layout(os, arch, options.scope, options.install_root.clone())?;
+    layout.ensure_base_dirs()?;
+
+    let token = env::var("GITHUB_TOKEN").ok();
+    let release_client = ReleaseClient::new(token)?;
+    let releases = match selector {
+        VersionSelector::MajorMinorWildcard(line) => {
+            release_client.resolve_all_in_line(line, os, arch, options.include_prerelease)?
+        }
+        _ => vec![release_client.resolve_selector(selector, os, arch, options.include_prerelease)?],
+    };
+
+    let mut metadata = load_package_metadata(&layout)?;
+    let mut touched_lines: Vec<MajorMinor> = Vec::new();
+    let mut touched_majors: Vec<u64> = Vec::new();
+
+    for release in releases {
+        let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release)?;
+        let patch_alias = create_or_update_patch_alias(&layout, os, &release.version, &executable_path)?;
+        let version_path = executable_path.parent().unwrap_or_else(|| Path::new(""));
+
+        run_install_time_actions(&executable_path, &options)?;
+        persist_installer_properties(&layout, options.scope, &release.version, &options)?;
+        persist_installed_version_registration(options.scope, &release.version, &executable_path)?;
+        metadata.upsert_install(&release.version, &layout, &options);
+
+        println!("Installed PowerShell {}", release.version);
+        println!("Scope: {}", options.scope.display_name());
+        println!("Install root: {}", layout.home().display());
+        println!("Version path: {}", version_path.display());
+        println!("Updated patch alias: {}", patch_alias.display());
+
+        let line = release.version_line();
+        if !touched_lines.contains(&line) {
+            touched_lines.push(line);
+        }
+        if !touched_majors.contains(&release.version.major) {
+            touched_majors.push(release.version.major);
+        }
+    }
+
+    save_package_metadata(&layout, &metadata)?;
+    reconcile_shared_integrations(&layout, options.scope, &metadata)?;
+
+    touched_lines.sort();
+    touched_majors.sort();
+
+    for line in touched_lines {
+        let pinned = read_minor_pin(&layout, line)?;
+        let alias_path = sync_minor_alias(&layout, os, line)?;
+        match alias_path {
+            Some(path) => println!("Updated alias: {}", path.display()),
+            None if pinned.is_some() => {
+                println!(
+                    "Alias pwsh-{}.{} remains pinned but unresolved (target is not installed)",
+                    line.major, line.minor
+                );
+            }
+            None => {}
+        }
+    }
+
+    for major in touched_majors {
+        let major_alias_path = latest_installed_in_major(&layout, major)?
+            .map(|version| {
+                let target = layout.version_executable(&version);
+                create_or_update_major_alias(&layout, os, version.major, &version, &target)
+            })
+            .transpose()?;
+
+        if let Some(path) = major_alias_path {
+            println!("Updated major alias: {}", path.display());
+        }
+    }
+
+    println!("Alias bin: {}", layout.bin_dir().display());
+    println!("Add to PATH once for this scope: {}", layout.bin_dir().display());
+
+    Ok(())
+}
+
+fn run_package_uninstall(version_input: &str, layout_options: PackageLayoutOptions, force: bool) -> Result<()> {
+    let version = parse_exact_version(version_input)?;
+    let os = HostOs::detect()?;
+    let arch = HostArch::detect();
+    let layout = package_layout(os, arch, layout_options.scope, layout_options.root)?;
+    layout.ensure_base_dirs()?;
+
+    let mut metadata = load_package_metadata(&layout)?;
+    let removed_files = layout.remove_version_dirs(&version)?;
+    let removed_metadata = metadata.remove_install(&version);
+
+    if !removed_files && !removed_metadata && !force {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "version {} is not installed in scope {} (use --force to ignore)",
+            version,
+            layout_options.scope.display_name()
+        )));
+    }
+
+    if removed_files || removed_metadata {
+        println!("Removed PowerShell {}", version);
+        println!("Scope: {}", layout_options.scope.display_name());
+    } else {
+        println!(
+            "PowerShell {} is not installed; continuing because --force was provided",
+            version
+        );
+    }
+
+    remove_installed_version_registration(layout_options.scope, &version)?;
+    save_package_metadata(&layout, &metadata)?;
+    reconcile_shared_integrations(&layout, layout_options.scope, &metadata)?;
+    cleanup_aliases_for_removed_version(&layout, os, &version)?;
+    Ok(())
+}
+
+fn run_package_list(layout_options: PackageLayoutOptions) -> Result<()> {
+    let os = HostOs::detect()?;
+    let arch = HostArch::detect();
+    let layout = package_layout(os, arch, layout_options.scope, layout_options.root)?;
+    let metadata = load_package_metadata(&layout)?;
+
+    println!("Scope: {}", layout_options.scope.display_name());
+    println!("Install root: {}", layout.home().display());
+    println!("Alias bin: {}", layout.bin_dir().display());
+    println!("Versions dir: {}", layout.versions_dir().display());
+    println!("Metadata file: {}", package::package_metadata_file(&layout).display());
+    println!();
+
+    let records = metadata.resolved_records()?;
+    if records.is_empty() {
+        println!("Installed versions: (none)");
+        return Ok(());
+    }
+
+    println!("Installed versions:");
+    for record in records {
+        println!("  - {}", record.version);
+        println!("    path: {}", record.record.install_dir);
+        println!(
+            "    options: add_path={}, register_manifest={}, enable_psremoting={}, disable_telemetry={}, add_explorer_context_menu={}, add_file_context_menu={}, use_mu={}, enable_mu={}",
+            record.record.add_path,
+            record.record.register_manifest,
+            record.record.enable_psremoting,
+            record.record.disable_telemetry,
+            record.record.add_explorer_context_menu,
+            record.record.add_file_context_menu,
+            record.record.use_mu,
+            record.record.enable_mu
+        );
+    }
+
+    Ok(())
+}
+
+fn package_scope_has_version(scope: PackageScope, version: &Version) -> Result<bool> {
+    let os = HostOs::detect()?;
+    let arch = HostArch::detect();
+    let layout = package_layout(os, arch, scope, None)?;
+    let metadata = load_package_metadata(&layout)?;
+    let in_metadata = metadata
+        .resolved_records()?
+        .into_iter()
+        .any(|record| record.version == *version);
+    Ok(in_metadata || layout.version_executable(version).exists())
+}
+
+fn resolve_scoped_uninstall_scope(
+    current_user_installed: bool,
+    all_users_installed: bool,
+) -> Result<Option<PackageScope>> {
+    match (current_user_installed, all_users_installed) {
+        (true, true) => Err(MultiPwshError::InvalidArguments(
+            "the requested version is installed in both user and machine scopes; rerun with --scope <user|machine>"
+                .to_string(),
+        )),
+        (true, false) => Ok(Some(PackageScope::CurrentUser)),
+        (false, true) => Ok(Some(PackageScope::AllUsers)),
+        (false, false) => Ok(None),
+    }
+}
+
+fn run_scoped_uninstall(version_input: &str, options: WindowsUninstallOptions) -> Result<()> {
+    let version = parse_exact_version(version_input)?;
+    let os = HostOs::detect()?;
+
+    if options.root.is_some() && options.scope.is_none() {
+        return Err(MultiPwshError::InvalidArguments(
+            "--root requires --scope <user|machine> for uninstall".to_string(),
+        ));
+    }
+
+    let Some(scope) = (match options.scope {
+        Some(scope) => Some(scope),
+        None => resolve_scoped_uninstall_scope(
+            package_scope_has_version(PackageScope::CurrentUser, &version)?,
+            package_scope_has_version(PackageScope::AllUsers, &version)?,
+        )?,
+    }) else {
+        if options.force {
+            println!(
+                "PowerShell {} is not installed in user or machine scopes; continuing because --force was provided",
+                version
+            );
+            return Ok(());
+        }
+
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "version {} is not installed in user or machine scopes (use --force to ignore)",
+            version
+        )));
+    };
+
+    if os != HostOs::Windows && scope == PackageScope::CurrentUser && options.root.is_none() {
+        return run_uninstall(version_input, options.force);
+    }
+
+    run_package_uninstall(
+        version_input,
+        PackageLayoutOptions {
+            scope,
+            root: options.root,
+        },
+        options.force,
+    )
+}
+
+fn run_current_user_list(os: HostOs, root: Option<PathBuf>) -> Result<()> {
+    let layout = match root {
+        Some(root) => package_layout(os, HostArch::detect(), PackageScope::CurrentUser, Some(root))?,
+        None => InstallLayout::new(os)?,
+    };
+    let versions = layout.installed_versions()?;
+    let aliases = aliases::read_alias_metadata(&layout)?;
+    let pins = read_minor_pins(&layout)?;
+
+    println!("Home: {}", layout.home().display());
+    println!("Alias bin: {}", layout.bin_dir().display());
+    println!("Versions dir: {}", layout.versions_dir().display());
+    println!("Venv dir: {}", layout.venvs_dir().display());
+    println!("Cache dir: {}", layout.cache_dir().display());
+    println!();
+
+    if versions.is_empty() {
+        println!("Installed versions: (none)");
+    } else {
+        println!("Installed versions:");
+        for version in versions {
+            println!("  - {}", version);
+        }
+    }
+
+    println!();
+    if aliases.is_empty() {
+        println!("Aliases: (none)");
+    } else {
+        println!("Aliases:");
+        let mut items: Vec<_> = aliases.into_iter().collect();
+        items.sort_by(|a, b| a.0.cmp(&b.0));
+        for (alias, version) in items {
+            println!("  - {} -> {}", alias, version);
+        }
+    }
+
+    println!();
+    if pins.is_empty() {
+        println!("Minor alias pins: (none)");
+    } else {
+        println!("Minor alias pins:");
+        let mut items: Vec<_> = pins.into_iter().collect();
+        items.sort_by(|a, b| a.0.cmp(&b.0));
+        for (line, version) in items {
+            println!("  - {} -> {}", line, version);
+        }
+    }
+
+    Ok(())
+}
+
+fn run_scoped_list_scope(os: HostOs, scope: PackageScope, root: Option<PathBuf>) -> Result<()> {
+    if os != HostOs::Windows && scope == PackageScope::CurrentUser {
+        return run_current_user_list(os, root);
+    }
+
+    run_package_list(PackageLayoutOptions { scope, root })
+}
+
+fn run_scoped_list(scope: Option<WindowsListScope>, root: Option<PathBuf>) -> Result<()> {
+    let os = HostOs::detect()?;
+
+    match scope.unwrap_or(WindowsListScope::CurrentUser) {
+        WindowsListScope::CurrentUser => run_scoped_list_scope(os, PackageScope::CurrentUser, root),
+        WindowsListScope::AllUsers => run_scoped_list_scope(os, PackageScope::AllUsers, root),
+        WindowsListScope::All => {
+            if root.is_some() {
+                return Err(MultiPwshError::InvalidArguments(
+                    "--root cannot be used with --scope all".to_string(),
+                ));
+            }
+
+            run_scoped_list_scope(os, PackageScope::CurrentUser, None)?;
+            println!();
+            run_scoped_list_scope(os, PackageScope::AllUsers, None)
+        }
+    }
+}
+
+fn run_package(args: &[String]) -> Result<()> {
+    if args.is_empty() {
+        return Err(MultiPwshError::InvalidArguments(
+            "package requires: install <selector>, uninstall <version>, or list".to_string(),
+        ));
+    }
+
+    match args[0].as_str() {
+        "install" => {
+            if args.len() < 2 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "package install requires <version|major|major.minor|major.minor.x>".to_string(),
+                ));
+            }
+
+            let options = parse_package_install_options(&args[2..])?;
+            run_package_install(&args[1], options)
+        }
+        "uninstall" => {
+            if args.len() < 2 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "package uninstall requires <version>".to_string(),
+                ));
+            }
+
+            let (layout_options, force) = parse_package_uninstall_options(&args[2..])?;
+            run_package_uninstall(&args[1], layout_options, force)
+        }
+        "list" => {
+            let layout_options = parse_package_layout_options(&args[1..])?;
+            run_package_list(layout_options)
+        }
+        _ => Err(MultiPwshError::InvalidArguments(
+            "package requires: install <selector>, uninstall <version>, or list".to_string(),
+        )),
+    }
+}
+
 fn run_install(selector_input: &str, arch: Option<HostArch>, include_prerelease: bool) -> Result<()> {
     let selector = parse_install_selector(selector_input)?;
     let os = HostOs::detect()?;
@@ -1043,81 +1821,8 @@ fn run_update(line_input: &str, arch: Option<HostArch>, include_prerelease: bool
     Ok(())
 }
 
-fn parse_force_option(args: &[String]) -> Result<bool> {
-    if args.is_empty() {
-        return Ok(false);
-    }
-
-    if args.len() == 1 && args[0] == "--force" {
-        return Ok(true);
-    }
-
-    Err(MultiPwshError::InvalidArguments(
-        "expected optional --force".to_string(),
-    ))
-}
-
-fn parse_list_option(args: &[String]) -> Result<ListOption> {
-    if args.is_empty() {
-        return Ok(ListOption::Installed);
-    }
-
-    let mut available = false;
-    let mut include_prerelease = false;
-
-    for arg in args {
-        match arg.as_str() {
-            "--available" | "--online" => {
-                available = true;
-            }
-            "--include-prerelease" | "--prerelease" => {
-                include_prerelease = true;
-            }
-            _ => {
-                return Err(MultiPwshError::InvalidArguments(
-                    "expected optional --available and/or --include-prerelease".to_string(),
-                ));
-            }
-        }
-    }
-
-    if include_prerelease && !available {
-        return Err(MultiPwshError::InvalidArguments(
-            "--include-prerelease requires --available".to_string(),
-        ));
-    }
-
-    if available {
-        return Ok(ListOption::Available { include_prerelease });
-    }
-
-    Err(MultiPwshError::InvalidArguments(
-        "expected optional --available".to_string(),
-    ))
-}
-
-fn run_uninstall(version_input: &str, force: bool) -> Result<()> {
-    let version = parse_exact_version(version_input)?;
-    let os = HostOs::detect()?;
-
-    let layout = InstallLayout::new(os)?;
-    layout.ensure_base_dirs()?;
-
-    if layout.remove_version_dirs(&version)? {
-        println!("Removed PowerShell {}", version);
-    } else if force {
-        println!(
-            "PowerShell {} is not installed; continuing because --force was provided",
-            version
-        );
-    } else {
-        return Err(MultiPwshError::InvalidArguments(format!(
-            "version {} is not installed (use --force to ignore)",
-            version
-        )));
-    }
-
-    let aliases = aliases::read_alias_metadata(&layout)?;
+fn cleanup_aliases_for_removed_version(layout: &InstallLayout, os: HostOs, version: &Version) -> Result<()> {
+    let aliases = aliases::read_alias_metadata(layout)?;
     let removed_version_text = version.to_string();
     let mut affected_aliases: Vec<String> = aliases
         .into_iter()
@@ -1146,8 +1851,8 @@ fn run_uninstall(version_input: &str, force: bool) -> Result<()> {
         let alias_selector = parse_alias_command_selector(&alias_name);
         let fallback_version = match alias_selector {
             Some(AliasSelector::MajorMinor(line)) => {
-                let pinned = read_minor_pin(&layout, line)?;
-                if pinned.as_ref() == Some(&version) {
+                let pinned = read_minor_pin(layout, line)?;
+                if pinned.as_ref() == Some(version) {
                     println!(
                         "Keeping pinned alias {} -> {} (target is now unresolved)",
                         alias_name, version
@@ -1173,12 +1878,12 @@ fn run_uninstall(version_input: &str, force: bool) -> Result<()> {
             let target = layout.version_executable(&fallback_version);
             let alias_path = match alias_selector {
                 Some(AliasSelector::MajorMinor(line)) => {
-                    create_or_update_alias(&layout, os, line, &fallback_version, &target)?
+                    create_or_update_alias(layout, os, line, &fallback_version, &target)?
                 }
                 Some(AliasSelector::Major(major)) => {
-                    create_or_update_major_alias(&layout, os, major, &fallback_version, &target)?
+                    create_or_update_major_alias(layout, os, major, &fallback_version, &target)?
                 }
-                Some(AliasSelector::Exact(_)) => create_or_update_patch_alias(&layout, os, &fallback_version, &target)?,
+                Some(AliasSelector::Exact(_)) => create_or_update_patch_alias(layout, os, &fallback_version, &target)?,
                 None => continue,
             };
             println!("Updated alias: {} -> {}", alias_name, fallback_version);
@@ -1187,7 +1892,7 @@ fn run_uninstall(version_input: &str, force: bool) -> Result<()> {
             continue;
         }
 
-        if remove_alias(&layout, os, &alias_name)? {
+        if remove_alias(layout, os, &alias_name)? {
             println!("Removed alias: {}", alias_name);
         }
         removed_aliases += 1;
@@ -1201,56 +1906,136 @@ fn run_uninstall(version_input: &str, force: bool) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+fn parse_force_option(args: &[String]) -> Result<bool> {
+    if args.is_empty() {
+        return Ok(false);
+    }
+
+    if args.len() == 1 && args[0] == "--force" {
+        return Ok(true);
+    }
+
+    Err(MultiPwshError::InvalidArguments(
+        "expected optional --force".to_string(),
+    ))
+}
+
+fn parse_list_option(args: &[String]) -> Result<ListOption> {
+    let mut available = false;
+    let mut include_prerelease = false;
+    let mut scope = None;
+    let mut root = None;
+    let mut index = 0usize;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--available" | "--online" => {
+                available = true;
+                index += 1;
+            }
+            "--include-prerelease" | "--prerelease" => {
+                include_prerelease = true;
+                index += 1;
+            }
+            "--scope" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --scope".to_string(),
+                    ));
+                }
+
+                if scope.is_some() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--scope can only be specified once".to_string(),
+                    ));
+                }
+
+                scope = Some(WindowsListScope::parse(&args[index + 1]).ok_or_else(|| {
+                    MultiPwshError::InvalidArguments(format!(
+                        "unsupported scope '{}', expected one of: user, machine, all",
+                        args[index + 1]
+                    ))
+                })?);
+                index += 2;
+            }
+            "--root" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --root".to_string(),
+                    ));
+                }
+
+                if root.is_some() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--root can only be specified once".to_string(),
+                    ));
+                }
+
+                root = Some(PathBuf::from(&args[index + 1]));
+                index += 2;
+            }
+            _ => {
+                return Err(MultiPwshError::InvalidArguments(
+                    "expected optional --scope <user|machine|all>, --root <path>, --available, and/or --include-prerelease"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+
+    if include_prerelease && !available {
+        return Err(MultiPwshError::InvalidArguments(
+            "--include-prerelease requires --available".to_string(),
+        ));
+    }
+
+    if available {
+        if scope.is_some() || root.is_some() {
+            return Err(MultiPwshError::InvalidArguments(
+                "--scope and --root are only supported for installed-version listings".to_string(),
+            ));
+        }
+        return Ok(ListOption::Available { include_prerelease });
+    }
+
+    Ok(ListOption::Installed { scope, root })
+}
+
+fn run_uninstall(version_input: &str, force: bool) -> Result<()> {
+    let version = parse_exact_version(version_input)?;
+    let os = HostOs::detect()?;
+
+    let layout = InstallLayout::new(os)?;
+    layout.ensure_base_dirs()?;
+
+    if layout.remove_version_dirs(&version)? {
+        println!("Removed PowerShell {}", version);
+    } else if force {
+        println!(
+            "PowerShell {} is not installed; continuing because --force was provided",
+            version
+        );
+    } else {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "version {} is not installed (use --force to ignore)",
+            version
+        )));
+    }
+
+    cleanup_aliases_for_removed_version(&layout, os, &version)
+}
+
 fn run_list(option: ListOption) -> Result<()> {
     match option {
-        ListOption::Installed => {
-            let os = HostOs::detect()?;
-            let layout = InstallLayout::new(os)?;
-            let versions = layout.installed_versions()?;
-            let aliases = aliases::read_alias_metadata(&layout)?;
-            let pins = read_minor_pins(&layout)?;
-
-            println!("Home: {}", layout.home().display());
-            println!("Alias bin: {}", layout.bin_dir().display());
-            println!("Versions dir: {}", layout.versions_dir().display());
-            println!("Venv dir: {}", layout.venvs_dir().display());
-            println!("Cache dir: {}", layout.cache_dir().display());
-            println!();
-
-            if versions.is_empty() {
-                println!("Installed versions: (none)");
-            } else {
-                println!("Installed versions:");
-                for version in versions {
-                    println!("  - {}", version);
-                }
+        ListOption::Installed { scope, root } => {
+            if root.is_some() && scope.is_none() {
+                return Err(MultiPwshError::InvalidArguments(
+                    "--root requires --scope <user|machine> for installed-version listings".to_string(),
+                ));
             }
 
-            println!();
-            if aliases.is_empty() {
-                println!("Aliases: (none)");
-            } else {
-                println!("Aliases:");
-                let mut items: Vec<_> = aliases.into_iter().collect();
-                items.sort_by(|a, b| a.0.cmp(&b.0));
-                for (alias, version) in items {
-                    println!("  - {} -> {}", alias, version);
-                }
-            }
-
-            println!();
-            if pins.is_empty() {
-                println!("Minor alias pins: (none)");
-            } else {
-                println!("Minor alias pins:");
-                let mut items: Vec<_> = pins.into_iter().collect();
-                items.sort_by(|a, b| a.0.cmp(&b.0));
-                for (line, version) in items {
-                    println!("  - {} -> {}", line, version);
-                }
-            }
-
-            Ok(())
+            run_scoped_list(scope, root)
         }
         ListOption::Available { include_prerelease } => {
             let token = env::var("GITHUB_TOKEN").ok();
@@ -1364,6 +2149,7 @@ fn run_doctor(args: &[String]) -> Result<()> {
 
 fn run() -> Result<()> {
     let args: Vec<String> = env::args().skip(1).collect();
+    let os = HostOs::detect()?;
     if args.is_empty() {
         print_usage();
         return Err(MultiPwshError::InvalidArguments("missing command".to_string()));
@@ -1376,8 +2162,13 @@ fn run() -> Result<()> {
                     "install requires <version|major|major.minor|major.minor.x>".to_string(),
                 ));
             }
-            let options = parse_release_selection_options(&args[2..])?;
-            run_install(&args[1], options.arch, options.include_prerelease)
+            if os == HostOs::Windows || requires_scoped_install_backend(&args[2..]) {
+                let options = parse_package_install_options(&args[2..])?;
+                run_package_install(&args[1], options)
+            } else {
+                let options = parse_release_selection_options(&args[2..])?;
+                run_install(&args[1], options.arch, options.include_prerelease)
+            }
         }
         "update" => {
             if args.len() < 2 {
@@ -1385,8 +2176,14 @@ fn run() -> Result<()> {
                     "update requires <major.minor>".to_string(),
                 ));
             }
-            let options = parse_release_selection_options(&args[2..])?;
-            run_update(&args[1], options.arch, options.include_prerelease)
+            if os == HostOs::Windows || requires_scoped_install_backend(&args[2..]) {
+                parse_major_minor_selector(&args[1])?;
+                let options = parse_package_install_options(&args[2..])?;
+                run_package_install(&args[1], options)
+            } else {
+                let options = parse_release_selection_options(&args[2..])?;
+                run_update(&args[1], options.arch, options.include_prerelease)
+            }
         }
         "uninstall" => {
             if args.len() < 2 {
@@ -1394,13 +2191,14 @@ fn run() -> Result<()> {
                     "uninstall requires <version>".to_string(),
                 ));
             }
-            let force = parse_force_option(&args[2..])?;
-            run_uninstall(&args[1], force)
+            let options = parse_windows_uninstall_options(&args[2..])?;
+            run_scoped_uninstall(&args[1], options)
         }
         "list" => {
             let list_option = parse_list_option(&args[1..])?;
             run_list(list_option)
         }
+        "package" => run_package(&args[1..]),
         "venv" => run_venv(&args[1..]),
         "alias" => run_alias(&args[1..]),
         "host" => {
@@ -1438,6 +2236,7 @@ fn main() {
 mod tests {
     use super::*;
     use std::sync::Mutex;
+    use tempfile::TempDir;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -1481,7 +2280,13 @@ mod tests {
     #[test]
     fn parse_list_option_defaults_to_installed() {
         let args: Vec<String> = Vec::new();
-        assert!(matches!(parse_list_option(&args).unwrap(), ListOption::Installed));
+        assert!(matches!(
+            parse_list_option(&args).unwrap(),
+            ListOption::Installed {
+                scope: None,
+                root: None
+            }
+        ));
     }
 
     #[test]
@@ -1516,6 +2321,51 @@ mod tests {
     fn parse_list_option_rejects_prerelease_without_available() {
         let args = vec!["--include-prerelease".to_string()];
         assert!(parse_list_option(&args).is_err());
+    }
+
+    #[test]
+    fn parse_list_option_accepts_scope_all() {
+        let args = vec!["--scope".to_string(), "All".to_string()];
+        assert!(matches!(
+            parse_list_option(&args).unwrap(),
+            ListOption::Installed {
+                scope: Some(WindowsListScope::All),
+                root: None
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_list_option_rejects_scope_for_available() {
+        let args = vec!["--available".to_string(), "--scope".to_string(), "machine".to_string()];
+        assert!(parse_list_option(&args).is_err());
+    }
+
+    #[test]
+    fn parse_package_install_options_rejects_microsoft_update_flags() {
+        let args = vec!["--scope".to_string(), "machine".to_string(), "--use-mu".to_string()];
+        let error = parse_package_install_options(&args).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Microsoft Update integration is not supported for archive installs yet"));
+    }
+
+    #[test]
+    fn resolve_scoped_uninstall_scope_prefers_unambiguous_scope() {
+        assert_eq!(
+            resolve_scoped_uninstall_scope(true, false).unwrap(),
+            Some(PackageScope::CurrentUser)
+        );
+        assert_eq!(
+            resolve_scoped_uninstall_scope(false, true).unwrap(),
+            Some(PackageScope::AllUsers)
+        );
+        assert_eq!(resolve_scoped_uninstall_scope(false, false).unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_scoped_uninstall_scope_rejects_ambiguous_version() {
+        assert!(resolve_scoped_uninstall_scope(true, true).is_err());
     }
 
     #[test]
@@ -1579,6 +2429,80 @@ mod tests {
 
         let selector = detect_implicit_host_selector(&bin_dir, &PathBuf::from("C:/Users/test/other/pwsh-7.4.exe"));
         assert!(selector.is_none());
+    }
+
+    #[test]
+    fn infer_layout_from_host_shim_uses_parent_of_bin_dir() {
+        let executable_path = PathBuf::from("C:/Program Files/PowerShell/bin/pwsh-7.4.exe");
+
+        let layout = infer_layout_from_host_shim(HostOs::Windows, &executable_path).unwrap();
+        assert_eq!(layout.home(), Path::new("C:/Program Files/PowerShell"));
+        assert_eq!(layout.bin_dir(), PathBuf::from("C:/Program Files/PowerShell/bin"));
+        assert_eq!(layout.cache_dir(), PathBuf::from("C:/Program Files/PowerShell/cache"));
+        assert_eq!(
+            layout.versions_dir(),
+            PathBuf::from("C:/Program Files/PowerShell/multi")
+        );
+    }
+
+    #[test]
+    fn infer_layout_from_host_shim_uses_package_root_when_metadata_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().join("PowerShell");
+        fs::create_dir_all(home.join("bin")).unwrap();
+        fs::write(home.join(PACKAGE_METADATA_FILE), "{}").unwrap();
+        let executable_path = home.join("bin").join("pwsh-7.4.exe");
+
+        let layout = infer_layout_from_host_shim(HostOs::Windows, &executable_path).unwrap();
+        assert_eq!(layout.home(), home.as_path());
+        assert_eq!(layout.bin_dir(), home.join("bin"));
+        assert_eq!(layout.versions_dir(), home);
+    }
+
+    #[test]
+    fn infer_layout_from_host_shim_rejects_non_bin_parent() {
+        let executable_path = PathBuf::from("C:/Program Files/PowerShell/shims/pwsh-7.4.exe");
+        assert!(infer_layout_from_host_shim(HostOs::Windows, &executable_path).is_none());
+    }
+
+    #[test]
+    fn infer_layout_from_host_shim_uses_layout_hint_for_shared_bin() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().join("payload-root");
+        let bin_dir = temp_dir.path().join("shared-bin");
+        let cache_dir = temp_dir.path().join("cache-root");
+        let venvs_dir = temp_dir.path().join("venv-root");
+        let versions_dir = temp_dir.path().join("versions-root");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let layout = InstallLayout::from_parts(
+            HostOs::Linux,
+            home.clone(),
+            bin_dir.clone(),
+            cache_dir.clone(),
+            venvs_dir.clone(),
+            versions_dir.clone(),
+        )
+        .unwrap();
+        let hint = serde_json::json!({
+            "home": home.display().to_string(),
+            "bin_dir": bin_dir.display().to_string(),
+            "cache_dir": cache_dir.display().to_string(),
+            "venvs_dir": venvs_dir.display().to_string(),
+            "versions_dir": versions_dir.display().to_string()
+        });
+        fs::write(
+            bin_dir.join("multi-pwsh-layout.json"),
+            serde_json::to_string_pretty(&hint).unwrap(),
+        )
+        .unwrap();
+        let executable_path = bin_dir.join("pwsh-7.4");
+
+        let inferred = infer_layout_from_host_shim(HostOs::Linux, &executable_path).unwrap();
+        assert_eq!(inferred.home(), layout.home());
+        assert_eq!(inferred.bin_dir(), layout.bin_dir());
+        assert_eq!(inferred.cache_dir(), layout.cache_dir());
+        assert_eq!(inferred.venvs_dir(), layout.venvs_dir());
+        assert_eq!(inferred.versions_dir(), layout.versions_dir());
     }
 
     #[test]

--- a/crates/multi-pwsh/src/package.rs
+++ b/crates/multi-pwsh/src/package.rs
@@ -1,0 +1,1031 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use home::home_dir;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{MultiPwshError, Result};
+use crate::layout::InstallLayout;
+use crate::platform::{HostArch, HostOs};
+
+pub const PACKAGE_METADATA_FILE: &str = "package-installs.json";
+const EXPLORER_CONTEXT_MENU_KEY: &str = "MultiPwsh.OpenPowerShell";
+const FILE_CONTEXT_MENU_KEY: &str = "MultiPwsh.RunWithPowerShell";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PackageScope {
+    CurrentUser,
+    AllUsers,
+}
+
+impl PackageScope {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "current-user" | "currentuser" | "user" => Some(PackageScope::CurrentUser),
+            "all-users" | "allusers" | "machine" | "system" => Some(PackageScope::AllUsers),
+            _ => None,
+        }
+    }
+
+    pub fn display_name(self) -> &'static str {
+        match self {
+            PackageScope::CurrentUser => "user",
+            PackageScope::AllUsers => "machine",
+        }
+    }
+
+    fn registry_target_name(self) -> &'static str {
+        match self {
+            PackageScope::CurrentUser => "User",
+            PackageScope::AllUsers => "Machine",
+        }
+    }
+
+    fn registry_drive(self) -> &'static str {
+        match self {
+            PackageScope::CurrentUser => "HKCU:",
+            PackageScope::AllUsers => "HKLM:",
+        }
+    }
+
+    fn classes_root(self) -> &'static str {
+        match self {
+            PackageScope::CurrentUser => r"Registry::HKEY_CURRENT_USER\Software\Classes",
+            PackageScope::AllUsers => r"Registry::HKEY_LOCAL_MACHINE\Software\Classes",
+        }
+    }
+
+    fn start_menu_programs_dir(self) -> Result<PathBuf> {
+        let base = match self {
+            PackageScope::CurrentUser => env::var_os("APPDATA").map(PathBuf::from).ok_or_else(|| {
+                MultiPwshError::InvalidArguments(
+                    "APPDATA is not defined; unable to determine current-user Start Menu location".to_string(),
+                )
+            })?,
+            PackageScope::AllUsers => env::var_os("ProgramData").map(PathBuf::from).ok_or_else(|| {
+                MultiPwshError::InvalidArguments(
+                    "ProgramData is not defined; unable to determine all-users Start Menu location".to_string(),
+                )
+            })?,
+        };
+
+        Ok(base
+            .join("Microsoft")
+            .join("Windows")
+            .join("Start Menu")
+            .join("Programs")
+            .join("PowerShell"))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PackageInstallOptions {
+    pub scope: PackageScope,
+    pub arch: Option<HostArch>,
+    pub include_prerelease: bool,
+    pub install_root: Option<PathBuf>,
+    pub add_path: bool,
+    pub register_manifest: bool,
+    pub enable_psremoting: bool,
+    pub disable_telemetry: bool,
+    pub add_explorer_context_menu: bool,
+    pub add_file_context_menu: bool,
+    pub use_mu: bool,
+    pub enable_mu: bool,
+}
+
+impl PackageInstallOptions {
+    #[cfg(test)]
+    pub fn with_defaults(scope: PackageScope) -> Self {
+        Self::with_platform_defaults(scope, HostOs::Windows)
+    }
+
+    pub fn with_platform_defaults(scope: PackageScope, os: HostOs) -> Self {
+        let privileged_defaults = os == HostOs::Windows && scope == PackageScope::AllUsers;
+
+        Self {
+            scope,
+            arch: None,
+            include_prerelease: false,
+            install_root: None,
+            add_path: true,
+            register_manifest: privileged_defaults,
+            enable_psremoting: false,
+            disable_telemetry: false,
+            add_explorer_context_menu: false,
+            add_file_context_menu: false,
+            use_mu: false,
+            enable_mu: false,
+        }
+    }
+
+    pub fn validate(&self, os: HostOs) -> Result<()> {
+        if self.use_mu || self.enable_mu {
+            return Err(MultiPwshError::InvalidArguments(
+                "Microsoft Update integration is not supported for archive installs yet".to_string(),
+            ));
+        }
+
+        if self.scope == PackageScope::CurrentUser {
+            for (enabled, flag_name) in [
+                (self.register_manifest, "--register-manifest"),
+                (self.enable_psremoting, "--enable-psremoting"),
+            ] {
+                if enabled {
+                    return Err(MultiPwshError::InvalidArguments(format!(
+                        "{} requires --scope {}",
+                        flag_name,
+                        PackageScope::AllUsers.display_name()
+                    )));
+                }
+            }
+        }
+
+        if os != HostOs::Windows {
+            for (enabled, flag_name) in [
+                (self.register_manifest, "--register-manifest"),
+                (self.enable_psremoting, "--enable-psremoting"),
+                (self.disable_telemetry, "--disable-telemetry"),
+                (self.add_explorer_context_menu, "--add-explorer-context-menu"),
+                (self.add_file_context_menu, "--add-file-context-menu"),
+                (self.use_mu, "--use-mu"),
+                (self.enable_mu, "--enable-mu"),
+            ] {
+                if enabled {
+                    return Err(MultiPwshError::InvalidArguments(format!(
+                        "{} is currently supported only on Windows",
+                        flag_name
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct PackageMetadata {
+    #[serde(default)]
+    installs: Vec<PackageInstallRecord>,
+}
+
+impl PackageMetadata {
+    #[cfg(test)]
+    pub fn installs(&self) -> &[PackageInstallRecord] {
+        &self.installs
+    }
+
+    pub fn upsert_install(&mut self, version: &Version, layout: &InstallLayout, options: &PackageInstallOptions) {
+        let install_dir = layout.version_install_dir(version);
+        let install_dir = install_dir.to_string_lossy().to_string();
+        let new_record = PackageInstallRecord {
+            version: version.to_string(),
+            install_dir,
+            add_path: options.add_path,
+            register_manifest: options.register_manifest,
+            enable_psremoting: options.enable_psremoting,
+            disable_telemetry: options.disable_telemetry,
+            add_explorer_context_menu: options.add_explorer_context_menu,
+            add_file_context_menu: options.add_file_context_menu,
+            use_mu: options.use_mu,
+            enable_mu: options.enable_mu,
+        };
+
+        if let Some(existing) = self
+            .installs
+            .iter_mut()
+            .find(|record| record.version == new_record.version)
+        {
+            *existing = new_record;
+        } else {
+            self.installs.push(new_record);
+        }
+    }
+
+    pub fn remove_install(&mut self, version: &Version) -> bool {
+        let before = self.installs.len();
+        let version_text = version.to_string();
+        self.installs.retain(|record| record.version != version_text);
+        before != self.installs.len()
+    }
+
+    pub fn resolved_records(&self) -> Result<Vec<ResolvedPackageRecord>> {
+        let mut records = Vec::new();
+        for record in &self.installs {
+            records.push(ResolvedPackageRecord {
+                version: Version::parse(&record.version)?,
+                record: record.clone(),
+            });
+        }
+
+        records.sort_by(|left, right| right.version.cmp(&left.version));
+        Ok(records)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PackageInstallRecord {
+    pub version: String,
+    pub install_dir: String,
+    pub add_path: bool,
+    pub register_manifest: bool,
+    pub enable_psremoting: bool,
+    pub disable_telemetry: bool,
+    pub add_explorer_context_menu: bool,
+    pub add_file_context_menu: bool,
+    pub use_mu: bool,
+    pub enable_mu: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct ResolvedPackageRecord {
+    pub version: Version,
+    pub record: PackageInstallRecord,
+}
+
+impl ResolvedPackageRecord {
+    fn executable_path(&self, os: HostOs) -> PathBuf {
+        PathBuf::from(&self.record.install_dir).join(os.executable_name())
+    }
+}
+
+pub fn package_layout(
+    os: HostOs,
+    arch: HostArch,
+    scope: PackageScope,
+    install_root: Option<PathBuf>,
+) -> Result<InstallLayout> {
+    match (os, scope, install_root) {
+        (HostOs::Windows, scope, install_root) => {
+            let root = match install_root {
+                Some(root) => root,
+                None => default_install_root(os, scope, arch)?,
+            };
+            InstallLayout::from_root_with_versions_dir(os, root.clone(), root)
+        }
+        (HostOs::Macos | HostOs::Linux, PackageScope::CurrentUser, Some(root)) => InstallLayout::from_root(os, root),
+        (HostOs::Macos | HostOs::Linux, PackageScope::CurrentUser, None) => InstallLayout::new(os),
+        (HostOs::Macos | HostOs::Linux, PackageScope::AllUsers, install_root) => {
+            let root = match install_root {
+                Some(root) => root,
+                None => default_install_root(os, scope, arch)?,
+            };
+            let bin_dir = default_shared_bin_dir(os, scope)?;
+            InstallLayout::from_parts(os, root.clone(), bin_dir, root.join("cache"), root.join("venv"), root)
+        }
+    }
+}
+
+pub fn default_install_root(os: HostOs, scope: PackageScope, arch: HostArch) -> Result<PathBuf> {
+    match (os, scope) {
+        (HostOs::Windows, PackageScope::CurrentUser) => {
+            let base = env::var_os("LOCALAPPDATA").map(PathBuf::from).ok_or_else(|| {
+                MultiPwshError::InvalidArguments(
+                    "LOCALAPPDATA is not defined; unable to determine current-user package install root".to_string(),
+                )
+            })?;
+            Ok(base.join("PowerShell"))
+        }
+        (HostOs::Windows, PackageScope::AllUsers) => {
+            let key = if arch == HostArch::X86 {
+                "ProgramFiles(x86)"
+            } else {
+                "ProgramFiles"
+            };
+
+            let base = env::var_os(key)
+                .or_else(|| env::var_os("ProgramFiles"))
+                .map(PathBuf::from)
+                .ok_or_else(|| {
+                    MultiPwshError::InvalidArguments(format!(
+                        "{} is not defined; unable to determine all-users package install root",
+                        key
+                    ))
+                })?;
+            Ok(base.join("PowerShell"))
+        }
+        (HostOs::Macos, PackageScope::CurrentUser) | (HostOs::Linux, PackageScope::CurrentUser) => Ok(home_dir()
+            .ok_or_else(|| {
+                MultiPwshError::InvalidArguments(
+                    "HOME is not defined; unable to determine current-user package install root".to_string(),
+                )
+            })?
+            .join(".pwsh")),
+        (HostOs::Macos, PackageScope::AllUsers) => Ok(PathBuf::from("/usr/local/microsoft/powershell")),
+        (HostOs::Linux, PackageScope::AllUsers) => Ok(PathBuf::from("/opt/microsoft/powershell")),
+    }
+}
+
+fn default_shared_bin_dir(os: HostOs, scope: PackageScope) -> Result<PathBuf> {
+    match (os, scope) {
+        (HostOs::Windows, _) => Err(MultiPwshError::Host(
+            "default_shared_bin_dir is only used for Unix scope layouts".to_string(),
+        )),
+        (HostOs::Macos | HostOs::Linux, PackageScope::CurrentUser) => {
+            Ok(default_install_root(os, PackageScope::CurrentUser, HostArch::detect())?.join("bin"))
+        }
+        (HostOs::Macos | HostOs::Linux, PackageScope::AllUsers) => Ok(PathBuf::from("/usr/local/bin")),
+    }
+}
+
+pub fn load_package_metadata(layout: &InstallLayout) -> Result<PackageMetadata> {
+    let path = package_metadata_file(layout);
+    if !path.exists() {
+        return Ok(PackageMetadata::default());
+    }
+
+    let content = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&content)?)
+}
+
+pub fn save_package_metadata(layout: &InstallLayout, metadata: &PackageMetadata) -> Result<()> {
+    let path = package_metadata_file(layout);
+    let payload = serde_json::to_string_pretty(metadata)?;
+    fs::write(path, payload)?;
+    Ok(())
+}
+
+pub fn package_metadata_file(layout: &InstallLayout) -> PathBuf {
+    layout.home().join(PACKAGE_METADATA_FILE)
+}
+
+pub fn persist_installer_properties(
+    layout: &InstallLayout,
+    scope: PackageScope,
+    version: &Version,
+    options: &PackageInstallOptions,
+) -> Result<()> {
+    if layout.os() != HostOs::Windows {
+        return Ok(());
+    }
+
+    let key_path = format!(
+        r"{}\Software\Microsoft\PowerShellCore\{}",
+        scope.registry_drive(),
+        installer_properties_key(version)
+    );
+    let install_root = layout.home().display().to_string();
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         $key = {key}; \
+         New-Item -Path $key -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'InstallFolder' -Value {install_root} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'AddToPath' -Value {add_path} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'RegisterManifest' -Value {register_manifest} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'EnablePSRemoting' -Value {enable_psremoting} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'DisableTelemetry' -Value {disable_telemetry} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'AddExplorerContextMenuOpenPowerShell' -Value {add_explorer} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'AddFileContextMenuRunPowerShell' -Value {add_file} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'UseMU' -Value {use_mu} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'EnableMU' -Value {enable_mu} -PropertyType String -Force | Out-Null",
+        key = ps_literal(&key_path),
+        install_root = ps_literal(&install_root),
+        add_path = ps_literal(bool_property(options.add_path)),
+        register_manifest = ps_literal(bool_property(options.register_manifest)),
+        enable_psremoting = ps_literal(bool_property(options.enable_psremoting)),
+        disable_telemetry = ps_literal(bool_property(options.disable_telemetry)),
+        add_explorer = ps_literal(bool_property(options.add_explorer_context_menu)),
+        add_file = ps_literal(bool_property(options.add_file_context_menu)),
+        use_mu = ps_literal(bool_property(options.use_mu)),
+        enable_mu = ps_literal(bool_property(options.enable_mu)),
+    );
+
+    execute_windows_powershell(&script, "persist installer properties")
+}
+
+pub fn persist_installed_version_registration(
+    scope: PackageScope,
+    version: &Version,
+    executable_path: &Path,
+) -> Result<()> {
+    if cfg!(not(windows)) {
+        return Ok(());
+    }
+
+    let install_dir = executable_path
+        .parent()
+        .ok_or_else(|| MultiPwshError::Host("installed executable path had no parent directory".to_string()))?;
+    let key_path = installed_version_registry_path(scope, version);
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         $key = {key}; \
+         New-Item -Path $key -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'SemanticVersion' -Value {version} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'InstallLocation' -Value {install_dir} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'ExecutablePath' -Value {exe} -PropertyType String -Force | Out-Null",
+        key = ps_literal(&key_path),
+        version = ps_literal(&version.to_string()),
+        install_dir = ps_literal(&install_dir.display().to_string()),
+        exe = ps_literal(&executable_path.display().to_string()),
+    );
+
+    execute_windows_powershell(&script, "persist installed version registration")
+}
+
+pub fn remove_installed_version_registration(scope: PackageScope, version: &Version) -> Result<()> {
+    if cfg!(not(windows)) {
+        return Ok(());
+    }
+
+    let key_path = installed_version_registry_path(scope, version);
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         if (Test-Path -Path {key}) {{ Remove-Item -Path {key} -Recurse -Force }}",
+        key = ps_literal(&key_path),
+    );
+
+    execute_windows_powershell(&script, "remove installed version registration")
+}
+
+pub fn run_install_time_actions(executable_path: &Path, options: &PackageInstallOptions) -> Result<()> {
+    ensure_unix_executable_permissions(executable_path)?;
+
+    let install_dir = executable_path
+        .parent()
+        .ok_or_else(|| MultiPwshError::Host("installed executable path had no parent directory".to_string()))?;
+
+    if options.register_manifest {
+        let script_path = install_dir.join("RegisterManifest.ps1");
+        if !script_path.exists() {
+            return Err(MultiPwshError::Host(format!(
+                "register manifest was requested, but '{}' was not found",
+                script_path.display()
+            )));
+        }
+
+        run_installed_pwsh(
+            executable_path,
+            &[
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                &script_path.display().to_string(),
+            ],
+            "register event manifest",
+        )?;
+    }
+
+    if options.enable_psremoting {
+        run_installed_pwsh(
+            executable_path,
+            &[
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                "Enable-PSRemoting -Force",
+            ],
+            "enable psremoting",
+        )?;
+    }
+
+    if options.enable_mu {
+        let script_path = install_dir.join("RegisterMicrosoftUpdate.ps1");
+        if !script_path.exists() {
+            return Err(MultiPwshError::Host(format!(
+                "microsoft update registration was requested, but '{}' was not found",
+                script_path.display()
+            )));
+        }
+
+        run_installed_pwsh(
+            executable_path,
+            &[
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                &script_path.display().to_string(),
+            ],
+            "enable microsoft update registration",
+        )?;
+    }
+
+    Ok(())
+}
+
+pub fn reconcile_shared_integrations(
+    layout: &InstallLayout,
+    scope: PackageScope,
+    metadata: &PackageMetadata,
+) -> Result<()> {
+    let os = layout.os();
+    if os != HostOs::Windows {
+        return Ok(());
+    }
+
+    let resolved = metadata.resolved_records()?;
+    let primary = resolved
+        .iter()
+        .map(|record| record.executable_path(os))
+        .find(|path| path.exists());
+    let stable_primary = resolved
+        .iter()
+        .find(|record| record.version.pre.is_empty())
+        .map(|record| record.executable_path(os))
+        .filter(|path| path.exists());
+
+    sync_path_membership(
+        scope,
+        &layout.bin_dir(),
+        resolved.iter().any(|record| record.record.add_path),
+    )?;
+    sync_telemetry_opt_out(scope, resolved.iter().any(|record| record.record.disable_telemetry))?;
+
+    if let Some(primary_executable) = primary.as_ref() {
+        sync_start_menu_shortcut(scope, primary_executable)?;
+    } else {
+        remove_start_menu_shortcut(scope)?;
+    }
+
+    if resolved.iter().any(|record| record.record.add_explorer_context_menu) {
+        if let Some(primary_executable) = primary.as_ref() {
+            sync_explorer_context_menu(scope, primary_executable)?;
+        } else {
+            remove_explorer_context_menu(scope)?;
+        }
+    } else {
+        remove_explorer_context_menu(scope)?;
+    }
+
+    if resolved.iter().any(|record| record.record.add_file_context_menu) {
+        if let Some(primary_executable) = primary.as_ref() {
+            sync_file_context_menu(scope, primary_executable)?;
+        } else {
+            remove_file_context_menu(scope)?;
+        }
+    } else {
+        remove_file_context_menu(scope)?;
+    }
+
+    if let Some(stable_executable) = stable_primary.as_ref() {
+        sync_app_path(scope, stable_executable)?;
+    } else {
+        remove_app_path(scope)?;
+    }
+
+    Ok(())
+}
+
+fn installed_version_registry_path(scope: PackageScope, version: &Version) -> String {
+    format!(
+        r"{}\Software\Microsoft\PowerShellCore\InstalledVersions\multi-pwsh\{}",
+        scope.registry_drive(),
+        version
+    )
+}
+
+fn installer_properties_key(version: &Version) -> &'static str {
+    if version.pre.is_empty() {
+        "InstallerProperties"
+    } else {
+        "PreviewInstallerProperties"
+    }
+}
+
+fn bool_property(enabled: bool) -> &'static str {
+    if enabled {
+        "1"
+    } else {
+        "0"
+    }
+}
+
+fn ensure_unix_executable_permissions(executable_path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let metadata = fs::metadata(executable_path)?;
+        let mut permissions = metadata.permissions();
+        let mode = permissions.mode();
+        let desired_mode = mode | 0o755;
+        if desired_mode != mode {
+            permissions.set_mode(desired_mode);
+            fs::set_permissions(executable_path, permissions)?;
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = executable_path;
+    }
+
+    Ok(())
+}
+
+fn ps_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn run_installed_pwsh(executable_path: &Path, args: &[&str], description: &str) -> Result<()> {
+    let output = Command::new(executable_path).args(args).output()?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() { stderr } else { stdout };
+
+    Err(MultiPwshError::Host(format!(
+        "{} failed for '{}': {}",
+        description,
+        executable_path.display(),
+        detail
+    )))
+}
+
+fn execute_windows_powershell(script: &str, description: &str) -> Result<()> {
+    if cfg!(not(windows)) {
+        return Ok(());
+    }
+
+    let output = Command::new("powershell.exe")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+        ])
+        .output()?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() { stderr } else { stdout };
+
+    Err(MultiPwshError::Host(format!("{} failed: {}", description, detail)))
+}
+
+fn sync_path_membership(scope: PackageScope, bin_dir: &Path, enabled: bool) -> Result<()> {
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         $target = {target}; \
+         $scope = [System.EnvironmentVariableTarget]::{scope_name}; \
+         $current = [System.Environment]::GetEnvironmentVariable('PATH', $scope); \
+         $parts = @(); \
+         if (-not [string]::IsNullOrWhiteSpace($current)) {{ $parts = @($current -split [System.IO.Path]::PathSeparator | Where-Object {{ -not [string]::IsNullOrWhiteSpace($_) }}) }}; \
+         $normalizedTarget = $target.TrimEnd([System.IO.Path]::DirectorySeparatorChar); \
+         $filtered = @($parts | Where-Object {{ $_.TrimEnd([System.IO.Path]::DirectorySeparatorChar) -ne $normalizedTarget }}); \
+         if ({enabled}) {{ $filtered += $target }}; \
+         $newValue = if ($filtered.Count -eq 0) {{ $null }} else {{ ($filtered -join [System.IO.Path]::PathSeparator) }}; \
+         [System.Environment]::SetEnvironmentVariable('PATH', $newValue, $scope)",
+        target = ps_literal(&bin_dir.display().to_string()),
+        scope_name = scope.registry_target_name(),
+        enabled = if enabled { "$true" } else { "$false" },
+    );
+
+    execute_windows_powershell(&script, "update PATH")
+}
+
+fn sync_telemetry_opt_out(scope: PackageScope, enabled: bool) -> Result<()> {
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         $scope = [System.EnvironmentVariableTarget]::{scope_name}; \
+         $value = if ({enabled}) {{ '1' }} else {{ $null }}; \
+         [System.Environment]::SetEnvironmentVariable('POWERSHELL_TELEMETRY_OPTOUT', $value, $scope)",
+        scope_name = scope.registry_target_name(),
+        enabled = if enabled { "$true" } else { "$false" },
+    );
+
+    execute_windows_powershell(&script, "update POWERSHELL_TELEMETRY_OPTOUT")
+}
+
+fn sync_app_path(scope: PackageScope, executable_path: &Path) -> Result<()> {
+    let install_dir = executable_path
+        .parent()
+        .ok_or_else(|| MultiPwshError::Host("installed executable path had no parent directory".to_string()))?;
+    let key_path = format!(
+        r"{}\Software\Microsoft\Windows\CurrentVersion\App Paths\pwsh.exe",
+        scope.registry_drive()
+    );
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         $key = {key}; \
+         New-Item -Path $key -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name '(default)' -Value {exe} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path $key -Name 'Path' -Value {path_value} -PropertyType String -Force | Out-Null",
+        key = ps_literal(&key_path),
+        exe = ps_literal(&executable_path.display().to_string()),
+        path_value = ps_literal(&install_dir.display().to_string()),
+    );
+
+    execute_windows_powershell(&script, "update App Paths")
+}
+
+fn remove_app_path(scope: PackageScope) -> Result<()> {
+    let key_path = format!(
+        r"{}\Software\Microsoft\Windows\CurrentVersion\App Paths\pwsh.exe",
+        scope.registry_drive()
+    );
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         if (Test-Path -Path {key}) {{ Remove-Item -Path {key} -Recurse -Force }}",
+        key = ps_literal(&key_path),
+    );
+
+    execute_windows_powershell(&script, "remove App Paths entry")
+}
+
+fn sync_start_menu_shortcut(scope: PackageScope, executable_path: &Path) -> Result<()> {
+    let shortcut_dir = scope.start_menu_programs_dir()?;
+    let link_path = shortcut_dir.join("PowerShell.lnk");
+    let description = format!(
+        "PowerShell {}",
+        executable_path
+            .parent()
+            .and_then(|path| path.file_name())
+            .map(|value| value.to_string_lossy().to_string())
+            .unwrap_or_else(|| "package".to_string())
+    );
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         $dir = {dir}; \
+         $link = {link}; \
+         New-Item -Path $dir -ItemType Directory -Force | Out-Null; \
+         $shell = New-Object -ComObject WScript.Shell; \
+         $shortcut = $shell.CreateShortcut($link); \
+         $shortcut.TargetPath = {exe}; \
+         $shortcut.Arguments = '-WorkingDirectory ~'; \
+         $shortcut.Description = {description}; \
+         $shortcut.IconLocation = {exe}; \
+         $shortcut.Save()",
+        dir = ps_literal(&shortcut_dir.display().to_string()),
+        link = ps_literal(&link_path.display().to_string()),
+        exe = ps_literal(&executable_path.display().to_string()),
+        description = ps_literal(&description),
+    );
+
+    execute_windows_powershell(&script, "update Start Menu shortcut")
+}
+
+fn remove_start_menu_shortcut(scope: PackageScope) -> Result<()> {
+    let shortcut_dir = scope.start_menu_programs_dir()?;
+    let link_path = shortcut_dir.join("PowerShell.lnk");
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         if (Test-Path -Path {link}) {{ Remove-Item -Path {link} -Force }}; \
+         if (Test-Path -Path {dir}) {{ \
+            $remaining = @(Get-ChildItem -Path {dir} -Force -ErrorAction SilentlyContinue); \
+            if ($remaining.Count -eq 0) {{ Remove-Item -Path {dir} -Force }} \
+         }}",
+        link = ps_literal(&link_path.display().to_string()),
+        dir = ps_literal(&shortcut_dir.display().to_string()),
+    );
+
+    execute_windows_powershell(&script, "remove Start Menu shortcut")
+}
+
+fn sync_explorer_context_menu(scope: PackageScope, executable_path: &Path) -> Result<()> {
+    let base = scope.classes_root();
+    let title = format!(
+        "Open PowerShell here ({})",
+        executable_path
+            .parent()
+            .and_then(|path| path.file_name())
+            .map(|value| value.to_string_lossy().to_string())
+            .unwrap_or_else(|| "PowerShell".to_string())
+    );
+    let command = format!(
+        "\"{}\" -NoExit -Command \"Set-Location -LiteralPath '%V'\"",
+        executable_path.display()
+    );
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         $paths = @({background}, {directory}, {drive}); \
+         foreach ($path in $paths) {{ \
+            New-Item -Path $path -Force | Out-Null; \
+            New-ItemProperty -Path $path -Name 'MUIVerb' -Value {title} -PropertyType String -Force | Out-Null; \
+            New-ItemProperty -Path $path -Name 'Icon' -Value {exe} -PropertyType String -Force | Out-Null; \
+            $commandKey = Join-Path $path 'command'; \
+            New-Item -Path $commandKey -Force | Out-Null; \
+            New-ItemProperty -Path $commandKey -Name '(default)' -Value {command} -PropertyType String -Force | Out-Null \
+         }}",
+        background = ps_literal(&format!(r"{}\Directory\Background\shell\{}", base, EXPLORER_CONTEXT_MENU_KEY)),
+        directory = ps_literal(&format!(r"{}\Directory\shell\{}", base, EXPLORER_CONTEXT_MENU_KEY)),
+        drive = ps_literal(&format!(r"{}\Drive\shell\{}", base, EXPLORER_CONTEXT_MENU_KEY)),
+        title = ps_literal(&title),
+        exe = ps_literal(&executable_path.display().to_string()),
+        command = ps_literal(&command),
+    );
+
+    execute_windows_powershell(&script, "update Explorer context menu")
+}
+
+fn remove_explorer_context_menu(scope: PackageScope) -> Result<()> {
+    let base = scope.classes_root();
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         foreach ($path in @({background}, {directory}, {drive})) {{ \
+            if (Test-Path -Path $path) {{ Remove-Item -Path $path -Recurse -Force }} \
+         }}",
+        background = ps_literal(&format!(
+            r"{}\Directory\Background\shell\{}",
+            base, EXPLORER_CONTEXT_MENU_KEY
+        )),
+        directory = ps_literal(&format!(r"{}\Directory\shell\{}", base, EXPLORER_CONTEXT_MENU_KEY)),
+        drive = ps_literal(&format!(r"{}\Drive\shell\{}", base, EXPLORER_CONTEXT_MENU_KEY)),
+    );
+
+    execute_windows_powershell(&script, "remove Explorer context menu")
+}
+
+fn sync_file_context_menu(scope: PackageScope, executable_path: &Path) -> Result<()> {
+    let base = scope.classes_root();
+    let title = format!(
+        "Run with PowerShell ({})",
+        executable_path
+            .parent()
+            .and_then(|path| path.file_name())
+            .map(|value| value.to_string_lossy().to_string())
+            .unwrap_or_else(|| "PowerShell".to_string())
+    );
+    let command = format!("\"{}\" -File \"%1\"", executable_path.display());
+    let key = format!(r"{}\Microsoft.PowerShellScript.1\Shell\{}", base, FILE_CONTEXT_MENU_KEY);
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         New-Item -Path {key} -Force | Out-Null; \
+         New-ItemProperty -Path {key} -Name 'MUIVerb' -Value {title} -PropertyType String -Force | Out-Null; \
+         New-ItemProperty -Path {key} -Name 'Icon' -Value {exe} -PropertyType String -Force | Out-Null; \
+         $commandKey = Join-Path {key} 'command'; \
+         New-Item -Path $commandKey -Force | Out-Null; \
+         New-ItemProperty -Path $commandKey -Name '(default)' -Value {command} -PropertyType String -Force | Out-Null",
+        key = ps_literal(&key),
+        title = ps_literal(&title),
+        exe = ps_literal(&executable_path.display().to_string()),
+        command = ps_literal(&command),
+    );
+
+    execute_windows_powershell(&script, "update PowerShell file context menu")
+}
+
+fn remove_file_context_menu(scope: PackageScope) -> Result<()> {
+    let base = scope.classes_root();
+    let key = format!(r"{}\Microsoft.PowerShellScript.1\Shell\{}", base, FILE_CONTEXT_MENU_KEY);
+    let script = format!(
+        "$ErrorActionPreference = 'Stop'; \
+         if (Test-Path -Path {key}) {{ Remove-Item -Path {key} -Recurse -Force }}",
+        key = ps_literal(&key),
+    );
+
+    execute_windows_powershell(&script, "remove PowerShell file context menu")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_scope_parses_aliases() {
+        assert_eq!(PackageScope::parse("current-user"), Some(PackageScope::CurrentUser));
+        assert_eq!(PackageScope::parse("CurrentUser"), Some(PackageScope::CurrentUser));
+        assert_eq!(PackageScope::parse("all-users"), Some(PackageScope::AllUsers));
+        assert_eq!(PackageScope::parse("AllUsers"), Some(PackageScope::AllUsers));
+        assert_eq!(PackageScope::parse("machine"), Some(PackageScope::AllUsers));
+    }
+
+    #[test]
+    fn current_user_defaults_disable_machine_actions() {
+        let options = PackageInstallOptions::with_defaults(PackageScope::CurrentUser);
+        assert!(!options.register_manifest);
+        assert!(!options.use_mu);
+        assert!(!options.enable_mu);
+    }
+
+    #[test]
+    fn validate_rejects_microsoft_update_flags_for_archive_installs() {
+        let mut options = PackageInstallOptions::with_defaults(PackageScope::AllUsers);
+        options.use_mu = true;
+
+        let error = options.validate(HostOs::Windows).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Microsoft Update integration is not supported for archive installs yet"));
+    }
+
+    #[test]
+    fn all_users_unix_defaults_disable_windows_integrations() {
+        let options = PackageInstallOptions::with_platform_defaults(PackageScope::AllUsers, HostOs::Linux);
+        assert!(!options.register_manifest);
+        assert!(!options.use_mu);
+        assert!(!options.enable_mu);
+    }
+
+    #[test]
+    fn validate_rejects_windows_only_flags_on_unix() {
+        let mut options = PackageInstallOptions::with_platform_defaults(PackageScope::AllUsers, HostOs::Linux);
+        options.enable_psremoting = true;
+
+        let error = options.validate(HostOs::Linux).unwrap_err();
+        assert!(error.to_string().contains("supported only on Windows"));
+    }
+
+    #[test]
+    fn metadata_upsert_replaces_existing_version() {
+        let layout = InstallLayout::from_root_with_versions_dir(
+            HostOs::Windows,
+            PathBuf::from(r"C:\PowerShell"),
+            PathBuf::from(r"C:\PowerShell"),
+        )
+        .unwrap();
+        let version = Version::parse("7.4.13").unwrap();
+        let mut metadata = PackageMetadata::default();
+        let mut options = PackageInstallOptions::with_defaults(PackageScope::AllUsers);
+        options.disable_telemetry = true;
+
+        metadata.upsert_install(&version, &layout, &options);
+        assert_eq!(metadata.installs().len(), 1);
+        assert!(metadata.installs()[0].disable_telemetry);
+        assert_eq!(metadata.installs()[0].install_dir, r"C:\PowerShell\7.4.13");
+
+        options.disable_telemetry = false;
+        metadata.upsert_install(&version, &layout, &options);
+        assert_eq!(metadata.installs().len(), 1);
+        assert!(!metadata.installs()[0].disable_telemetry);
+    }
+
+    #[test]
+    fn resolved_records_sort_descending() {
+        let metadata = PackageMetadata {
+            installs: vec![
+                PackageInstallRecord {
+                    version: "7.4.12".to_string(),
+                    install_dir: r"C:\PowerShell\7.4.12".to_string(),
+                    add_path: true,
+                    register_manifest: true,
+                    enable_psremoting: false,
+                    disable_telemetry: false,
+                    add_explorer_context_menu: false,
+                    add_file_context_menu: false,
+                    use_mu: true,
+                    enable_mu: true,
+                },
+                PackageInstallRecord {
+                    version: "7.5.0".to_string(),
+                    install_dir: r"C:\PowerShell\7.5.0".to_string(),
+                    add_path: true,
+                    register_manifest: true,
+                    enable_psremoting: false,
+                    disable_telemetry: false,
+                    add_explorer_context_menu: false,
+                    add_file_context_menu: false,
+                    use_mu: true,
+                    enable_mu: true,
+                },
+            ],
+        };
+
+        let resolved = metadata.resolved_records().unwrap();
+        assert_eq!(resolved[0].version, Version::parse("7.5.0").unwrap());
+        assert_eq!(resolved[1].version, Version::parse("7.4.12").unwrap());
+    }
+
+    #[test]
+    fn package_layout_uses_direct_version_root() {
+        let layout = package_layout(
+            HostOs::Windows,
+            HostArch::X64,
+            PackageScope::AllUsers,
+            Some(PathBuf::from(r"C:\PowerShell")),
+        )
+        .unwrap();
+
+        assert_eq!(layout.home(), Path::new(r"C:\PowerShell"));
+        assert_eq!(layout.bin_dir(), PathBuf::from(r"C:\PowerShell\bin"));
+        assert_eq!(layout.versions_dir(), PathBuf::from(r"C:\PowerShell"));
+        assert_eq!(
+            layout.version_install_dir(&Version::parse("7.4.13").unwrap()),
+            PathBuf::from(r"C:\PowerShell\7.4.13")
+        );
+    }
+
+    #[test]
+    fn package_layout_uses_shared_bin_for_macos_all_users() {
+        let layout = package_layout(HostOs::Macos, HostArch::Arm64, PackageScope::AllUsers, None).unwrap();
+
+        assert_eq!(layout.home(), Path::new("/usr/local/microsoft/powershell"));
+        assert_eq!(layout.bin_dir(), PathBuf::from("/usr/local/bin"));
+        assert_eq!(layout.versions_dir(), PathBuf::from("/usr/local/microsoft/powershell"));
+    }
+
+    #[test]
+    fn package_layout_uses_shared_bin_for_linux_all_users() {
+        let layout = package_layout(HostOs::Linux, HostArch::X64, PackageScope::AllUsers, None).unwrap();
+
+        assert_eq!(layout.home(), Path::new("/opt/microsoft/powershell"));
+        assert_eq!(layout.bin_dir(), PathBuf::from("/usr/local/bin"));
+        assert_eq!(layout.versions_dir(), PathBuf::from("/opt/microsoft/powershell"));
+    }
+}

--- a/crates/multi-pwsh/tests/cli_args.rs
+++ b/crates/multi-pwsh/tests/cli_args.rs
@@ -1031,3 +1031,52 @@ fn host_venv_stdin_import_module_psresourceget_keeps_get_installed_psresource_ve
         "expected stdin-driven PSResourceGet import to preserve venv-installed resource discovery"
     );
 }
+
+#[cfg(windows)]
+#[test]
+fn list_uses_explicit_root_and_scope() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let package_root = temp_dir.path().join("package-root");
+    let package_root_text = package_root.display().to_string();
+
+    let output = run_multi_pwsh(
+        &["list", "--scope", "machine", "--root", &package_root_text],
+        temp_dir.path(),
+    );
+
+    assert!(
+        output.status.success(),
+        "expected scoped list to succeed: {}",
+        normalize_output(&output.stderr)
+    );
+
+    let stdout = normalize_output(&output.stdout);
+    assert!(stdout.contains("Scope: machine"), "unexpected stdout: {}", stdout);
+    assert!(
+        stdout.contains(&package_root_text),
+        "expected package root in output: {}",
+        stdout
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn install_rejects_machine_actions_for_current_user_scope() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let output = run_multi_pwsh(
+        &["install", "7.4", "--scope", "user", "--register-manifest"],
+        temp_dir.path(),
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected install to fail for current-user manifest registration"
+    );
+
+    let stderr = normalize_output(&output.stderr);
+    assert!(
+        stderr.contains("--register-manifest requires --scope machine"),
+        "unexpected stderr: {}",
+        stderr
+    );
+}

--- a/scripts/demo/_DemoCommon.ps1
+++ b/scripts/demo/_DemoCommon.ps1
@@ -138,13 +138,7 @@ function Get-DemoBinItemPath {
     )
 
     if ($IsWindows) {
-        $exePath = Join-Path $Context.BinDir "$CommandName.exe"
-        if (Test-Path -LiteralPath $exePath) {
-            return $exePath
-        }
-
-        $cmdPath = Join-Path $Context.BinDir "$CommandName.cmd"
-        return $cmdPath
+        return (Join-Path $Context.BinDir "$CommandName.exe")
     }
 
     Join-Path $Context.BinDir $CommandName

--- a/tests/Invoke-ScopedInstallSmokeTest.ps1
+++ b/tests/Invoke-ScopedInstallSmokeTest.ps1
@@ -1,0 +1,256 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)]
+        [bool]$Condition,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-Contains {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Text,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Expected,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Context
+    )
+
+    if (-not $Text.Contains($Expected)) {
+        throw "Expected $Context to contain '$Expected'.`nActual output:`n$Text"
+    }
+}
+
+function Invoke-MultiPwsh {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+
+        [switch]$UseMachinePrivileges,
+
+        [int[]]$AllowedExitCodes = @(0)
+    )
+
+    $description = "multi-pwsh $($Arguments -join ' ')"
+
+    if ($UseMachinePrivileges -and -not $IsWindows) {
+        $output = & sudo env `
+            "PATH=${env:PATH}" `
+            "GITHUB_TOKEN=${env:GITHUB_TOKEN}" `
+            "MULTI_PWSH_CACHE_DIR=${env:MULTI_PWSH_CACHE_DIR}" `
+            "MULTI_PWSH_CACHE_KEEP=${env:MULTI_PWSH_CACHE_KEEP}" `
+            $script:MultiPwshExe @Arguments 2>&1 | Out-String
+    }
+    else {
+    $output = & $script:MultiPwshExe @Arguments 2>&1 | Out-String
+    }
+
+    $exitCode = $LASTEXITCODE
+    $output = $output.Trim()
+
+    if ($AllowedExitCodes -notcontains $exitCode) {
+        throw "Command failed with exit code ${exitCode}: $description`n$output"
+    }
+
+    $global:LASTEXITCODE = 0
+
+    [pscustomobject]@{
+        ExitCode = $exitCode
+        Output   = $output
+    }
+}
+
+function Invoke-PwshAlias {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AliasPath
+    )
+
+    $output = & $AliasPath -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()' 2>&1 | Out-String
+    $exitCode = $LASTEXITCODE
+    $output = $output.Trim()
+
+    if ($exitCode -ne 0) {
+        throw "Alias invocation failed with exit code ${exitCode}: $AliasPath`n$output"
+    }
+
+    $global:LASTEXITCODE = 0
+
+    $output
+}
+
+function Get-UserScopeRoot {
+    if ($IsWindows) {
+        Join-Path $env:LOCALAPPDATA "PowerShell"
+    }
+    else {
+        Join-Path $HOME ".pwsh"
+    }
+}
+
+function Get-UserScopeBin {
+    Join-Path (Get-UserScopeRoot) "bin"
+}
+
+function Get-MachineScopeRoot {
+    if ($IsWindows) {
+        Join-Path $env:ProgramFiles "PowerShell"
+    }
+    elseif ($IsMacOS) {
+        "/usr/local/microsoft/powershell"
+    }
+    else {
+        "/opt/microsoft/powershell"
+    }
+}
+
+function Get-MachineScopeBin {
+    if ($IsWindows) {
+        Join-Path (Get-MachineScopeRoot) "bin"
+    }
+    else {
+        "/usr/local/bin"
+    }
+}
+
+function Get-AliasPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("user", "machine")]
+        [string]$Scope,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AliasName
+    )
+
+    $binDir = if ($Scope -eq "user") { Get-UserScopeBin } else { Get-MachineScopeBin }
+    $fileName = if ($IsWindows) { "$AliasName.exe" } else { $AliasName }
+    Join-Path $binDir $fileName
+}
+
+function Assert-ListContainsVersions {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Output,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Context
+    )
+
+    foreach ($expected in @("7.4", "7.5", "7.6")) {
+        Assert-Contains -Text $Output -Expected $expected -Context $Context
+    }
+}
+
+$script:MultiPwshExe = (Get-Command multi-pwsh -CommandType Application).Source
+Assert-True -Condition ([string]::IsNullOrWhiteSpace($script:MultiPwshExe) -eq $false) -Message "multi-pwsh is not installed on PATH"
+
+$userRoot = Get-UserScopeRoot
+$userBin = Get-UserScopeBin
+$machineRoot = Get-MachineScopeRoot
+$machineBin = Get-MachineScopeBin
+
+Write-Host "multi-pwsh executable: ${script:MultiPwshExe}"
+Write-Host "User root: $userRoot"
+Write-Host "User bin: $userBin"
+Write-Host "Machine root: $machineRoot"
+Write-Host "Machine bin: $machineBin"
+
+$installMatrix = @(
+    @{ Selector = "7.4"; InstallArgs = @(); ExpectedPrefix = "7.4." },
+    @{ Selector = "7.5"; InstallArgs = @(); ExpectedPrefix = "7.5." },
+    @{ Selector = "7.6"; InstallArgs = @("--include-prerelease"); ExpectedPrefix = "7.6." }
+)
+
+foreach ($scope in @("user", "machine")) {
+    $useMachinePrivileges = ($scope -eq "machine" -and -not $IsWindows)
+
+    foreach ($install in $installMatrix) {
+        $args = @("install", $install.Selector, "--scope", $scope) + $install.InstallArgs
+        if ($scope -eq "machine" -and $IsWindows) {
+            $args += @("--no-register-manifest")
+        }
+        $result = Invoke-MultiPwsh -Arguments $args -UseMachinePrivileges:$useMachinePrivileges
+        Write-Host $result.Output
+    }
+}
+
+$userList = Invoke-MultiPwsh -Arguments @("list", "--scope", "user")
+$machineList = Invoke-MultiPwsh -Arguments @("list", "--scope", "machine") -UseMachinePrivileges:(-not $IsWindows)
+$allList = Invoke-MultiPwsh -Arguments @("list", "--scope", "all")
+
+Assert-Contains -Text $userList.Output -Expected $userRoot -Context "user scope list"
+Assert-Contains -Text $userList.Output -Expected $userBin -Context "user scope list"
+Assert-ListContainsVersions -Output $userList.Output -Context "user scope list"
+
+Assert-Contains -Text $machineList.Output -Expected $machineRoot -Context "machine scope list"
+Assert-Contains -Text $machineList.Output -Expected $machineBin -Context "machine scope list"
+Assert-ListContainsVersions -Output $machineList.Output -Context "machine scope list"
+
+Assert-Contains -Text $allList.Output -Expected $userRoot -Context "all scope list"
+Assert-Contains -Text $allList.Output -Expected $machineRoot -Context "all scope list"
+Assert-ListContainsVersions -Output $allList.Output -Context "all scope list"
+
+$resolvedVersions = @{}
+
+foreach ($scope in @("user", "machine")) {
+    $sevenSixVersion = $null
+
+    foreach ($install in $installMatrix) {
+        $lineAliasName = "pwsh-$($install.Selector)"
+        $lineAliasPath = Get-AliasPath -Scope $scope -AliasName $lineAliasName
+
+        Assert-True -Condition (Test-Path -Path $lineAliasPath) -Message "Expected alias to exist: $lineAliasPath"
+
+        $resolvedVersion = Invoke-PwshAlias -AliasPath $lineAliasPath
+        Assert-True `
+            -Condition ($resolvedVersion.StartsWith($install.ExpectedPrefix)) `
+            -Message "Expected $lineAliasPath to resolve to a version starting with $($install.ExpectedPrefix), but got $resolvedVersion"
+
+        $patchAliasName = "pwsh-$resolvedVersion"
+        $patchAliasPath = Get-AliasPath -Scope $scope -AliasName $patchAliasName
+        Assert-True -Condition (Test-Path -Path $patchAliasPath) -Message "Expected patch alias to exist: $patchAliasPath"
+
+        $patchVersion = Invoke-PwshAlias -AliasPath $patchAliasPath
+        Assert-True `
+            -Condition ($patchVersion -eq $resolvedVersion) `
+            -Message "Expected $patchAliasPath to resolve to $resolvedVersion, but got $patchVersion"
+
+        if ($install.Selector -eq "7.6") {
+            $sevenSixVersion = $resolvedVersion
+        }
+
+        $resolvedVersions["$scope-$($install.Selector)"] = $resolvedVersion
+    }
+
+    $majorAliasPath = Get-AliasPath -Scope $scope -AliasName "pwsh-7"
+    Assert-True -Condition (Test-Path -Path $majorAliasPath) -Message "Expected major alias to exist: $majorAliasPath"
+
+    $majorVersion = Invoke-PwshAlias -AliasPath $majorAliasPath
+    Assert-True `
+        -Condition ($majorVersion -eq $sevenSixVersion) `
+        -Message "Expected $majorAliasPath to resolve to $sevenSixVersion, but got $majorVersion"
+}
+
+$ambiguousVersion = $resolvedVersions["user-7.4"]
+$ambiguousUninstall = Invoke-MultiPwsh -Arguments @("uninstall", $ambiguousVersion) -AllowedExitCodes @(1)
+Assert-Contains `
+    -Text $ambiguousUninstall.Output `
+    -Expected "installed in both user and machine scopes" `
+    -Context "ambiguous uninstall output"
+
+Write-Host "Scoped install smoke test completed successfully."


### PR DESCRIPTION
## Summary
- unify `install`, `update`, `uninstall`, and `list` around cross-platform `--scope <user|machine>` behavior
- add self-managed Unix machine installs from the official PowerShell archives with one shared alias/bin directory per scope
- keep Windows archive installs MSI-like where it makes sense, while scoping Microsoft Update out for now and using `.exe`-only aliases
- add cross-platform smoke coverage plus README and demo updates for the scoped install model

## Sample commands
```powershell
multi-pwsh install 7.4
multi-pwsh install 7.5 --scope machine
multi-pwsh install 7.5 --scope machine --enable-psremoting
multi-pwsh list --scope all
pwsh-7 --version
pwsh-7.5 --version
multi-pwsh uninstall 7.5.5 --scope machine
```

`--enable-psremoting` is a Windows archive-install option; on macOS/Linux the scoped surface is intentionally narrower.

## Machine-scoped install model
Machine-scoped installs remain self-managed by `multi-pwsh`: they use PowerShell archives, not MSI/Homebrew/apt/rpm/snap delegation. Each scope gets one stable alias/bin directory, so `PATH` only needs one entry per scope while exact versions remain side-by-side under the install root.

### Windows
- payload root: `C:\Program Files\PowerShell`
- version directories: `C:\Program Files\PowerShell\7.4.14`, `C:\Program Files\PowerShell\7.5.5`, ...
- shared alias directory: `C:\Program Files\PowerShell\bin`
- alias forms: `pwsh-7.exe`, `pwsh-7.4.exe`, `pwsh-7.4.14.exe`
- archive-friendly integration options supported: PATH, manifest registration, PSRemoting, telemetry opt-out, Explorer/file context menus

### macOS
- payload root: `/usr/local/microsoft/powershell`
- version directories: `/usr/local/microsoft/powershell/7.4.14`, `/usr/local/microsoft/powershell/7.5.5`, ...
- shared alias directory: `/usr/local/bin`
- uses official `.tar.gz` archives
- caller supplies elevation; `multi-pwsh` does not invoke `sudo`

### Linux
- payload root: `/opt/microsoft/powershell`
- version directories: `/opt/microsoft/powershell/7.4.14`, `/opt/microsoft/powershell/7.5.5`, ...
- shared alias directory: `/usr/local/bin`
- uses official `.tar.gz` archives
- caller supplies elevation; `multi-pwsh` does not invoke `sudo`

## Behavior notes
- `user` remains the default when `--scope` is omitted
- `list --scope all` spans both scopes
- when the same exact version exists in both scopes, uninstall/list flows can require explicit `--scope` to disambiguate
- legacy values such as `current-user` and `all-users` are still accepted for compatibility, but the primary CLI surface is now `user` / `machine`

## Verification
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj`
- `dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build`
- GitHub Actions `CI`
- GitHub Actions `Smoke tests`