### PR TITLE
Add PowerShell channel selectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
         run: |
           $multiPwshHome = if ($env:MULTI_PWSH_HOME) { $env:MULTI_PWSH_HOME } else { Join-Path $HOME '.pwsh' }
           $multiPwshBin = if ($env:MULTI_PWSH_BIN_DIR) { $env:MULTI_PWSH_BIN_DIR } else { Join-Path $multiPwshHome 'bin' }
+          $userAliasBin = Join-Path $env:LOCALAPPDATA 'PowerShell\bin'
           $multiPwshBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $userAliasBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Add multi-pwsh bin to PATH (Unix)
         if: matrix.os != 'windows-latest'

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/t
 ## Install and verify aliases
 
 ```powershell
+multi-pwsh install stable
 multi-pwsh install 7.4
 multi-pwsh install 7.5
 ```
@@ -72,6 +73,9 @@ Platform behavior:
 Examples:
 
 ```powershell
+multi-pwsh install stable
+multi-pwsh install preview
+multi-pwsh install lts
 multi-pwsh install 7.4
 multi-pwsh install 7.5 --scope machine --enable-psremoting --add-explorer-context-menu
 multi-pwsh install 7.5 --scope machine
@@ -106,6 +110,9 @@ The Windows-only integration flags above currently return an error on macOS/Linu
 
 ```powershell
 multi-pwsh install 7.4.x
+multi-pwsh update stable
+multi-pwsh update preview
+multi-pwsh update lts
 multi-pwsh update 7.4
 multi-pwsh update 7.5
 multi-pwsh list
@@ -116,6 +123,10 @@ multi-pwsh install 7.6-preview6
 multi-pwsh install 7.6-rc1
 multi-pwsh install 7.6.0-rc.1
 multi-pwsh update 7.6 --include-prerelease
+multi-pwsh alias set pwsh stable
+multi-pwsh alias set pwsh lts
+multi-pwsh alias set pwsh-preview preview
+multi-pwsh alias set pwsh-lts lts
 multi-pwsh alias set 7.4 7.4.11
 multi-pwsh alias unset 7.4
 multi-pwsh venv create msgraph
@@ -130,8 +141,8 @@ multi-pwsh doctor --repair-aliases
 `multi-pwsh` usage reference:
 
 ```text
-multi-pwsh install <version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
-multi-pwsh update <major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
+multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
+multi-pwsh update <stable|preview|lts|major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
 multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]
 multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease]
 multi-pwsh venv create <name>
@@ -140,7 +151,8 @@ multi-pwsh venv export <name> <archive.zip>
 multi-pwsh venv import <name> <archive.zip>
 multi-pwsh venv list
 multi-pwsh alias set <major.minor> <version|latest>
-multi-pwsh alias unset <major.minor>
+multi-pwsh alias set <pwsh|pwsh-preview|pwsh-lts> <stable|preview|lts|version>
+multi-pwsh alias unset <major.minor|pwsh|pwsh-preview|pwsh-lts>
 multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]
 multi-pwsh doctor --repair-aliases
 ```
@@ -185,6 +197,9 @@ Notes:
 
 Selector behavior:
 
+- `stable` installs the latest GA/non-preview release for your platform and configures `pwsh` to follow the latest installed stable release.
+- `preview` installs the latest prerelease for your platform and configures `pwsh-preview` to follow the latest installed preview release.
+- `lts` installs the latest patch from the current LTS line for your platform and configures `pwsh-lts` to follow the latest installed LTS release.
 - `7` installs the latest available 7.x release for your platform.
 - `7.4` installs the latest available 7.4.x release for your platform.
 - `7.4.x` installs all available releases in that line for your platform.
@@ -193,6 +208,7 @@ Selector behavior:
 `multi-pwsh install 7.4.x` installs every available patch release in that line for your current platform and creates per-version aliases such as `pwsh-7.4.11`.
 The `pwsh-7.4` alias tracks latest by default; pin it with `multi-pwsh alias set 7.4 7.4.11` and unpin with `multi-pwsh alias unset 7.4`.
 If a pinned target version is not installed, the pin remains in metadata and the alias stays unresolved until you install that version or unpin.
+The bare `pwsh` alias is a managed policy alias. Configure it with `multi-pwsh alias set pwsh stable`, `multi-pwsh alias set pwsh lts`, `multi-pwsh alias set pwsh preview`, or an exact version. `pwsh-preview` tracks preview by default, and `pwsh-lts` tracks LTS by default. Policy aliases resolve only to installed versions; install or update the desired channel before pointing an alias at it.
 
 Native host mode:
 

--- a/crates/multi-pwsh/src/aliases.rs
+++ b/crates/multi-pwsh/src/aliases.rs
@@ -14,6 +14,9 @@ use crate::platform::HostOs;
 use crate::versions::MajorMinor;
 
 const LAYOUT_HINT_FILE: &str = "multi-pwsh-layout.json";
+pub const PWSH_ALIAS: &str = "pwsh";
+pub const PWSH_PREVIEW_ALIAS: &str = "pwsh-preview";
+pub const PWSH_LTS_ALIAS: &str = "pwsh-lts";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AliasSelector {
@@ -49,6 +52,52 @@ pub fn create_or_update_patch_alias(
     target: &Path,
 ) -> Result<PathBuf> {
     create_or_update_alias_with_selector(layout, os, AliasSelector::Exact(version.clone()), version, target)
+}
+
+pub fn create_or_update_named_alias(
+    layout: &InstallLayout,
+    os: HostOs,
+    alias_command: &str,
+    version: &Version,
+    target: &Path,
+) -> Result<PathBuf> {
+    if !is_special_alias_command(alias_command) {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "unsupported named alias '{}'",
+            alias_command
+        )));
+    }
+
+    create_or_update_named_alias_unchecked(layout, os, alias_command, version, target)
+}
+
+fn create_or_update_named_alias_unchecked(
+    layout: &InstallLayout,
+    os: HostOs,
+    alias_command: &str,
+    version: &Version,
+    target: &Path,
+) -> Result<PathBuf> {
+    fs::create_dir_all(layout.bin_dir())?;
+    write_layout_hint(layout)?;
+    let _ = target;
+
+    let alias_path = layout.bin_dir().join(alias_file_name_from_command(alias_command, os));
+
+    match os {
+        HostOs::Windows => {
+            create_or_update_windows_host_shim(layout, alias_command)?;
+        }
+        HostOs::Linux | HostOs::Macos => {
+            create_or_update_posix_host_shim(layout, alias_command)?;
+        }
+    }
+
+    let mut metadata = read_alias_metadata(layout)?;
+    metadata.insert(alias_command.to_string(), version.to_string());
+    write_alias_metadata(layout, metadata)?;
+
+    Ok(alias_path)
 }
 
 fn create_or_update_alias_with_selector(
@@ -175,6 +224,14 @@ pub fn parse_alias_command_selector(alias_command: &str) -> Option<AliasSelector
     None
 }
 
+pub fn is_special_alias_command(alias_command: &str) -> bool {
+    matches!(alias_command, PWSH_ALIAS | PWSH_PREVIEW_ALIAS | PWSH_LTS_ALIAS)
+}
+
+pub fn is_supported_alias_command(alias_command: &str) -> bool {
+    is_special_alias_command(alias_command) || parse_alias_command_selector(alias_command).is_some()
+}
+
 pub fn read_alias_metadata(layout: &InstallLayout) -> Result<HashMap<String, String>> {
     Ok(read_alias_document(layout)?.aliases)
 }
@@ -212,6 +269,48 @@ pub fn set_minor_pin(layout: &InstallLayout, line: MajorMinor, version: Option<V
     }
 
     write_alias_document(layout, &document)
+}
+
+pub fn read_special_alias_policies(layout: &InstallLayout) -> Result<HashMap<String, String>> {
+    Ok(read_alias_document(layout)?.special_policies)
+}
+
+pub fn read_special_alias_policy(layout: &InstallLayout, alias_command: &str) -> Result<Option<String>> {
+    Ok(read_alias_document(layout)?
+        .special_policies
+        .get(alias_command)
+        .cloned())
+}
+
+pub fn set_special_alias_policy(layout: &InstallLayout, alias_command: &str, policy: Option<&str>) -> Result<()> {
+    if !is_special_alias_command(alias_command) {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "unsupported named alias '{}'",
+            alias_command
+        )));
+    }
+
+    let mut document = read_alias_document(layout)?;
+    match policy {
+        Some(policy) => {
+            document
+                .special_policies
+                .insert(alias_command.to_string(), policy.to_string());
+        }
+        None => {
+            document.special_policies.remove(alias_command);
+        }
+    }
+
+    write_alias_document(layout, &document)
+}
+
+pub fn ensure_special_alias_policy(layout: &InstallLayout, alias_command: &str, policy: &str) -> Result<()> {
+    if read_special_alias_policy(layout, alias_command)?.is_some() {
+        return Ok(());
+    }
+
+    set_special_alias_policy(layout, alias_command, Some(policy))
 }
 
 fn line_pin_key(line: MajorMinor) -> String {
@@ -411,6 +510,8 @@ struct AliasMetadata {
     aliases: HashMap<String, String>,
     #[serde(default)]
     pins: HashMap<String, String>,
+    #[serde(default)]
+    special_policies: HashMap<String, String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -470,6 +571,31 @@ mod tests {
     fn rejects_invalid_alias_selector() {
         assert!(parse_alias_command_selector("pwsh").is_none());
         assert!(parse_alias_command_selector("not-pwsh-7.5").is_none());
+    }
+
+    #[test]
+    fn recognizes_special_alias_commands() {
+        assert!(is_supported_alias_command("pwsh"));
+        assert!(is_supported_alias_command("pwsh-preview"));
+        assert!(is_supported_alias_command("pwsh-lts"));
+        assert!(is_supported_alias_command("pwsh-7.5"));
+        assert!(!is_supported_alias_command("pwsh-stable"));
+    }
+
+    #[test]
+    fn special_alias_policy_round_trips() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = InstallLayout::from_root(HostOs::Linux, temp_dir.path().join("home")).unwrap();
+        fs::create_dir_all(layout.home()).unwrap();
+
+        set_special_alias_policy(&layout, PWSH_ALIAS, Some("stable")).unwrap();
+        assert_eq!(
+            read_special_alias_policy(&layout, PWSH_ALIAS).unwrap().as_deref(),
+            Some("stable")
+        );
+
+        set_special_alias_policy(&layout, PWSH_ALIAS, None).unwrap();
+        assert!(read_special_alias_policy(&layout, PWSH_ALIAS).unwrap().is_none());
     }
 
     #[test]

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -17,8 +17,10 @@ use std::process;
 use semver::Version;
 
 use aliases::{
-    create_or_update_alias, create_or_update_major_alias, create_or_update_patch_alias, parse_alias_command_selector,
-    read_layout_hint, read_minor_pin, read_minor_pins, remove_alias, set_minor_pin, AliasSelector,
+    create_or_update_alias, create_or_update_major_alias, create_or_update_named_alias, create_or_update_patch_alias,
+    ensure_special_alias_policy, is_special_alias_command, is_supported_alias_command, parse_alias_command_selector,
+    read_layout_hint, read_minor_pin, read_minor_pins, remove_alias, set_minor_pin, set_special_alias_policy,
+    AliasSelector, PWSH_ALIAS, PWSH_LTS_ALIAS, PWSH_PREVIEW_ALIAS,
 };
 use error::{MultiPwshError, Result};
 use install::{ensure_installed, ChecksumSource};
@@ -31,8 +33,8 @@ use package::{
 use platform::{HostArch, HostOs};
 use release::ReleaseClient;
 use versions::{
-    parse_exact_version, parse_install_selector, parse_major_minor_selector, parse_major_selector, MajorMinor,
-    VersionSelector,
+    is_current_lts_version, parse_exact_version, parse_install_selector, parse_major_minor_selector,
+    parse_major_selector, MajorMinor, VersionSelector,
 };
 
 const POWERSHELL_UPDATECHECK_ENV_VAR: &str = "POWERSHELL_UPDATECHECK";
@@ -42,7 +44,7 @@ const VIRTUAL_ENVIRONMENT_SHORT_FLAG: &str = "-venv";
 
 fn print_usage() {
     eprintln!(
-        "Usage:\n  multi-pwsh install <version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh update <major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]\n  multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease]\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias unset <major.minor>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
+        "Usage:\n  multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh update <stable|preview|lts|major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]\n  multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease]\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias set <pwsh|pwsh-preview|pwsh-lts> <stable|preview|lts|version>\n  multi-pwsh alias unset <major.minor|pwsh|pwsh-preview|pwsh-lts>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
     );
 }
 
@@ -141,12 +143,17 @@ fn configure_virtual_environment_host_env(os: HostOs, venv_dir: &Path) -> Result
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum HostSelector {
+    NamedAlias(String),
     Major(u64),
     MajorMinor(MajorMinor),
     Exact(Version),
 }
 
 fn parse_host_selector(value: &str) -> Result<HostSelector> {
+    if is_special_alias_command(value) {
+        return Ok(HostSelector::NamedAlias(value.to_string()));
+    }
+
     if let Some(selector) = parse_alias_command_selector(value) {
         return Ok(match selector {
             AliasSelector::Major(major) => HostSelector::Major(major),
@@ -175,6 +182,16 @@ fn parse_host_selector(value: &str) -> Result<HostSelector> {
 
 fn resolve_host_version(layout: &InstallLayout, selector: &HostSelector) -> Result<Version> {
     match selector {
+        HostSelector::NamedAlias(alias_name) => {
+            let aliases = aliases::read_alias_metadata(layout)?;
+            let version_text = aliases.get(alias_name).ok_or_else(|| {
+                MultiPwshError::InvalidArguments(format!(
+                    "alias '{}' is unresolved; configure it with: multi-pwsh alias set {} <stable|preview|lts|version>",
+                    alias_name, alias_name
+                ))
+            })?;
+            Ok(Version::parse(version_text)?)
+        }
         HostSelector::Exact(version) => Ok(version.clone()),
         HostSelector::Major(major) => latest_installed_in_major(layout, *major)?.ok_or_else(|| {
             MultiPwshError::InvalidArguments(format!(
@@ -641,7 +658,9 @@ fn detect_implicit_host_selector(bin_dir: &Path, executable_path: &Path) -> Opti
         return None;
     }
 
-    parse_alias_command_selector(&selector)?;
+    if !is_supported_alias_command(&selector) {
+        return None;
+    }
 
     let parent = executable_path.parent()?;
     if !paths_refer_to_same_location(parent, bin_dir) {
@@ -653,7 +672,7 @@ fn detect_implicit_host_selector(bin_dir: &Path, executable_path: &Path) -> Opti
 
 fn infer_layout_from_host_shim(os: HostOs, executable_path: &Path) -> Option<InstallLayout> {
     let selector = executable_selector_name(executable_path)?;
-    if selector.eq_ignore_ascii_case("multi-pwsh") || parse_alias_command_selector(&selector).is_none() {
+    if selector.eq_ignore_ascii_case("multi-pwsh") || !is_supported_alias_command(&selector) {
         return None;
     }
 
@@ -693,7 +712,7 @@ fn run_implicit_host_mode_if_needed() -> Result<Option<i32>> {
         Some(selector_name) => selector_name,
         None => return Ok(None),
     };
-    if selector_name.eq_ignore_ascii_case("multi-pwsh") || parse_alias_command_selector(&selector_name).is_none() {
+    if selector_name.eq_ignore_ascii_case("multi-pwsh") || !is_supported_alias_command(&selector_name) {
         return Ok(None);
     }
 
@@ -718,6 +737,148 @@ fn latest_installed_in_line(layout: &InstallLayout, line: MajorMinor) -> Result<
     Ok(versions
         .into_iter()
         .find(|version| version.major == line.major && version.minor == line.minor))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum SpecialAliasPolicy {
+    Stable,
+    Preview,
+    Lts,
+    Exact(Version),
+}
+
+impl SpecialAliasPolicy {
+    fn as_metadata_value(&self) -> String {
+        match self {
+            SpecialAliasPolicy::Stable => "stable".to_string(),
+            SpecialAliasPolicy::Preview => "preview".to_string(),
+            SpecialAliasPolicy::Lts => "lts".to_string(),
+            SpecialAliasPolicy::Exact(version) => version.to_string(),
+        }
+    }
+}
+
+fn parse_special_alias_policy(value: &str) -> Result<SpecialAliasPolicy> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "stable" => return Ok(SpecialAliasPolicy::Stable),
+        "preview" => return Ok(SpecialAliasPolicy::Preview),
+        "lts" => return Ok(SpecialAliasPolicy::Lts),
+        _ => {}
+    }
+
+    Ok(SpecialAliasPolicy::Exact(parse_exact_version(value)?))
+}
+
+fn validate_special_alias_policy(alias_name: &str, policy: &SpecialAliasPolicy) -> Result<()> {
+    match (alias_name, policy) {
+        (PWSH_PREVIEW_ALIAS, SpecialAliasPolicy::Preview) => Ok(()),
+        (PWSH_PREVIEW_ALIAS, SpecialAliasPolicy::Exact(version)) if !version.pre.is_empty() => Ok(()),
+        (PWSH_PREVIEW_ALIAS, _) => Err(MultiPwshError::InvalidArguments(
+            "pwsh-preview can only track preview or an exact prerelease version".to_string(),
+        )),
+        (PWSH_LTS_ALIAS, SpecialAliasPolicy::Lts) => Ok(()),
+        (PWSH_LTS_ALIAS, SpecialAliasPolicy::Exact(version)) if is_current_lts_version(version) => Ok(()),
+        (PWSH_LTS_ALIAS, _) => Err(MultiPwshError::InvalidArguments(
+            "pwsh-lts can only track lts or an exact current LTS version".to_string(),
+        )),
+        (PWSH_ALIAS, _) => Ok(()),
+        _ => Err(MultiPwshError::InvalidArguments(format!(
+            "unsupported named alias '{}'",
+            alias_name
+        ))),
+    }
+}
+
+fn resolve_special_alias_policy_from_installed(
+    installed_versions: &[Version],
+    policy: &SpecialAliasPolicy,
+) -> Option<Version> {
+    match policy {
+        SpecialAliasPolicy::Stable => installed_versions
+            .iter()
+            .find(|version| version.pre.is_empty())
+            .cloned(),
+        SpecialAliasPolicy::Preview => installed_versions
+            .iter()
+            .find(|version| !version.pre.is_empty())
+            .cloned(),
+        SpecialAliasPolicy::Lts => installed_versions
+            .iter()
+            .find(|version| version.pre.is_empty() && is_current_lts_version(version))
+            .cloned(),
+        SpecialAliasPolicy::Exact(version) => installed_versions
+            .iter()
+            .find(|candidate| *candidate == version)
+            .cloned(),
+    }
+}
+
+fn refresh_special_aliases(layout: &InstallLayout, os: HostOs) -> Result<()> {
+    let policies = aliases::read_special_alias_policies(layout)?;
+    if policies.is_empty() {
+        return Ok(());
+    }
+
+    let mut items: Vec<_> = policies.into_iter().collect();
+    items.sort_by(|a, b| a.0.cmp(&b.0));
+    let installed_versions = layout.installed_versions()?;
+
+    for (alias_name, policy_text) in items {
+        if !is_special_alias_command(&alias_name) {
+            eprintln!("Skipping alias policy {}: unsupported named alias", alias_name);
+            continue;
+        }
+
+        let policy = match parse_special_alias_policy(&policy_text) {
+            Ok(policy) => policy,
+            Err(error) => {
+                eprintln!("Skipping alias policy {}: {}", alias_name, error);
+                continue;
+            }
+        };
+
+        let Some(version) = resolve_special_alias_policy_from_installed(&installed_versions, &policy) else {
+            remove_alias(layout, os, &alias_name)?;
+            println!(
+                "Alias {} remains configured for {} but unresolved (no installed matching version)",
+                alias_name, policy_text
+            );
+            continue;
+        };
+
+        let target = layout.version_executable(&version);
+        if !target.exists() {
+            remove_alias(layout, os, &alias_name)?;
+            println!(
+                "Alias {} remains configured for {} but unresolved (target executable is missing)",
+                alias_name, policy_text
+            );
+            continue;
+        }
+
+        let alias_path = create_or_update_named_alias(layout, os, &alias_name, &version, &target)?;
+        println!("Updated alias: {} -> {}", alias_name, version);
+        println!("Alias path: {}", alias_path.display());
+    }
+
+    Ok(())
+}
+
+fn ensure_default_special_policy(layout: &InstallLayout, selector: &VersionSelector) -> Result<()> {
+    match selector {
+        VersionSelector::Stable => {
+            ensure_special_alias_policy(layout, PWSH_ALIAS, &SpecialAliasPolicy::Stable.as_metadata_value())
+        }
+        VersionSelector::Preview => ensure_special_alias_policy(
+            layout,
+            PWSH_PREVIEW_ALIAS,
+            &SpecialAliasPolicy::Preview.as_metadata_value(),
+        ),
+        VersionSelector::Lts => {
+            ensure_special_alias_policy(layout, PWSH_LTS_ALIAS, &SpecialAliasPolicy::Lts.as_metadata_value())
+        }
+        _ => Ok(()),
+    }
 }
 
 fn sync_minor_alias(layout: &InstallLayout, os: HostOs, line: MajorMinor) -> Result<Option<PathBuf>> {
@@ -749,6 +910,15 @@ fn parse_alias_set_target(target: &str) -> Result<Option<Version>> {
 
     let version = parse_exact_version(target)?;
     Ok(Some(version))
+}
+
+fn parse_update_selector(value: &str) -> Result<VersionSelector> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "stable" => Ok(VersionSelector::Stable),
+        "preview" => Ok(VersionSelector::Preview),
+        "lts" => Ok(VersionSelector::Lts),
+        _ => parse_major_minor_selector(value).map(VersionSelector::MajorMinor),
+    }
 }
 
 fn run_venv(args: &[String]) -> Result<()> {
@@ -882,7 +1052,7 @@ fn run_venv(args: &[String]) -> Result<()> {
 fn run_alias(args: &[String]) -> Result<()> {
     if args.is_empty() {
         return Err(MultiPwshError::InvalidArguments(
-            "alias requires: set <major.minor> <version|latest> or unset <major.minor>".to_string(),
+            "alias requires: set <major.minor> <version|latest>, set <pwsh|pwsh-preview|pwsh-lts> <stable|preview|lts|version>, unset <major.minor>, or unset <pwsh|pwsh-preview|pwsh-lts>".to_string(),
         ));
     }
 
@@ -894,8 +1064,18 @@ fn run_alias(args: &[String]) -> Result<()> {
         "set" => {
             if args.len() != 3 {
                 return Err(MultiPwshError::InvalidArguments(
-                    "alias set requires: <major.minor> <version|latest>".to_string(),
+                    "alias set requires: <major.minor> <version|latest> or <pwsh|pwsh-preview|pwsh-lts> <stable|preview|lts|version>".to_string(),
                 ));
+            }
+
+            if is_special_alias_command(&args[1]) {
+                let policy = parse_special_alias_policy(&args[2])?;
+                validate_special_alias_policy(&args[1], &policy)?;
+                let policy_text = policy.as_metadata_value();
+                set_special_alias_policy(&layout, &args[1], Some(&policy_text))?;
+                refresh_special_aliases(&layout, os)?;
+                println!("Configured alias {} to follow {}", args[1], policy_text);
+                return Ok(());
             }
 
             let line = parse_major_minor_selector(&args[1])?;
@@ -939,8 +1119,17 @@ fn run_alias(args: &[String]) -> Result<()> {
         "unset" => {
             if args.len() != 2 {
                 return Err(MultiPwshError::InvalidArguments(
-                    "alias unset requires: <major.minor>".to_string(),
+                    "alias unset requires: <major.minor> or <pwsh|pwsh-preview|pwsh-lts>".to_string(),
                 ));
+            }
+
+            if is_special_alias_command(&args[1]) {
+                set_special_alias_policy(&layout, &args[1], None)?;
+                if remove_alias(&layout, os, &args[1])? {
+                    println!("Removed alias {}", args[1]);
+                }
+                println!("Removed policy for {}", args[1]);
+                return Ok(());
             }
 
             let line = parse_major_minor_selector(&args[1])?;
@@ -957,7 +1146,7 @@ fn run_alias(args: &[String]) -> Result<()> {
             Ok(())
         }
         _ => Err(MultiPwshError::InvalidArguments(
-            "alias requires: set <major.minor> <version|latest> or unset <major.minor>".to_string(),
+            "alias requires: set <major.minor> <version|latest>, set <pwsh|pwsh-preview|pwsh-lts> <stable|preview|lts|version>, unset <major.minor>, or unset <pwsh|pwsh-preview|pwsh-lts>".to_string(),
         )),
     }
 }
@@ -1454,11 +1643,11 @@ fn run_package_install(selector_input: &str, install_options: InstallCommandOpti
 
     let token = env::var("GITHUB_TOKEN").ok();
     let release_client = ReleaseClient::new(token)?;
-    let releases = match selector {
+    let releases = match selector.clone() {
         VersionSelector::MajorMinorWildcard(line) => {
             release_client.resolve_all_in_line(line, os, arch, options.include_prerelease)?
         }
-        _ => vec![release_client.resolve_selector(selector, os, arch, options.include_prerelease)?],
+        _ => vec![release_client.resolve_selector(selector.clone(), os, arch, options.include_prerelease)?],
     };
 
     let mut metadata = load_package_metadata(&layout)?;
@@ -1523,6 +1712,9 @@ fn run_package_install(selector_input: &str, install_options: InstallCommandOpti
             println!("Updated major alias: {}", path.display());
         }
     }
+
+    ensure_default_special_policy(&layout, &selector)?;
+    refresh_special_aliases(&layout, os)?;
 
     println!("Alias bin: {}", layout.bin_dir().display());
     println!("Add to PATH once for this scope: {}", layout.bin_dir().display());
@@ -1810,11 +2002,11 @@ fn run_install(
 
     let token = env::var("GITHUB_TOKEN").ok();
     let release_client = ReleaseClient::new(token)?;
-    let releases = match selector {
+    let releases = match selector.clone() {
         VersionSelector::MajorMinorWildcard(line) => {
             release_client.resolve_all_in_line(line, os, arch, include_prerelease)?
         }
-        _ => vec![release_client.resolve_selector(selector, os, arch, include_prerelease)?],
+        _ => vec![release_client.resolve_selector(selector.clone(), os, arch, include_prerelease)?],
     };
 
     let mut touched_lines: Vec<MajorMinor> = Vec::new();
@@ -1868,6 +2060,9 @@ fn run_install(
             println!("Updated major alias: {}", path.display());
         }
     }
+
+    ensure_default_special_policy(&layout, &selector)?;
+    refresh_special_aliases(&layout, os)?;
 
     println!("Add to PATH once: {}", layout.bin_dir().display());
 
@@ -2002,6 +2197,8 @@ fn cleanup_aliases_for_removed_version(layout: &InstallLayout, os: HostOs, versi
         "Alias cleanup complete: {} updated, {} removed, {} pinned unresolved",
         updated_aliases, removed_aliases, unresolved_pinned_aliases
     );
+
+    refresh_special_aliases(layout, os)?;
 
     Ok(())
 }
@@ -2172,6 +2369,8 @@ fn run_doctor(args: &[String]) -> Result<()> {
     let layout = InstallLayout::new(os)?;
     layout.ensure_base_dirs()?;
 
+    refresh_special_aliases(&layout, os)?;
+
     let aliases = aliases::read_alias_metadata(&layout)?;
     if aliases.is_empty() {
         println!("No aliases found in metadata.");
@@ -2226,6 +2425,9 @@ fn run_doctor(args: &[String]) -> Result<()> {
             Some(AliasSelector::MajorMinor(line)) => create_or_update_alias(&layout, os, line, &version, &target)?,
             Some(AliasSelector::Major(major)) => create_or_update_major_alias(&layout, os, major, &version, &target)?,
             Some(AliasSelector::Exact(_)) => create_or_update_patch_alias(&layout, os, &version, &target)?,
+            None if is_special_alias_command(&alias_name) => {
+                create_or_update_named_alias(&layout, os, &alias_name, &version, &target)?
+            }
             None => {
                 eprintln!("Skipping alias {}: unsupported alias name format", alias_name);
                 skipped += 1;
@@ -2259,7 +2461,7 @@ fn run() -> Result<()> {
         "install" => {
             if args.len() < 2 {
                 return Err(MultiPwshError::InvalidArguments(
-                    "install requires <version|major|major.minor|major.minor.x>".to_string(),
+                    "install requires <stable|preview|lts|version|major|major.minor|major.minor.x>".to_string(),
                 ));
             }
             if os == HostOs::Windows || requires_scoped_install_backend(&args[2..]) {
@@ -2278,16 +2480,25 @@ fn run() -> Result<()> {
         "update" => {
             if args.len() < 2 {
                 return Err(MultiPwshError::InvalidArguments(
-                    "update requires <major.minor>".to_string(),
+                    "update requires <major.minor|stable|preview|lts>".to_string(),
                 ));
             }
+            let update_selector = parse_update_selector(&args[1])?;
+
             if os == HostOs::Windows || requires_scoped_install_backend(&args[2..]) {
-                parse_major_minor_selector(&args[1])?;
                 let options = parse_package_install_options(&args[2..])?;
                 run_package_install(&args[1], options)
-            } else {
+            } else if matches!(update_selector, VersionSelector::MajorMinor(_)) {
                 let options = parse_release_selection_options(&args[2..])?;
                 run_update(
+                    &args[1],
+                    options.arch,
+                    options.include_prerelease,
+                    options.checksum_source,
+                )
+            } else {
+                let options = parse_release_selection_options(&args[2..])?;
+                run_install(
                     &args[1],
                     options.arch,
                     options.include_prerelease,
@@ -2510,6 +2721,30 @@ mod tests {
     }
 
     #[test]
+    fn detect_implicit_host_selector_accepts_bare_pwsh_alias() {
+        let bin_dir = PathBuf::from("C:/Users/test/.pwsh/bin");
+
+        let selector = detect_implicit_host_selector(&bin_dir, &bin_dir.join("pwsh.exe"));
+        assert_eq!(selector, Some("pwsh".to_string()));
+    }
+
+    #[test]
+    fn detect_implicit_host_selector_accepts_preview_alias() {
+        let bin_dir = PathBuf::from("C:/Users/test/.pwsh/bin");
+
+        let selector = detect_implicit_host_selector(&bin_dir, &bin_dir.join("pwsh-preview.exe"));
+        assert_eq!(selector, Some("pwsh-preview".to_string()));
+    }
+
+    #[test]
+    fn detect_implicit_host_selector_accepts_lts_alias() {
+        let bin_dir = PathBuf::from("C:/Users/test/.pwsh/bin");
+
+        let selector = detect_implicit_host_selector(&bin_dir, &bin_dir.join("pwsh-lts.exe"));
+        assert_eq!(selector, Some("pwsh-lts".to_string()));
+    }
+
+    #[test]
     fn detect_implicit_host_selector_accepts_posix_alias_with_dot() {
         let bin_dir = PathBuf::from("/home/test/.pwsh/bin");
 
@@ -2715,6 +2950,76 @@ mod tests {
     fn parse_alias_set_target_accepts_exact_version() {
         let version = parse_alias_set_target("7.4.11").unwrap().unwrap();
         assert_eq!(version, Version::parse("7.4.11").unwrap());
+    }
+
+    #[test]
+    fn parse_special_alias_policy_accepts_channels() {
+        assert_eq!(
+            parse_special_alias_policy("stable").unwrap(),
+            SpecialAliasPolicy::Stable
+        );
+        assert_eq!(
+            parse_special_alias_policy("PREVIEW").unwrap(),
+            SpecialAliasPolicy::Preview
+        );
+        assert_eq!(parse_special_alias_policy("lts").unwrap(), SpecialAliasPolicy::Lts);
+    }
+
+    #[test]
+    fn parse_special_alias_policy_accepts_exact_version() {
+        assert_eq!(
+            parse_special_alias_policy("7.6.2").unwrap(),
+            SpecialAliasPolicy::Exact(Version::parse("7.6.2").unwrap())
+        );
+    }
+
+    #[test]
+    fn validate_special_alias_policy_restricts_preview_alias() {
+        assert!(validate_special_alias_policy(PWSH_PREVIEW_ALIAS, &SpecialAliasPolicy::Preview).is_ok());
+        assert!(validate_special_alias_policy(
+            PWSH_PREVIEW_ALIAS,
+            &SpecialAliasPolicy::Exact(Version::parse("7.7.0-preview.1").unwrap())
+        )
+        .is_ok());
+        assert!(validate_special_alias_policy(PWSH_PREVIEW_ALIAS, &SpecialAliasPolicy::Stable).is_err());
+    }
+
+    #[test]
+    fn validate_special_alias_policy_restricts_lts_alias() {
+        assert!(validate_special_alias_policy(PWSH_LTS_ALIAS, &SpecialAliasPolicy::Lts).is_ok());
+        assert!(validate_special_alias_policy(
+            PWSH_LTS_ALIAS,
+            &SpecialAliasPolicy::Exact(Version::parse("7.6.2").unwrap())
+        )
+        .is_ok());
+        assert!(validate_special_alias_policy(PWSH_LTS_ALIAS, &SpecialAliasPolicy::Stable).is_err());
+        assert!(validate_special_alias_policy(
+            PWSH_LTS_ALIAS,
+            &SpecialAliasPolicy::Exact(Version::parse("7.5.7").unwrap())
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn resolve_special_alias_policy_selects_expected_versions() {
+        let versions = vec![
+            Version::parse("7.7.0-preview.1").unwrap(),
+            Version::parse("7.6.2").unwrap(),
+            Version::parse("7.5.7").unwrap(),
+        ];
+
+        assert_eq!(
+            resolve_special_alias_policy_from_installed(&versions, &SpecialAliasPolicy::Stable),
+            Some(Version::parse("7.6.2").unwrap())
+        );
+        assert_eq!(
+            resolve_special_alias_policy_from_installed(&versions, &SpecialAliasPolicy::Preview),
+            Some(Version::parse("7.7.0-preview.1").unwrap())
+        );
+        assert_eq!(
+            resolve_special_alias_policy_from_installed(&versions, &SpecialAliasPolicy::Lts),
+            Some(Version::parse("7.6.2").unwrap())
+        );
     }
 
     #[test]

--- a/crates/multi-pwsh/src/release.rs
+++ b/crates/multi-pwsh/src/release.rs
@@ -4,7 +4,7 @@ use ureq::Agent;
 
 use crate::error::{MultiPwshError, Result};
 use crate::platform::{HostArch, HostOs};
-use crate::versions::{MajorMinor, VersionSelector};
+use crate::versions::{is_current_lts_version, MajorMinor, VersionSelector};
 
 const CHECKSUM_ASSET_NAME: &str = "hashes.sha256";
 
@@ -55,6 +55,9 @@ impl ReleaseClient {
         include_prerelease: bool,
     ) -> Result<ResolvedRelease> {
         match selector {
+            VersionSelector::Stable => self.resolve_latest_stable(os, arch),
+            VersionSelector::Preview => self.resolve_latest_preview(os, arch),
+            VersionSelector::Lts => self.resolve_latest_lts(os, arch),
             VersionSelector::Major(major) => self.resolve_latest_in_major(major, os, arch, include_prerelease),
             VersionSelector::Exact(version) => self.resolve_exact(version, os, arch),
             VersionSelector::MajorMinor(line) => self.resolve_latest_in_line(line, os, arch, include_prerelease),
@@ -120,6 +123,33 @@ impl ReleaseClient {
             .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("no release found for major {}", major)))?;
 
         resolve_release_asset(release, os, arch)
+    }
+
+    pub fn resolve_latest_stable(&self, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
+        let releases = self.fetch_releases()?;
+        let candidates = sorted_candidates(releases, |github_release, parsed| {
+            !github_release.prerelease && parsed.version.pre.is_empty()
+        });
+
+        resolve_first_candidate_asset(candidates, os, arch, "no stable release found")
+    }
+
+    pub fn resolve_latest_preview(&self, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
+        let releases = self.fetch_releases()?;
+        let candidates = sorted_candidates(releases, |github_release, parsed| {
+            github_release.prerelease && !parsed.version.pre.is_empty()
+        });
+
+        resolve_first_candidate_asset(candidates, os, arch, "no preview release found")
+    }
+
+    pub fn resolve_latest_lts(&self, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
+        let releases = self.fetch_releases()?;
+        let candidates = sorted_candidates(releases, |github_release, parsed| {
+            !github_release.prerelease && parsed.version.pre.is_empty() && is_current_lts_version(&parsed.version)
+        });
+
+        resolve_first_candidate_asset(candidates, os, arch, "no current LTS release found")
     }
 
     pub fn resolve_latest_in_line(
@@ -208,6 +238,44 @@ impl ReleaseClient {
 
         Ok(all_releases)
     }
+}
+
+fn sorted_candidates(
+    releases: Vec<GithubRelease>,
+    predicate: impl Fn(&GithubRelease, &ParsedRelease) -> bool,
+) -> Vec<ParsedRelease> {
+    let mut candidates: Vec<ParsedRelease> = releases
+        .into_iter()
+        .filter_map(|github_release| {
+            let parsed = ParsedRelease::from_github_release(github_release)?;
+            if predicate(&parsed.source, &parsed) {
+                Some(parsed)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    candidates.sort_by(|a, b| b.version.cmp(&a.version));
+    candidates
+}
+
+fn resolve_first_candidate_asset(
+    candidates: Vec<ParsedRelease>,
+    os: HostOs,
+    arch: HostArch,
+    not_found_message: &str,
+) -> Result<ResolvedRelease> {
+    let mut last_asset_error = None;
+
+    for candidate in candidates {
+        match resolve_release_asset(candidate, os, arch) {
+            Ok(release) => return Ok(release),
+            Err(error) => last_asset_error = Some(error),
+        }
+    }
+
+    Err(last_asset_error.unwrap_or_else(|| MultiPwshError::ReleaseNotFound(not_found_message.to_string())))
 }
 
 fn resolve_release_asset(release: ParsedRelease, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
@@ -309,7 +377,7 @@ fn wildcard_match(pattern: &str, text: &str) -> bool {
     true
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct GithubRelease {
     tag_name: String,
     prerelease: bool,
@@ -324,6 +392,7 @@ struct GithubAsset {
 
 #[derive(Debug)]
 struct ParsedRelease {
+    source: GithubRelease,
     tag_name: String,
     version: Version,
     assets: Vec<GithubAsset>,
@@ -335,9 +404,10 @@ impl ParsedRelease {
         let version = Version::parse(version_text).ok()?;
 
         Some(ParsedRelease {
-            tag_name: release.tag_name,
+            tag_name: release.tag_name.clone(),
             version,
-            assets: release.assets,
+            assets: release.assets.clone(),
+            source: release,
         })
     }
 }
@@ -365,6 +435,11 @@ mod tests {
     #[test]
     fn resolve_release_asset_includes_checksum_asset() {
         let release = ParsedRelease {
+            source: GithubRelease {
+                tag_name: "v7.4.13".to_string(),
+                prerelease: false,
+                assets: Vec::new(),
+            },
             tag_name: "v7.4.13".to_string(),
             version: Version::parse("7.4.13").unwrap(),
             assets: vec![
@@ -392,6 +467,11 @@ mod tests {
     #[test]
     fn resolve_release_asset_allows_missing_checksum_asset() {
         let release = ParsedRelease {
+            source: GithubRelease {
+                tag_name: "v7.4.13".to_string(),
+                prerelease: false,
+                assets: Vec::new(),
+            },
             tag_name: "v7.4.13".to_string(),
             version: Version::parse("7.4.13").unwrap(),
             assets: vec![GithubAsset {
@@ -404,5 +484,48 @@ mod tests {
 
         assert!(resolved.checksum_asset_name.is_none());
         assert!(resolved.checksum_asset_url.is_none());
+    }
+
+    fn github_release(tag_name: &str, prerelease: bool) -> GithubRelease {
+        GithubRelease {
+            tag_name: tag_name.to_string(),
+            prerelease,
+            assets: vec![GithubAsset {
+                name: format!("PowerShell-{}-win-x64.zip", tag_name.trim_start_matches('v')),
+                browser_download_url: format!("https://example.invalid/{}.zip", tag_name),
+            }],
+        }
+    }
+
+    #[test]
+    fn sorted_candidates_can_filter_stable_releases() {
+        let candidates = sorted_candidates(
+            vec![
+                github_release("v7.7.0-preview.1", true),
+                github_release("v7.6.2", false),
+                github_release("v7.5.7", false),
+            ],
+            |github_release, parsed| !github_release.prerelease && parsed.version.pre.is_empty(),
+        );
+
+        assert_eq!(candidates[0].version, Version::parse("7.6.2").unwrap());
+        assert_eq!(candidates[1].version, Version::parse("7.5.7").unwrap());
+    }
+
+    #[test]
+    fn sorted_candidates_can_filter_current_lts_releases() {
+        let candidates = sorted_candidates(
+            vec![
+                github_release("v7.7.0-preview.1", true),
+                github_release("v7.6.2", false),
+                github_release("v7.4.16", false),
+            ],
+            |github_release, parsed| {
+                !github_release.prerelease && parsed.version.pre.is_empty() && is_current_lts_version(&parsed.version)
+            },
+        );
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].version, Version::parse("7.6.2").unwrap());
     }
 }

--- a/crates/multi-pwsh/src/versions.rs
+++ b/crates/multi-pwsh/src/versions.rs
@@ -27,6 +27,9 @@ impl fmt::Display for MajorMinor {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VersionSelector {
+    Stable,
+    Preview,
+    Lts,
     Major(u64),
     Exact(Version),
     MajorMinor(MajorMinor),
@@ -34,6 +37,13 @@ pub enum VersionSelector {
 }
 
 pub fn parse_install_selector(value: &str) -> Result<VersionSelector> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "stable" => return Ok(VersionSelector::Stable),
+        "preview" => return Ok(VersionSelector::Preview),
+        "lts" => return Ok(VersionSelector::Lts),
+        _ => {}
+    }
+
     if let Ok(line) = parse_major_minor_wildcard_selector(value) {
         return Ok(VersionSelector::MajorMinorWildcard(line));
     }
@@ -48,6 +58,30 @@ pub fn parse_install_selector(value: &str) -> Result<VersionSelector> {
 
     let exact = parse_exact_version(value)?;
     Ok(VersionSelector::Exact(exact))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LtsLine {
+    pub line: MajorMinor,
+    pub current: bool,
+}
+
+pub const POWERSHELL_LTS_LINES: &[LtsLine] = &[
+    LtsLine {
+        line: MajorMinor { major: 7, minor: 6 },
+        current: true,
+    },
+    LtsLine {
+        line: MajorMinor { major: 7, minor: 4 },
+        current: false,
+    },
+];
+
+pub fn is_current_lts_version(version: &Version) -> bool {
+    let line = MajorMinor::from_version(version);
+    POWERSHELL_LTS_LINES
+        .iter()
+        .any(|lts_line| lts_line.current && lts_line.line == line)
 }
 
 pub fn parse_major_minor_wildcard_selector(value: &str) -> Result<MajorMinor> {
@@ -205,6 +239,13 @@ mod tests {
             }
             _ => panic!("expected major selector"),
         }
+    }
+
+    #[test]
+    fn parses_channel_selectors() {
+        assert_eq!(parse_install_selector("stable").unwrap(), VersionSelector::Stable);
+        assert_eq!(parse_install_selector("PREVIEW").unwrap(), VersionSelector::Preview);
+        assert_eq!(parse_install_selector("lts").unwrap(), VersionSelector::Lts);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add stable, preview, and lts install/update selectors
- add managed special aliases for pwsh, pwsh-preview, and pwsh-lts
- document channel selectors and alias policy behavior

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets
- cargo build --all-targets
- $env:RUST_TEST_THREADS='1'; cargo test --all-targets
- dotnet build dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj
- dotnet test dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj --no-build