### PR TITLE
Add checksum verification for release installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +120,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cstr"
@@ -122,6 +150,16 @@ dependencies = [
  "bitflags 1.3.2",
  "cc",
  "libc",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -220,6 +258,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -527,6 +575,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "tempfile",
  "thiserror",
@@ -894,6 +943,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1136,12 @@ name = "toml_writer"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "u16cstr"

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -21,6 +21,7 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 home = "0.5"
 tempfile = "3.12"
 pwsh-host = { path = "../pwsh-host" }
+sha2 = "0.10"
 
 [build-dependencies]
 winresource = "0.1"

--- a/crates/multi-pwsh/src/install.rs
+++ b/crates/multi-pwsh/src/install.rs
@@ -1,11 +1,12 @@
 use std::fs;
 use std::fs::File;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::Duration;
 
 use flate2::read::GzDecoder;
+use sha2::{Digest, Sha256};
 use ureq::Agent;
 
 use crate::error::{MultiPwshError, Result};
@@ -37,6 +38,8 @@ pub fn ensure_installed(
     if !archive_path.exists() {
         download_with_retry(http, &release.asset_url, &archive_path, 8)?;
     }
+
+    validate_archive_checksum(http, release, &archive_path)?;
 
     extract_archive(&archive_path, &install_dir)?;
 
@@ -85,6 +88,109 @@ fn download_with_retry(http: &Agent, url: &str, destination: &Path, retries: usi
     }
 
     Err(last_error.unwrap_or_else(|| MultiPwshError::Archive("download failed without detailed error".to_string())))
+}
+
+fn download_text_with_retry(http: &Agent, url: &str, retries: usize) -> Result<String> {
+    let mut last_error = None;
+
+    for attempt in 1..=retries {
+        let result = (|| -> Result<String> {
+            let response = http.get(url).set("User-Agent", "multi-pwsh").call()?;
+            Ok(response.into_string()?)
+        })();
+
+        match result {
+            Ok(body) => return Ok(body),
+            Err(error) => {
+                last_error = Some(error);
+                if attempt < retries {
+                    let delay_seconds = 2u64.pow(attempt as u32);
+                    thread::sleep(Duration::from_secs(delay_seconds.min(30)));
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| MultiPwshError::Archive("download failed without detailed error".to_string())))
+}
+
+fn validate_archive_checksum(http: &Agent, release: &ResolvedRelease, archive_path: &Path) -> Result<()> {
+    let checksums = download_text_with_retry(http, &release.checksum_asset_url, 8)?;
+    let expected = find_expected_checksum(&checksums, &release.asset_name)?;
+    let actual = sha256_file(archive_path)?;
+
+    if expected.eq_ignore_ascii_case(&actual) {
+        return Ok(());
+    }
+
+    let _ = fs::remove_file(archive_path);
+    Err(MultiPwshError::Archive(format!(
+        "checksum mismatch for '{}' using '{}': expected {}, got {}",
+        release.asset_name, release.checksum_asset_name, expected, actual
+    )))
+}
+
+fn find_expected_checksum(checksums: &str, asset_name: &str) -> Result<String> {
+    for (index, line) in checksums.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let checksum = trimmed
+            .split_ascii_whitespace()
+            .next()
+            .ok_or_else(|| MultiPwshError::Archive(format!("malformed checksum line {}", index + 1)))?;
+
+        if !is_valid_sha256_hex(checksum) {
+            return Err(MultiPwshError::Archive(format!(
+                "invalid sha256 checksum on line {}",
+                index + 1
+            )));
+        }
+
+        let file_name = trimmed[checksum.len()..].trim_start().trim_start_matches('*');
+        if file_name.is_empty() {
+            return Err(MultiPwshError::Archive(format!(
+                "missing file name in checksum line {}",
+                index + 1
+            )));
+        }
+
+        if file_name == asset_name {
+            return Ok(checksum.to_ascii_lowercase());
+        }
+    }
+
+    Err(MultiPwshError::Archive(format!(
+        "checksum entry for '{}' not found in checksum file",
+        asset_name
+    )))
+}
+
+fn is_valid_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.as_bytes().iter().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 8192];
+
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    let digest = hasher.finalize();
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        output.push_str(&format!("{:02x}", byte));
+    }
+    Ok(output)
 }
 
 fn cache_keep_archives() -> bool {
@@ -237,5 +343,58 @@ mod tests {
         with_cache_keep(Some("false"), || {
             assert!(!cache_keep_archives());
         });
+    }
+
+    #[test]
+    fn find_expected_checksum_accepts_common_sha256_formats() {
+        let checksum = find_expected_checksum(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  PowerShell-7.4.13-win-x64.zip\n\
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb *other.zip",
+            "PowerShell-7.4.13-win-x64.zip",
+        )
+        .unwrap();
+
+        assert_eq!(
+            checksum,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+
+    #[test]
+    fn find_expected_checksum_rejects_invalid_lines() {
+        let error = find_expected_checksum(
+            "not-a-hash  PowerShell-7.4.13-win-x64.zip",
+            "PowerShell-7.4.13-win-x64.zip",
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("invalid sha256 checksum"));
+    }
+
+    #[test]
+    fn find_expected_checksum_requires_matching_asset() {
+        let error = find_expected_checksum(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  other.zip",
+            "PowerShell-7.4.13-win-x64.zip",
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("checksum entry for 'PowerShell-7.4.13-win-x64.zip' not found"));
+    }
+
+    #[test]
+    fn sha256_file_hashes_file_contents() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("sample.txt");
+        fs::write(&path, b"abc").unwrap();
+
+        let digest = sha256_file(&path).unwrap();
+
+        assert_eq!(
+            digest,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
     }
 }

--- a/crates/multi-pwsh/src/install.rs
+++ b/crates/multi-pwsh/src/install.rs
@@ -96,7 +96,10 @@ fn download_text_with_retry(http: &Agent, url: &str, retries: usize) -> Result<S
     for attempt in 1..=retries {
         let result = (|| -> Result<String> {
             let response = http.get(url).set("User-Agent", "multi-pwsh").call()?;
-            Ok(response.into_string()?)
+            let mut reader = response.into_reader();
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes)?;
+            decode_checksum_text(&bytes)
         })();
 
         match result {
@@ -112,6 +115,85 @@ fn download_text_with_retry(http: &Agent, url: &str, retries: usize) -> Result<S
     }
 
     Err(last_error.unwrap_or_else(|| MultiPwshError::Archive("download failed without detailed error".to_string())))
+}
+
+fn decode_checksum_text(bytes: &[u8]) -> Result<String> {
+    match detect_text_encoding(bytes) {
+        TextEncoding::Utf8 => String::from_utf8(bytes.to_vec()).map_err(invalid_checksum_encoding),
+        TextEncoding::Utf8Bom => String::from_utf8(bytes[3..].to_vec()).map_err(invalid_checksum_encoding),
+        TextEncoding::Utf16Le => decode_utf16_text(&bytes[2..], true),
+        TextEncoding::Utf16Be => decode_utf16_text(&bytes[2..], false),
+        TextEncoding::Utf16LeNoBom => decode_utf16_text(bytes, true),
+        TextEncoding::Utf16BeNoBom => decode_utf16_text(bytes, false),
+    }
+}
+
+fn decode_utf16_text(bytes: &[u8], little_endian: bool) -> Result<String> {
+    if bytes.len() % 2 != 0 {
+        return Err(MultiPwshError::Archive(
+            "invalid checksum file encoding: odd-length utf-16 payload".to_string(),
+        ));
+    }
+
+    let units: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|chunk| {
+            if little_endian {
+                u16::from_le_bytes([chunk[0], chunk[1]])
+            } else {
+                u16::from_be_bytes([chunk[0], chunk[1]])
+            }
+        })
+        .collect();
+
+    String::from_utf16(&units)
+        .map_err(|error| MultiPwshError::Archive(format!("invalid checksum file encoding: {}", error)))
+}
+
+fn invalid_checksum_encoding(error: std::string::FromUtf8Error) -> MultiPwshError {
+    MultiPwshError::Archive(format!("invalid checksum file encoding: {}", error))
+}
+
+fn detect_text_encoding(bytes: &[u8]) -> TextEncoding {
+    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        return TextEncoding::Utf8Bom;
+    }
+
+    if bytes.starts_with(&[0xFF, 0xFE]) {
+        return TextEncoding::Utf16Le;
+    }
+
+    if bytes.starts_with(&[0xFE, 0xFF]) {
+        return TextEncoding::Utf16Be;
+    }
+
+    if looks_like_utf16_le(bytes) {
+        return TextEncoding::Utf16LeNoBom;
+    }
+
+    if looks_like_utf16_be(bytes) {
+        return TextEncoding::Utf16BeNoBom;
+    }
+
+    TextEncoding::Utf8
+}
+
+fn looks_like_utf16_le(bytes: &[u8]) -> bool {
+    bytes.len() >= 4 && bytes[1] == 0 && bytes[3] == 0
+}
+
+fn looks_like_utf16_be(bytes: &[u8]) -> bool {
+    bytes.len() >= 4 && bytes[0] == 0 && bytes[2] == 0
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TextEncoding {
+    Utf8,
+    Utf8Bom,
+    Utf16Le,
+    Utf16Be,
+    Utf16LeNoBom,
+    Utf16BeNoBom,
 }
 
 fn validate_archive_checksum(http: &Agent, release: &ResolvedRelease, archive_path: &Path) -> Result<()> {
@@ -132,33 +214,10 @@ fn validate_archive_checksum(http: &Agent, release: &ResolvedRelease, archive_pa
 
 fn find_expected_checksum(checksums: &str, asset_name: &str) -> Result<String> {
     for (index, line) in checksums.lines().enumerate() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        let checksum = trimmed
-            .split_ascii_whitespace()
-            .next()
-            .ok_or_else(|| MultiPwshError::Archive(format!("malformed checksum line {}", index + 1)))?;
-
-        if !is_valid_sha256_hex(checksum) {
-            return Err(MultiPwshError::Archive(format!(
-                "invalid sha256 checksum on line {}",
-                index + 1
-            )));
-        }
-
-        let file_name = trimmed[checksum.len()..].trim_start().trim_start_matches('*');
-        if file_name.is_empty() {
-            return Err(MultiPwshError::Archive(format!(
-                "missing file name in checksum line {}",
-                index + 1
-            )));
-        }
-
-        if file_name == asset_name {
-            return Ok(checksum.to_ascii_lowercase());
+        if let Some((checksum, file_name)) = parse_checksum_line(line, index + 1, asset_name)? {
+            if file_name == asset_name {
+                return Ok(checksum);
+            }
         }
     }
 
@@ -170,6 +229,81 @@ fn find_expected_checksum(checksums: &str, asset_name: &str) -> Result<String> {
 
 fn is_valid_sha256_hex(value: &str) -> bool {
     value.len() == 64 && value.as_bytes().iter().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn parse_checksum_line<'a>(
+    line: &'a str,
+    line_number: usize,
+    target_asset_name: &str,
+) -> Result<Option<(String, &'a str)>> {
+    let trimmed = line.trim().trim_start_matches('\u{feff}');
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return Ok(None);
+    }
+
+    if let Some(parsed) = parse_bsd_checksum_line(trimmed, line_number)? {
+        return Ok(Some(parsed));
+    }
+
+    parse_gnu_checksum_line(trimmed, line_number, target_asset_name)
+}
+
+fn parse_bsd_checksum_line<'a>(line: &'a str, line_number: usize) -> Result<Option<(String, &'a str)>> {
+    let Some((left, right)) = line.split_once('=') else {
+        return Ok(None);
+    };
+
+    let Some(file_name) = left
+        .trim()
+        .strip_prefix("SHA256 (")
+        .and_then(|value| value.strip_suffix(')'))
+    else {
+        return Ok(None);
+    };
+
+    let checksum = right.trim();
+    if !is_valid_sha256_hex(checksum) {
+        return Err(MultiPwshError::Archive(format!(
+            "invalid sha256 checksum on line {}",
+            line_number
+        )));
+    }
+
+    Ok(Some((checksum.to_ascii_lowercase(), file_name)))
+}
+
+fn parse_gnu_checksum_line<'a>(
+    line: &'a str,
+    line_number: usize,
+    target_asset_name: &str,
+) -> Result<Option<(String, &'a str)>> {
+    let mut parts = line.split_ascii_whitespace();
+    let Some(checksum) = parts.next() else {
+        return Ok(None);
+    };
+
+    let remainder = line[checksum.len()..].trim_start();
+    if remainder.is_empty() {
+        return Ok(None);
+    }
+
+    let file_name = remainder.trim_start_matches('*').trim();
+    if file_name.is_empty() {
+        return Ok(None);
+    }
+
+    if !is_valid_sha256_hex(checksum) {
+        if file_name == target_asset_name {
+            return Err(MultiPwshError::Archive(format!(
+                "invalid sha256 checksum on line {}",
+                line_number
+            )));
+        }
+
+        return Ok(None);
+    }
+
+    Ok(Some((checksum.to_ascii_lowercase(), file_name)))
 }
 
 fn sha256_file(path: &Path) -> Result<String> {
@@ -361,6 +495,35 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb *other.zip",
     }
 
     #[test]
+    fn find_expected_checksum_accepts_bsd_format() {
+        let checksum = find_expected_checksum(
+            "SHA256 (PowerShell-7.4.13-win-x64.zip) = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "PowerShell-7.4.13-win-x64.zip",
+        )
+        .unwrap();
+
+        assert_eq!(
+            checksum,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+
+    #[test]
+    fn find_expected_checksum_ignores_unrelated_non_checksum_lines() {
+        let checksum = find_expected_checksum(
+            "Checksums for release assets\n\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  PowerShell-7.4.13-win-x64.zip",
+            "PowerShell-7.4.13-win-x64.zip",
+        )
+        .unwrap();
+
+        assert_eq!(
+            checksum,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+
+    #[test]
     fn find_expected_checksum_rejects_invalid_lines() {
         let error = find_expected_checksum(
             "not-a-hash  PowerShell-7.4.13-win-x64.zip",
@@ -382,6 +545,39 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb *other.zip",
         assert!(error
             .to_string()
             .contains("checksum entry for 'PowerShell-7.4.13-win-x64.zip' not found"));
+    }
+
+    #[test]
+    fn decode_checksum_text_accepts_utf16le_bom() {
+        let content =
+            "73601859461b130ee1e6624f0683000a794cbe86db0f4ff9f2ce2a7d4f5f6a01 *powershell-7.4.13-1.cm.aarch64.rpm\n";
+        let mut bytes = vec![0xFF, 0xFE];
+        for unit in content.encode_utf16() {
+            bytes.extend_from_slice(&unit.to_le_bytes());
+        }
+
+        let decoded = decode_checksum_text(&bytes).unwrap();
+
+        assert_eq!(decoded, content);
+    }
+
+    #[test]
+    fn find_expected_checksum_accepts_real_powershell_utf16le_line() {
+        let content =
+            "0aa943342ddd5ff5cd5bbb964e6594b7af3e10758ff59874cd26420bebb3c755 *PowerShell-7.4.13-win-arm64.exe\n\
+1820febe6f9567c8bab21be601dacb902777c1185e1beb81843c3a6f902d6b9d *PowerShell-7.4.13-win-arm64.zip\n";
+        let mut bytes = vec![0xFF, 0xFE];
+        for unit in content.encode_utf16() {
+            bytes.extend_from_slice(&unit.to_le_bytes());
+        }
+
+        let decoded = decode_checksum_text(&bytes).unwrap();
+        let checksum = find_expected_checksum(&decoded, "PowerShell-7.4.13-win-arm64.zip").unwrap();
+
+        assert_eq!(
+            checksum,
+            "1820febe6f9567c8bab21be601dacb902777c1185e1beb81843c3a6f902d6b9d"
+        );
     }
 
     #[test]

--- a/crates/multi-pwsh/src/install.rs
+++ b/crates/multi-pwsh/src/install.rs
@@ -14,11 +14,20 @@ use crate::layout::InstallLayout;
 use crate::platform::HostOs;
 use crate::release::ResolvedRelease;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ChecksumSource {
+    ReleaseAsset,
+    Url(String),
+    File(PathBuf),
+    Skip,
+}
+
 pub fn ensure_installed(
     layout: &InstallLayout,
     http: &Agent,
     os: HostOs,
     release: &ResolvedRelease,
+    checksum_source: &ChecksumSource,
 ) -> Result<PathBuf> {
     let executable = layout.version_executable(&release.version);
     if executable.exists() {
@@ -39,7 +48,7 @@ pub fn ensure_installed(
         download_with_retry(http, &release.asset_url, &archive_path, 8)?;
     }
 
-    validate_archive_checksum(http, release, &archive_path)?;
+    validate_archive_checksum(http, release, checksum_source, &archive_path)?;
 
     extract_archive(&archive_path, &install_dir)?;
 
@@ -196,8 +205,17 @@ enum TextEncoding {
     Utf16BeNoBom,
 }
 
-fn validate_archive_checksum(http: &Agent, release: &ResolvedRelease, archive_path: &Path) -> Result<()> {
-    let checksums = download_text_with_retry(http, &release.checksum_asset_url, 8)?;
+fn validate_archive_checksum(
+    http: &Agent,
+    release: &ResolvedRelease,
+    checksum_source: &ChecksumSource,
+    archive_path: &Path,
+) -> Result<()> {
+    if matches!(checksum_source, ChecksumSource::Skip) {
+        return Ok(());
+    }
+
+    let (checksums, checksum_source_name) = load_checksum_text(http, release, checksum_source)?;
     let expected = find_expected_checksum(&checksums, &release.asset_name)?;
     let actual = sha256_file(archive_path)?;
 
@@ -208,8 +226,36 @@ fn validate_archive_checksum(http: &Agent, release: &ResolvedRelease, archive_pa
     let _ = fs::remove_file(archive_path);
     Err(MultiPwshError::Archive(format!(
         "checksum mismatch for '{}' using '{}': expected {}, got {}",
-        release.asset_name, release.checksum_asset_name, expected, actual
+        release.asset_name, checksum_source_name, expected, actual
     )))
+}
+
+fn load_checksum_text(
+    http: &Agent,
+    release: &ResolvedRelease,
+    checksum_source: &ChecksumSource,
+) -> Result<(String, String)> {
+    match checksum_source {
+        ChecksumSource::ReleaseAsset => {
+            let checksum_url = release.checksum_asset_url.as_deref().ok_or_else(|| {
+                MultiPwshError::Archive(format!(
+                    "release '{}' is missing checksum asset metadata; provide --hash-file <url-or-path> or use --skip-hash-verification to bypass verification",
+                    release.asset_name
+                ))
+            })?;
+            let checksum_name = release
+                .checksum_asset_name
+                .clone()
+                .unwrap_or_else(|| "hashes.sha256".to_string());
+            Ok((download_text_with_retry(http, checksum_url, 8)?, checksum_name))
+        }
+        ChecksumSource::Url(url) => Ok((download_text_with_retry(http, url, 8)?, url.clone())),
+        ChecksumSource::File(path) => {
+            let bytes = fs::read(path)?;
+            Ok((decode_checksum_text(&bytes)?, path.display().to_string()))
+        }
+        ChecksumSource::Skip => Ok((String::new(), "checksum verification disabled".to_string())),
+    }
 }
 
 fn find_expected_checksum(checksums: &str, asset_name: &str) -> Result<String> {
@@ -477,6 +523,48 @@ mod tests {
         with_cache_keep(Some("false"), || {
             assert!(!cache_keep_archives());
         });
+    }
+
+    #[test]
+    fn load_checksum_text_reads_local_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let checksum_path = temp_dir.path().join("hashes.sha256");
+        fs::write(
+            &checksum_path,
+            b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  PowerShell-7.4.13-win-x64.zip\n",
+        )
+        .unwrap();
+
+        let http = ureq::AgentBuilder::new().build();
+        let release = ResolvedRelease {
+            version: semver::Version::parse("7.4.13").unwrap(),
+            asset_name: "PowerShell-7.4.13-win-x64.zip".to_string(),
+            asset_url: "https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string(),
+            checksum_asset_name: None,
+            checksum_asset_url: None,
+        };
+
+        let (content, source_name) =
+            load_checksum_text(&http, &release, &ChecksumSource::File(checksum_path.clone())).unwrap();
+
+        assert!(content.contains("PowerShell-7.4.13-win-x64.zip"));
+        assert_eq!(source_name, checksum_path.display().to_string());
+    }
+
+    #[test]
+    fn load_checksum_text_requires_release_asset_for_default_source() {
+        let http = ureq::AgentBuilder::new().build();
+        let release = ResolvedRelease {
+            version: semver::Version::parse("7.4.13").unwrap(),
+            asset_name: "PowerShell-7.4.13-win-x64.zip".to_string(),
+            asset_url: "https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string(),
+            checksum_asset_name: None,
+            checksum_asset_url: None,
+        };
+
+        let error = load_checksum_text(&http, &release, &ChecksumSource::ReleaseAsset).unwrap_err();
+
+        assert!(error.to_string().contains("missing checksum asset metadata"));
     }
 
     #[test]

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -21,7 +21,7 @@ use aliases::{
     read_layout_hint, read_minor_pin, read_minor_pins, remove_alias, set_minor_pin, AliasSelector,
 };
 use error::{MultiPwshError, Result};
-use install::ensure_installed;
+use install::{ensure_installed, ChecksumSource};
 use layout::InstallLayout;
 use package::{
     load_package_metadata, package_layout, persist_installed_version_registration, persist_installer_properties,
@@ -49,6 +49,13 @@ fn print_usage() {
 struct ReleaseSelectionOptions {
     arch: Option<HostArch>,
     include_prerelease: bool,
+    checksum_source: ChecksumSource,
+}
+
+#[derive(Debug)]
+struct InstallCommandOptions {
+    package: PackageInstallOptions,
+    checksum_source: ChecksumSource,
 }
 
 #[derive(Clone, Debug)]
@@ -959,9 +966,18 @@ fn parse_release_selection_options(args: &[String]) -> Result<ReleaseSelectionOp
     let mut arch = None;
     let mut arch_specified = false;
     let mut include_prerelease = false;
+    let mut checksum_source = ChecksumSource::ReleaseAsset;
+    let mut checksum_source_specified = false;
 
     let mut index = 0usize;
     while index < args.len() {
+        if let Some(next_index) =
+            parse_checksum_cli_option(args, index, &mut checksum_source, &mut checksum_source_specified)?
+        {
+            index = next_index;
+            continue;
+        }
+
         match args[index].as_str() {
             "--arch" | "-a" => {
                 if index + 1 >= args.len() {
@@ -996,7 +1012,7 @@ fn parse_release_selection_options(args: &[String]) -> Result<ReleaseSelectionOp
             }
             _ => {
                 return Err(MultiPwshError::InvalidArguments(
-                    "expected optional --arch <value> and/or --include-prerelease".to_string(),
+                    "expected optional --arch <value>, --include-prerelease, --skip-hash-verification, and/or --hash-file <url-or-path>".to_string(),
                 ));
             }
         }
@@ -1005,7 +1021,66 @@ fn parse_release_selection_options(args: &[String]) -> Result<ReleaseSelectionOp
     Ok(ReleaseSelectionOptions {
         arch,
         include_prerelease,
+        checksum_source,
     })
+}
+
+fn parse_checksum_cli_option(
+    args: &[String],
+    index: usize,
+    checksum_source: &mut ChecksumSource,
+    checksum_source_specified: &mut bool,
+) -> Result<Option<usize>> {
+    match args[index].as_str() {
+        "--skip-hash-verification" | "--skip-checksum-verification" => {
+            set_checksum_source(checksum_source, checksum_source_specified, ChecksumSource::Skip)?;
+            Ok(Some(index + 1))
+        }
+        "--hash-file" | "--checksum-file" => {
+            if index + 1 >= args.len() {
+                return Err(MultiPwshError::InvalidArguments(
+                    "expected value after --hash-file".to_string(),
+                ));
+            }
+
+            let parsed = parse_checksum_source_argument(&args[index + 1])?;
+            set_checksum_source(checksum_source, checksum_source_specified, parsed)?;
+            Ok(Some(index + 2))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn set_checksum_source(
+    checksum_source: &mut ChecksumSource,
+    checksum_source_specified: &mut bool,
+    next_source: ChecksumSource,
+) -> Result<()> {
+    if *checksum_source_specified {
+        return Err(MultiPwshError::InvalidArguments(
+            "checksum verification source can only be specified once; choose only one of --skip-hash-verification or --hash-file <url-or-path>".to_string(),
+        ));
+    }
+
+    *checksum_source = next_source;
+    *checksum_source_specified = true;
+    Ok(())
+}
+
+fn parse_checksum_source_argument(value: &str) -> Result<ChecksumSource> {
+    let normalized = value.to_ascii_lowercase();
+    if normalized.starts_with("http://") || normalized.starts_with("https://") {
+        return Ok(ChecksumSource::Url(value.to_string()));
+    }
+
+    if value.contains("://") {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "unsupported checksum URL '{}'; expected http:// or https://, or provide a local file path",
+            value
+        )));
+    }
+
+    Ok(ChecksumSource::File(PathBuf::from(value)))
 }
 
 fn parse_package_layout_options(args: &[String]) -> Result<PackageLayoutOptions> {
@@ -1065,15 +1140,24 @@ fn parse_package_layout_options(args: &[String]) -> Result<PackageLayoutOptions>
     Ok(PackageLayoutOptions { scope, root })
 }
 
-fn parse_package_install_options(args: &[String]) -> Result<PackageInstallOptions> {
+fn parse_package_install_options(args: &[String]) -> Result<InstallCommandOptions> {
     let os = HostOs::detect()?;
     let mut options = PackageInstallOptions::with_platform_defaults(PackageScope::CurrentUser, os);
     let mut scope_specified = false;
     let mut root_specified = false;
     let mut arch_specified = false;
+    let mut checksum_source = ChecksumSource::ReleaseAsset;
+    let mut checksum_source_specified = false;
     let mut index = 0usize;
 
     while index < args.len() {
+        if let Some(next_index) =
+            parse_checksum_cli_option(args, index, &mut checksum_source, &mut checksum_source_specified)?
+        {
+            index = next_index;
+            continue;
+        }
+
         match args[index].as_str() {
             "--scope" => {
                 if index + 1 >= args.len() {
@@ -1201,7 +1285,7 @@ fn parse_package_install_options(args: &[String]) -> Result<PackageInstallOption
             }
             _ => {
                 return Err(MultiPwshError::InvalidArguments(
-                    "unexpected install options; expected scope/root/arch/include-prerelease and Windows integration flags"
+                    "unexpected install options; expected scope/root/arch/include-prerelease/checksum flags and Windows integration flags"
                         .to_string(),
                 ));
             }
@@ -1209,7 +1293,10 @@ fn parse_package_install_options(args: &[String]) -> Result<PackageInstallOption
     }
 
     options.validate(os)?;
-    Ok(options)
+    Ok(InstallCommandOptions {
+        package: options,
+        checksum_source,
+    })
 }
 
 fn requires_scoped_install_backend(args: &[String]) -> bool {
@@ -1356,9 +1443,11 @@ fn parse_windows_uninstall_options(args: &[String]) -> Result<WindowsUninstallOp
     Ok(WindowsUninstallOptions { scope, root, force })
 }
 
-fn run_package_install(selector_input: &str, options: PackageInstallOptions) -> Result<()> {
+fn run_package_install(selector_input: &str, install_options: InstallCommandOptions) -> Result<()> {
     let selector = parse_install_selector(selector_input)?;
     let os = HostOs::detect()?;
+    let options = install_options.package;
+    let checksum_source = install_options.checksum_source;
     let arch = options.arch.unwrap_or_else(HostArch::detect);
     let layout = package_layout(os, arch, options.scope, options.install_root.clone())?;
     layout.ensure_base_dirs()?;
@@ -1377,7 +1466,7 @@ fn run_package_install(selector_input: &str, options: PackageInstallOptions) -> 
     let mut touched_majors: Vec<u64> = Vec::new();
 
     for release in releases {
-        let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release)?;
+        let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release, &checksum_source)?;
         let patch_alias = create_or_update_patch_alias(&layout, os, &release.version, &executable_path)?;
         let version_path = executable_path.parent().unwrap_or_else(|| Path::new(""));
 
@@ -1706,7 +1795,12 @@ fn run_package(args: &[String]) -> Result<()> {
     }
 }
 
-fn run_install(selector_input: &str, arch: Option<HostArch>, include_prerelease: bool) -> Result<()> {
+fn run_install(
+    selector_input: &str,
+    arch: Option<HostArch>,
+    include_prerelease: bool,
+    checksum_source: ChecksumSource,
+) -> Result<()> {
     let selector = parse_install_selector(selector_input)?;
     let os = HostOs::detect()?;
     let arch = arch.unwrap_or_else(HostArch::detect);
@@ -1727,7 +1821,7 @@ fn run_install(selector_input: &str, arch: Option<HostArch>, include_prerelease:
     let mut touched_majors: Vec<u64> = Vec::new();
 
     for release in releases {
-        let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release)?;
+        let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release, &checksum_source)?;
         let patch_alias = create_or_update_patch_alias(&layout, os, &release.version, &executable_path)?;
         let version_path = executable_path.parent().unwrap_or_else(|| Path::new(""));
 
@@ -1780,7 +1874,12 @@ fn run_install(selector_input: &str, arch: Option<HostArch>, include_prerelease:
     Ok(())
 }
 
-fn run_update(line_input: &str, arch: Option<HostArch>, include_prerelease: bool) -> Result<()> {
+fn run_update(
+    line_input: &str,
+    arch: Option<HostArch>,
+    include_prerelease: bool,
+    checksum_source: ChecksumSource,
+) -> Result<()> {
     let line = parse_major_minor_selector(line_input)?;
     let os = HostOs::detect()?;
     let arch = arch.unwrap_or_else(HostArch::detect);
@@ -1791,7 +1890,7 @@ fn run_update(line_input: &str, arch: Option<HostArch>, include_prerelease: bool
     let token = env::var("GITHUB_TOKEN").ok();
     let release_client = ReleaseClient::new(token)?;
     let release = release_client.resolve_latest_in_line(line, os, arch, include_prerelease)?;
-    let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release)?;
+    let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release, &checksum_source)?;
     let patch_alias_path = create_or_update_patch_alias(&layout, os, &release.version, &executable_path)?;
     let version_path = executable_path.parent().unwrap_or_else(|| Path::new(""));
 
@@ -2168,7 +2267,12 @@ fn run() -> Result<()> {
                 run_package_install(&args[1], options)
             } else {
                 let options = parse_release_selection_options(&args[2..])?;
-                run_install(&args[1], options.arch, options.include_prerelease)
+                run_install(
+                    &args[1],
+                    options.arch,
+                    options.include_prerelease,
+                    options.checksum_source,
+                )
             }
         }
         "update" => {
@@ -2183,7 +2287,12 @@ fn run() -> Result<()> {
                 run_package_install(&args[1], options)
             } else {
                 let options = parse_release_selection_options(&args[2..])?;
-                run_update(&args[1], options.arch, options.include_prerelease)
+                run_update(
+                    &args[1],
+                    options.arch,
+                    options.include_prerelease,
+                    options.checksum_source,
+                )
             }
         }
         "uninstall" => {
@@ -2512,6 +2621,7 @@ mod tests {
         let options = parse_release_selection_options(&args).unwrap();
         assert!(options.include_prerelease);
         assert!(options.arch.is_none());
+        assert_eq!(options.checksum_source, ChecksumSource::ReleaseAsset);
     }
 
     #[test]
@@ -2524,6 +2634,75 @@ mod tests {
         let options = parse_release_selection_options(&args).unwrap();
         assert!(options.include_prerelease);
         assert!(matches!(options.arch, Some(HostArch::X64)));
+    }
+
+    #[test]
+    fn parse_release_selection_options_accepts_skip_hash_verification() {
+        let args = vec!["--skip-hash-verification".to_string()];
+        let options = parse_release_selection_options(&args).unwrap();
+
+        assert_eq!(options.checksum_source, ChecksumSource::Skip);
+    }
+
+    #[test]
+    fn parse_release_selection_options_accepts_checksum_file_url() {
+        let args = vec![
+            "--hash-file".to_string(),
+            "https://example.invalid/hashes.sha256".to_string(),
+        ];
+        let options = parse_release_selection_options(&args).unwrap();
+
+        assert_eq!(
+            options.checksum_source,
+            ChecksumSource::Url("https://example.invalid/hashes.sha256".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_release_selection_options_accepts_checksum_file_path() {
+        let args = vec!["--hash-file".to_string(), "C:\\temp\\hashes.sha256".to_string()];
+        let options = parse_release_selection_options(&args).unwrap();
+
+        assert_eq!(
+            options.checksum_source,
+            ChecksumSource::File(PathBuf::from("C:\\temp\\hashes.sha256"))
+        );
+    }
+
+    #[test]
+    fn parse_release_selection_options_rejects_multiple_checksum_sources() {
+        let args = vec![
+            "--skip-hash-verification".to_string(),
+            "--hash-file".to_string(),
+            "hashes.sha256".to_string(),
+        ];
+
+        assert!(parse_release_selection_options(&args).is_err());
+    }
+
+    #[test]
+    fn parse_package_install_options_accepts_checksum_file_url() {
+        let args = vec![
+            "--scope".to_string(),
+            "user".to_string(),
+            "--hash-file".to_string(),
+            "https://example.invalid/hashes.sha256".to_string(),
+        ];
+        let options = parse_package_install_options(&args).unwrap();
+
+        assert_eq!(
+            options.checksum_source,
+            ChecksumSource::Url("https://example.invalid/hashes.sha256".to_string())
+        );
+        assert_eq!(options.package.scope, PackageScope::CurrentUser);
+    }
+
+    #[test]
+    fn parse_package_install_options_accepts_skip_hash_verification() {
+        let args = vec!["--skip-hash-verification".to_string()];
+        let options = parse_package_install_options(&args).unwrap();
+
+        assert_eq!(options.checksum_source, ChecksumSource::Skip);
     }
 
     #[test]

--- a/crates/multi-pwsh/src/release.rs
+++ b/crates/multi-pwsh/src/release.rs
@@ -13,8 +13,8 @@ pub struct ResolvedRelease {
     pub version: Version,
     pub asset_name: String,
     pub asset_url: String,
-    pub checksum_asset_name: String,
-    pub checksum_asset_url: String,
+    pub checksum_asset_name: Option<String>,
+    pub checksum_asset_url: Option<String>,
 }
 
 impl ResolvedRelease {
@@ -217,13 +217,7 @@ fn resolve_release_asset(release: ParsedRelease, os: HostOs, arch: HostArch) -> 
         .assets
         .iter()
         .find(|asset| asset.name == CHECKSUM_ASSET_NAME)
-        .cloned()
-        .ok_or_else(|| {
-            MultiPwshError::AssetNotFound(format!(
-                "checksum asset '{}' not found in {}",
-                CHECKSUM_ASSET_NAME, tag_name
-            ))
-        })?;
+        .cloned();
     let asset = release
         .assets
         .into_iter()
@@ -236,8 +230,8 @@ fn resolve_release_asset(release: ParsedRelease, os: HostOs, arch: HostArch) -> 
         version: release.version,
         asset_name: asset.name,
         asset_url: asset.browser_download_url,
-        checksum_asset_name: checksum_asset.name,
-        checksum_asset_url: checksum_asset.browser_download_url,
+        checksum_asset_name: checksum_asset.as_ref().map(|asset| asset.name.clone()),
+        checksum_asset_url: checksum_asset.map(|asset| asset.browser_download_url),
     })
 }
 
@@ -388,12 +382,15 @@ mod tests {
         let resolved = resolve_release_asset(release, HostOs::Windows, HostArch::X64).unwrap();
 
         assert_eq!(resolved.asset_name, "PowerShell-7.4.13-win-x64.zip");
-        assert_eq!(resolved.checksum_asset_name, CHECKSUM_ASSET_NAME);
-        assert_eq!(resolved.checksum_asset_url, "https://example.invalid/hashes.sha256");
+        assert_eq!(resolved.checksum_asset_name.as_deref(), Some(CHECKSUM_ASSET_NAME));
+        assert_eq!(
+            resolved.checksum_asset_url.as_deref(),
+            Some("https://example.invalid/hashes.sha256")
+        );
     }
 
     #[test]
-    fn resolve_release_asset_requires_checksum_asset() {
+    fn resolve_release_asset_allows_missing_checksum_asset() {
         let release = ParsedRelease {
             tag_name: "v7.4.13".to_string(),
             version: Version::parse("7.4.13").unwrap(),
@@ -403,9 +400,9 @@ mod tests {
             }],
         };
 
-        let error = resolve_release_asset(release, HostOs::Windows, HostArch::X64).unwrap_err();
+        let resolved = resolve_release_asset(release, HostOs::Windows, HostArch::X64).unwrap();
 
-        assert!(matches!(error, MultiPwshError::AssetNotFound(_)));
-        assert!(error.to_string().contains(CHECKSUM_ASSET_NAME));
+        assert!(resolved.checksum_asset_name.is_none());
+        assert!(resolved.checksum_asset_url.is_none());
     }
 }

--- a/crates/multi-pwsh/src/release.rs
+++ b/crates/multi-pwsh/src/release.rs
@@ -6,11 +6,15 @@ use crate::error::{MultiPwshError, Result};
 use crate::platform::{HostArch, HostOs};
 use crate::versions::{MajorMinor, VersionSelector};
 
+const CHECKSUM_ASSET_NAME: &str = "hashes.sha256";
+
 #[derive(Clone, Debug)]
 pub struct ResolvedRelease {
     pub version: Version,
     pub asset_name: String,
     pub asset_url: String,
+    pub checksum_asset_name: String,
+    pub checksum_asset_url: String,
 }
 
 impl ResolvedRelease {
@@ -209,6 +213,17 @@ impl ReleaseClient {
 fn resolve_release_asset(release: ParsedRelease, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
     let pattern = asset_pattern(os, arch)?;
     let tag_name = release.tag_name.clone();
+    let checksum_asset = release
+        .assets
+        .iter()
+        .find(|asset| asset.name == CHECKSUM_ASSET_NAME)
+        .cloned()
+        .ok_or_else(|| {
+            MultiPwshError::AssetNotFound(format!(
+                "checksum asset '{}' not found in {}",
+                CHECKSUM_ASSET_NAME, tag_name
+            ))
+        })?;
     let asset = release
         .assets
         .into_iter()
@@ -221,6 +236,8 @@ fn resolve_release_asset(release: ParsedRelease, os: HostOs, arch: HostArch) -> 
         version: release.version,
         asset_name: asset.name,
         asset_url: asset.browser_download_url,
+        checksum_asset_name: checksum_asset.name,
+        checksum_asset_url: checksum_asset.browser_download_url,
     })
 }
 
@@ -305,7 +322,7 @@ struct GithubRelease {
     assets: Vec<GithubAsset>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct GithubAsset {
     name: String,
     browser_download_url: String,
@@ -349,5 +366,46 @@ mod tests {
             "powershell-*-linux-arm64.tar.gz",
             "powershell-7.5.1-linux-x64.tar.gz"
         ));
+    }
+
+    #[test]
+    fn resolve_release_asset_includes_checksum_asset() {
+        let release = ParsedRelease {
+            tag_name: "v7.4.13".to_string(),
+            version: Version::parse("7.4.13").unwrap(),
+            assets: vec![
+                GithubAsset {
+                    name: CHECKSUM_ASSET_NAME.to_string(),
+                    browser_download_url: "https://example.invalid/hashes.sha256".to_string(),
+                },
+                GithubAsset {
+                    name: "PowerShell-7.4.13-win-x64.zip".to_string(),
+                    browser_download_url: "https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string(),
+                },
+            ],
+        };
+
+        let resolved = resolve_release_asset(release, HostOs::Windows, HostArch::X64).unwrap();
+
+        assert_eq!(resolved.asset_name, "PowerShell-7.4.13-win-x64.zip");
+        assert_eq!(resolved.checksum_asset_name, CHECKSUM_ASSET_NAME);
+        assert_eq!(resolved.checksum_asset_url, "https://example.invalid/hashes.sha256");
+    }
+
+    #[test]
+    fn resolve_release_asset_requires_checksum_asset() {
+        let release = ParsedRelease {
+            tag_name: "v7.4.13".to_string(),
+            version: Version::parse("7.4.13").unwrap(),
+            assets: vec![GithubAsset {
+                name: "PowerShell-7.4.13-win-x64.zip".to_string(),
+                browser_download_url: "https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string(),
+            }],
+        };
+
+        let error = resolve_release_asset(release, HostOs::Windows, HostArch::X64).unwrap_err();
+
+        assert!(matches!(error, MultiPwshError::AssetNotFound(_)));
+        assert!(error.to_string().contains(CHECKSUM_ASSET_NAME));
     }
 }


### PR DESCRIPTION
## Summary
- validate GitHub release archives against SHA-256 checksums before extraction and install
- decode and parse real PowerShell `hashes.sha256` assets, including UTF-16LE BOM content and common checksum line formats
- add CLI controls to skip checksum verification or provide an explicit checksum file by URL or local path

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets
- cargo build --all-targets
- cargo test --all-targets
- dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj
- dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build
- smoke-tests workflow run 24158181093