### PR TITLE
Prepare 0.9.0 release cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,24 @@ jobs:
           $cargoBin = Join-Path $cargoHome 'bin'
           $cargoBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Add multi-pwsh alias bin to PATH (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $multiPwshHome = if ($env:MULTI_PWSH_HOME) { $env:MULTI_PWSH_HOME } else { Join-Path $HOME '.pwsh' }
+          $multiPwshBin = if ($env:MULTI_PWSH_BIN_DIR) { $env:MULTI_PWSH_BIN_DIR } else { Join-Path $multiPwshHome 'bin' }
+          $userAliasBin = Join-Path $env:LOCALAPPDATA 'PowerShell\bin'
+          $multiPwshBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $userAliasBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Add multi-pwsh alias bin to PATH (Unix)
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          multi_pwsh_home="${MULTI_PWSH_HOME:-$HOME/.pwsh}"
+          multi_pwsh_bin="${MULTI_PWSH_BIN_DIR:-${multi_pwsh_home}/bin}"
+          echo "$multi_pwsh_bin" >> "$GITHUB_PATH"
+
       - name: Cache multi-pwsh downloads
         uses: actions/cache@v4
         with:
@@ -101,6 +119,10 @@ jobs:
           multi-pwsh install lts
           multi-pwsh install 7.4
           multi-pwsh install 7.5
+
+      - name: Verify PowerShell aliases
+        shell: pwsh
+        run: |
           $stableVersion = & pwsh -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
           $previewLabel = & pwsh-preview -NoLogo -NoProfile -Command '$label = [string]$PSVersionTable.PSVersion.PreReleaseLabel; if ([string]::IsNullOrWhiteSpace($label)) { throw "Expected pwsh-preview to resolve to a prerelease build." }; $label'
           $ltsVersion = & pwsh-lts -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,35 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install multi-pwsh bootstrap
-        run: bash ./tools/install-multi-pwsh.sh
-
-      - name: Add multi-pwsh bin to PATH
-        shell: bash
-        run: |
-          multi_pwsh_home="${MULTI_PWSH_HOME:-$HOME/.pwsh}"
-          multi_pwsh_bin="${MULTI_PWSH_BIN_DIR:-${multi_pwsh_home}/bin}"
-          echo "$multi_pwsh_bin" >> "$GITHUB_PATH"
-
-      - name: Cache multi-pwsh downloads
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/multi-pwsh-cache
-          key: multi-pwsh-cache-${{ runner.os }}-${{ hashFiles('crates/multi-pwsh/Cargo.toml', '.github/workflows/ci.yml') }}
-          restore-keys: |
-            multi-pwsh-cache-${{ runner.os }}-
-
-      - name: Install PowerShell aliases
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          MULTI_PWSH_CACHE_KEEP: '1'
-        run: |
-          multi-pwsh install stable
-          multi-pwsh install preview
-          multi-pwsh install lts
-          multi-pwsh install 7.4
-
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v4
         with:
@@ -86,32 +57,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install multi-pwsh bootstrap (Windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: ./tools/install-multi-pwsh.ps1
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
 
-      - name: Install multi-pwsh bootstrap (Unix)
-        if: matrix.os != 'windows-latest'
-        run: bash ./tools/install-multi-pwsh.sh
-
-      - name: Add multi-pwsh bin to PATH (Windows)
-        if: matrix.os == 'windows-latest'
+      - name: Install Rust toolchain
         shell: pwsh
         run: |
-          $multiPwshHome = if ($env:MULTI_PWSH_HOME) { $env:MULTI_PWSH_HOME } else { Join-Path $HOME '.pwsh' }
-          $multiPwshBin = if ($env:MULTI_PWSH_BIN_DIR) { $env:MULTI_PWSH_BIN_DIR } else { Join-Path $multiPwshHome 'bin' }
-          $userAliasBin = Join-Path $env:LOCALAPPDATA 'PowerShell\bin'
-          $multiPwshBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          $userAliasBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
-      - name: Add multi-pwsh bin to PATH (Unix)
-        if: matrix.os != 'windows-latest'
-        shell: bash
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2.8.2
+
+      - name: Install multi-pwsh from source
+        shell: pwsh
+        run: cargo install --locked --path crates/multi-pwsh --force
+
+      - name: Add cargo bin to PATH
+        shell: pwsh
         run: |
-          multi_pwsh_home="${MULTI_PWSH_HOME:-$HOME/.pwsh}"
-          multi_pwsh_bin="${MULTI_PWSH_BIN_DIR:-${multi_pwsh_home}/bin}"
-          echo "$multi_pwsh_bin" >> "$GITHUB_PATH"
+          $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $HOME '.cargo' }
+          $cargoBin = Join-Path $cargoHome 'bin'
+          $cargoBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Cache multi-pwsh downloads
         uses: actions/cache@v4
@@ -142,20 +111,6 @@ jobs:
           Write-Host "pwsh-lts -> $ltsVersion"
           pwsh-7.4 -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
           pwsh-7.5 -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
-
-      - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: global.json
-
-      - name: Install Rust toolchain
-        shell: pwsh
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-
-      - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2.8.2
 
       - name: Configure static MSVC runtime
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MULTI_PWSH_CACHE_KEEP: '1'
         run: |
+          multi-pwsh install stable
+          multi-pwsh install preview
+          multi-pwsh install lts
           multi-pwsh install 7.4
-          multi-pwsh install 7.5
 
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v4
@@ -125,8 +127,19 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MULTI_PWSH_CACHE_KEEP: '1'
         run: |
+          multi-pwsh install stable
+          multi-pwsh install preview
+          multi-pwsh install lts
           multi-pwsh install 7.4
           multi-pwsh install 7.5
+          $stableVersion = & pwsh -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
+          $previewLabel = & pwsh-preview -NoLogo -NoProfile -Command '$label = [string]$PSVersionTable.PSVersion.PreReleaseLabel; if ([string]::IsNullOrWhiteSpace($label)) { throw "Expected pwsh-preview to resolve to a prerelease build." }; $label'
+          $ltsVersion = & pwsh-lts -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
+          & multi-pwsh alias set pwsh-preview preview
+          & multi-pwsh alias set pwsh-lts lts
+          Write-Host "pwsh -> $stableVersion"
+          Write-Host "pwsh-preview -> $previewLabel"
+          Write-Host "pwsh-lts -> $ltsVersion"
           pwsh-7.4 -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
           pwsh-7.5 -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to build/publish
+        description: Release tag to create/update when publishing
         required: true
         type: string
 
@@ -12,9 +12,67 @@ permissions:
   contents: write
 
 jobs:
+  validate:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      checkout_ref: ${{ steps.validate.outputs.checkout_ref }}
+      release_tag: ${{ steps.validate.outputs.release_tag }}
+      release_target: ${{ steps.validate.outputs.release_target }}
+      release_version: ${{ steps.validate.outputs.release_version }}
+
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.ref }}
+
+      - name: Validate tag format and crate versions
+        id: validate
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag }}
+          CHECKOUT_REF: ${{ github.ref }}
+        run: |
+          tag="${RELEASE_TAG}"
+
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must match vX.Y.Z or vX.Y.Z-suffix. Got: ${tag}" >&2
+            exit 1
+          fi
+
+          release_version="${tag#v}"
+          multi_version="$(sed -n 's/^version = "\(.*\)"/\1/p' crates/multi-pwsh/Cargo.toml | head -n 1)"
+          host_version="$(sed -n 's/^version = "\(.*\)"/\1/p' crates/pwsh-host/Cargo.toml | head -n 1)"
+
+          if [[ -z "${multi_version}" || -z "${host_version}" ]]; then
+            echo "Failed to read crate versions from Cargo.toml files." >&2
+            exit 1
+          fi
+
+          if [[ "${multi_version}" != "${host_version}" ]]; then
+            echo "Crate versions do not match: multi-pwsh=${multi_version}, pwsh-host=${host_version}" >&2
+            exit 1
+          fi
+
+          if [[ "${multi_version}" != "${release_version}" ]]; then
+            echo "Release tag ${tag} does not match crate version ${multi_version}" >&2
+            exit 1
+          fi
+
+          release_target="$(git rev-parse HEAD)"
+
+          echo "checkout_ref=${CHECKOUT_REF}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "release_target=${release_target}" >> "$GITHUB_OUTPUT"
+          echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: validate
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +117,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ needs.validate.outputs.checkout_ref }}
 
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v4
@@ -144,12 +202,15 @@ jobs:
   publish:
     name: Publish GitHub release
     runs-on: ubuntu-latest
-    needs: build
-    if: startsWith(github.event.inputs.tag, 'v')
+    needs:
+      - validate
+      - build
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.checkout_ref }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -183,8 +244,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ github.event.inputs.tag }}
-          RELEASE_TARGET: ${{ github.sha }}
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+          RELEASE_TARGET: ${{ needs.validate.outputs.release_target }}
         run: |
           $zipFiles = Get-ChildItem -Path dist -Recurse -File |
             Where-Object { $_.Name -like 'multi-pwsh-*.zip' } |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "flate2",
  "home",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/m
 irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.6.0`):
+Install a specific tag (example `v0.9.0`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.6.0
+curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.9.0
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.6.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.9.0
 ```
 
 Uninstall bootstrap scripts:
@@ -40,17 +40,25 @@ irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/t
 
 ```powershell
 multi-pwsh install stable
+multi-pwsh install preview
+multi-pwsh install lts
 multi-pwsh install 7.4
-multi-pwsh install 7.5
 ```
 
 Verify aliases:
 
 ```powershell
-pwsh-7 --version
+pwsh --version
+pwsh-preview --version
+pwsh-lts --version
 pwsh-7.4 --version
-pwsh-7.5 --version
 ```
+
+## More docs
+
+- [Native host mode and virtual environments](docs/host-and-venv.md)
+- [Testing guide](docs/testing.md)
+- [Release process](RELEASE.md)
 
 ## Scoped installs
 
@@ -108,34 +116,55 @@ The Windows-only integration flags above currently return an error on macOS/Linu
 
 ## Manage installed lines
 
+### Channel installs and updates
+
 ```powershell
-multi-pwsh install 7.4.x
+multi-pwsh install stable
+multi-pwsh install preview
+multi-pwsh install lts
 multi-pwsh update stable
 multi-pwsh update preview
 multi-pwsh update lts
-multi-pwsh update 7.4
-multi-pwsh update 7.5
 multi-pwsh list
 multi-pwsh list --available
 multi-pwsh list --available --include-prerelease
+```
+
+### Exact versions and lines
+
+```powershell
+multi-pwsh install 7.4.x
 multi-pwsh install 7.6 --include-prerelease
 multi-pwsh install 7.6-preview6
 multi-pwsh install 7.6-rc1
 multi-pwsh install 7.6.0-rc.1
+multi-pwsh update 7.4
+multi-pwsh update 7.5
 multi-pwsh update 7.6 --include-prerelease
+multi-pwsh uninstall 7.4.13
+```
+
+### Alias policy and host mode
+
+```powershell
 multi-pwsh alias set pwsh stable
 multi-pwsh alias set pwsh lts
 multi-pwsh alias set pwsh-preview preview
 multi-pwsh alias set pwsh-lts lts
 multi-pwsh alias set 7.4 7.4.11
 multi-pwsh alias unset 7.4
+multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile -Command "$env:PSModulePath"
+multi-pwsh doctor --repair-aliases
+```
+
+### Venv management
+
+```powershell
 multi-pwsh venv create msgraph
 multi-pwsh venv export msgraph msgraph.zip
 multi-pwsh venv import msgraph-copy msgraph.zip
 multi-pwsh venv delete msgraph
 multi-pwsh venv list
-multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile -Command "$env:PSModulePath"
-multi-pwsh doctor --repair-aliases
 ```
 
 `multi-pwsh` usage reference:
@@ -159,43 +188,7 @@ multi-pwsh doctor --repair-aliases
 
 The Windows integration flags in the `install` and `update` forms are limited to archive-friendly behaviors; on macOS/Linux, use `--scope`, `--root`, `--arch`, `--include-prerelease`, and `--add-path` controls. Legacy scope aliases such as `current-user` and `all-users` are still accepted for compatibility.
 
-### Venv cmdlet matrix tests (Pester)
-
-Use the local Pester harness to validate venv-sensitive cmdlet behavior across installed version aliases (`pwsh-x.y.z`).
-
-Run all installed version aliases:
-
-```powershell
-pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1
-```
-
-Run one alias only:
-
-```powershell
-pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1 -Aliases pwsh-7.4.13
-```
-
-Include online install tests (`Install-PSResource` / `Install-Module`):
-
-```powershell
-pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1 -EnableOnlineTests
-```
-
-Online mode details:
-
-- The tests do not modify PSGallery trust policy.
-- `Install-PSResource` uses `-TrustRepository -Quiet` and `Install-Module` uses `-Force -AcceptLicense -Confirm:$false` to run non-interactively.
-- The install checks use `Yayaml` to keep downloads and execution lightweight.
-
-Notes:
-
-- The runner creates a temporary venv per alias and deletes it by default.
-- Use `-KeepVenv` to keep those venvs for troubleshooting.
-- The runner stops on the first failed alias by default.
-- Use `-ContinueOnFailure` to keep running remaining aliases after a failure.
-- Pester must be available in the host PowerShell session.
-
-Selector behavior:
+## Selector behavior
 
 - `stable` installs the latest GA/non-preview release for your platform and configures `pwsh` to follow the latest installed stable release.
 - `preview` installs the latest prerelease for your platform and configures `pwsh-preview` to follow the latest installed preview release.
@@ -206,121 +199,27 @@ Selector behavior:
 - `7.4.11` installs that exact version.
 
 `multi-pwsh install 7.4.x` installs every available patch release in that line for your current platform and creates per-version aliases such as `pwsh-7.4.11`.
+
 The `pwsh-7.4` alias tracks latest by default; pin it with `multi-pwsh alias set 7.4 7.4.11` and unpin with `multi-pwsh alias unset 7.4`.
+
 If a pinned target version is not installed, the pin remains in metadata and the alias stays unresolved until you install that version or unpin.
+
 The bare `pwsh` alias is a managed policy alias. Configure it with `multi-pwsh alias set pwsh stable`, `multi-pwsh alias set pwsh lts`, `multi-pwsh alias set pwsh preview`, or an exact version. `pwsh-preview` tracks preview by default, and `pwsh-lts` tracks LTS by default. Policy aliases resolve only to installed versions; install or update the desired channel before pointing an alias at it.
 
-Native host mode:
+The current LTS line is encoded in the tool; at the moment that is `7.6`.
 
-- `multi-pwsh host <selector> ...` runs PowerShell through native hosting (`pwsh-host` crate) instead of launching a `pwsh` subprocess.
-- `<selector>` supports `7`, `7.4`, `7.4.13`, or alias-form selectors such as `pwsh-7.4`.
-- `-VirtualEnvironment <name>` and `-venv <name>` are consumed by `multi-pwsh` before handing control to PowerShell and set `PSModulePath` to the selected venv module root for that launch.
-- `PSMODULE_VENV_PATH` can also be used as an explicit path-based venv selector for hosted launches. If it is already set in the environment, `multi-pwsh host` treats it as an intentional venv opt-in.
-- Alias lifecycle now maintains native host shims as hard links to `multi-pwsh` automatically during install/update/doctor alias repair.
-- On Windows, alias command paths are `pwsh-*.exe` host shims in `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`).
-- On Linux/macOS, alias command paths (`pwsh-*`) are hard links to `multi-pwsh`.
-- `multi-pwsh doctor --repair-aliases` performs a shim health check and re-links broken hard links automatically.
-- You can still manually copy/rename `multi-pwsh.exe` under `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`) to an alias-like name (for example `pwsh-7.4.exe`); it automatically enters host mode and resolves the target installation from that alias name.
-- `-NamedPipeCommand <pipeName>` is supported in host mode (Windows only), matching `pwsh-host` behavior.
+## Native host mode and virtual environments
 
-### Virtual environments
+- `multi-pwsh host <selector> ...` runs PowerShell through native hosting instead of launching a `pwsh` subprocess.
+- Use `-venv <name>` or `-VirtualEnvironment <name>` to select a managed module root for hosted launches.
+- Use `multi-pwsh doctor --repair-aliases` to repair host shims and named aliases.
 
-`multi-pwsh` virtual environments provide isolated PowerShell module roots. They are conceptually similar to Python virtual environments, but in this first version the isolation is implemented by selecting a venv-specific `PSModulePath` entry for hosted launches.
+See [docs/host-and-venv.md](docs/host-and-venv.md) for host shims, venv layout, import/export, managed paths, and current limitations.
 
-By default, venvs live under `~/.pwsh/venv/<name>`. If `MULTI_PWSH_VENV_DIR` is set, they live under that directory instead.
+## Testing
 
-Available commands:
+- Scoped install smoke tests: `pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-ScopedInstallSmokeTest.ps1`
+- Venv matrix tests: `pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1`
 
-- `multi-pwsh venv create <name>` creates a named venv.
-- `multi-pwsh venv delete <name>` removes a named venv.
-- `multi-pwsh venv export <name> <archive.zip>` exports a named venv to a zip archive.
-- `multi-pwsh venv import <name> <archive.zip>` imports a named venv from a zip archive.
-- `multi-pwsh venv list` shows the configured venv root and all known venvs.
-
-#### Create and use a venv
-
-Create a venv and launch a hosted PowerShell session that uses it:
-
-```powershell
-multi-pwsh venv create msgraph
-multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile
-```
-
-You can verify which module root is being used:
-
-```powershell
-multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile -Command "$env:PSModulePath"
-```
-
-Both `-venv <name>` and `-VirtualEnvironment <name>` are supported.
-
-You can also opt into a venv by path with `PSMODULE_VENV_PATH`:
-
-```powershell
-$env:PSMODULE_VENV_PATH = Join-Path $HOME ".pwsh/venv/msgraph"
-multi-pwsh host 7.4 -NoLogo -NoProfile
-```
-
-`-venv <name>` and `-VirtualEnvironment <name>` accept a venv name and resolve it to a base path before launch. `PSMODULE_VENV_PATH` is the lower-level path form of the same idea and is useful when a parent PowerShell session already knows which venv path should flow to child hosted sessions.
-
-If both a venv flag and `PSMODULE_VENV_PATH` are present, the flag wins for that launch because `multi-pwsh` resolves the named venv and sets the effective path explicitly. If neither is present, no venv-specific startup-hook behavior is enabled.
-
-#### Populate a venv with modules
-
-Venvs are base directories, and the hosted PowerShell module root is `<venv-root>/Modules`. Modules should live under `<venv-root>/Modules/<ModuleName>`.
-
-For the current implementation, the safest way to place modules into a venv is to save them into that `Modules` directory:
-
-```powershell
-$venvRoot = Join-Path $HOME ".pwsh/venv/msgraph"
-$venvModules = Join-Path $venvRoot "Modules"
-Save-Module -Name Microsoft.Graph.Authentication -Repository PSGallery -Path $venvModules -Force
-Save-Module -Name Microsoft.Graph.Users -Repository PSGallery -Path $venvModules -Force
-```
-
-Then use the venv when launching PowerShell:
-
-```powershell
-multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile -Command "Get-Module -ListAvailable Microsoft.Graph.Authentication"
-```
-
-#### Export and import a venv
-
-You can package a venv as a zip archive and recreate it elsewhere:
-
-```powershell
-multi-pwsh venv export msgraph msgraph.zip
-multi-pwsh venv import msgraph-copy msgraph.zip
-multi-pwsh host 7.4 -venv msgraph-copy -NoLogo -NoProfile
-```
-
-Import is intentionally conservative: importing into an existing destination venv is rejected instead of merging archive contents.
-
-#### Current behavior and limitations
-
-- Venv selection changes module discovery and import precedence for hosted launches.
-- `Install-Module` and `Install-PSResource` use the venv's `Modules` directory during hosted launches.
-- PowerShell may still include some built-in or default module paths in the effective `PSModulePath`; the venv is intended to be the selected module root, not a perfect process-level sandbox.
-- The venv feature currently applies to `multi-pwsh host ...` and implicit host shims such as `pwsh-7.4.exe`, not to arbitrary external `pwsh` processes.
-
-Managed paths can be controlled with environment variables:
-
-- `MULTI_PWSH_HOME`: override the multi-pwsh home directory (default: `~/.pwsh`). Extracted PowerShell versions are stored under `MULTI_PWSH_HOME/multi`, virtual environments are stored under `MULTI_PWSH_HOME/venv` unless `MULTI_PWSH_VENV_DIR` is set, and alias metadata is stored in `MULTI_PWSH_HOME/aliases.json`.
-- `MULTI_PWSH_BIN_DIR`: override the shim and launcher directory (default: `MULTI_PWSH_HOME/bin`).
-- `MULTI_PWSH_CACHE_DIR`: override archive cache directory (default: `MULTI_PWSH_HOME/cache`).
-- `MULTI_PWSH_VENV_DIR`: override the virtual-environment root directory (default: `MULTI_PWSH_HOME/venv`).
-- `MULTI_PWSH_CACHE_KEEP`: keep downloaded archives after extraction when set to a truthy value (`1`, `true`, `yes`, or `on`).
-
-CI cache example:
-
-```powershell
-$env:MULTI_PWSH_HOME = "$(Join-Path $HOME '.pwsh')"
-$env:MULTI_PWSH_BIN_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'bin')"
-$env:MULTI_PWSH_CACHE_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'cache')"
-$env:MULTI_PWSH_VENV_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'venv')"
-$env:MULTI_PWSH_CACHE_KEEP = "1"
-multi-pwsh install 7.4.x
-```
-
-When installed via bootstrap scripts, `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`) is added to PATH automatically if needed.
+See [docs/testing.md](docs/testing.md) for online test mode, alias-targeted runs, and troubleshooting flags.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,53 @@
+# Release process
+
+## 1. Prepare the version
+
+Update crate versions and the README tag example:
+
+```powershell
+.\scripts\Bump-CrateVersions.ps1 -Version 0.9.0
+```
+
+Review the resulting diff in:
+
+- `crates\multi-pwsh\Cargo.toml`
+- `crates\pwsh-host\Cargo.toml`
+- `Cargo.lock`
+- `README.md`
+
+## 2. Run release checks
+
+```powershell
+rustup toolchain install stable --profile minimal
+rustup default stable
+rustup component add rustfmt clippy --toolchain stable
+cargo fmt --all --check
+cargo clippy --workspace --all-targets
+cargo build --all-targets
+cargo test --all-targets
+dotnet build dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj -p:PwshExePath="pwsh-7.4"
+dotnet test dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj --no-build -p:PwshExePath="pwsh-7.4"
+```
+
+## 3. Publish the release
+
+Dispatch `.github/workflows/release.yml` from the branch or commit you want to release, with the matching tag value, for example `v0.9.0`.
+
+You do **not** need to create the tag ahead of time. If the tag does not exist yet, the workflow creates it at the dispatched commit when it creates the GitHub release.
+
+The workflow:
+
+- validates that the tag input matches both crate versions
+- builds artifacts from the commit you dispatched the workflow from
+- creates the tag at that commit if needed
+- uploads archives and `checksums.txt` to the GitHub release
+
+If the release already exists, the workflow uploads the refreshed assets with `--clobber`.
+
+## 4. Verify release assets
+
+Confirm the release contains:
+
+- all platform zip archives
+- `checksums.txt`
+- generated release notes or any required manual edits

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "multi-pwsh"
-version = "0.7.0"
+version = "0.9.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
+homepage = "https://github.com/Devolutions/multi-pwsh"
+repository = "https://github.com/Devolutions/multi-pwsh"
 description = "Install and update side-by-side PowerShell versions in user context"
 
 [[bin]]

--- a/crates/multi-pwsh/src/install.rs
+++ b/crates/multi-pwsh/src/install.rs
@@ -138,7 +138,7 @@ fn decode_checksum_text(bytes: &[u8]) -> Result<String> {
 }
 
 fn decode_utf16_text(bytes: &[u8], little_endian: bool) -> Result<String> {
-    if bytes.len() % 2 != 0 {
+    if !bytes.len().is_multiple_of(2) {
         return Err(MultiPwshError::Archive(
             "invalid checksum file encoding: odd-length utf-16 payload".to_string(),
         ));
@@ -294,7 +294,7 @@ fn parse_checksum_line<'a>(
     parse_gnu_checksum_line(trimmed, line_number, target_asset_name)
 }
 
-fn parse_bsd_checksum_line<'a>(line: &'a str, line_number: usize) -> Result<Option<(String, &'a str)>> {
+fn parse_bsd_checksum_line(line: &str, line_number: usize) -> Result<Option<(String, &str)>> {
     let Some((left, right)) = line.split_once('=') else {
         return Ok(None);
     };

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -698,9 +698,7 @@ fn infer_layout_from_host_shim(os: HostOs, executable_path: &Path) -> Option<Ins
     } else {
         InstallLayout::from_root(os, home).ok()?
     };
-    if detect_implicit_host_selector(&layout.bin_dir(), executable_path).is_none() {
-        return None;
-    }
+    detect_implicit_host_selector(&layout.bin_dir(), executable_path)?;
 
     Some(layout)
 }

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.7.0"
+version = "0.9.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/crates/pwsh-host/src/host_detect.rs
+++ b/crates/pwsh-host/src/host_detect.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
@@ -12,14 +12,77 @@ pub enum EnvError {
     Missing,
 }
 
-pub fn find_pwsh_exe() -> Option<PathBuf> {
-    if let Ok(pwsh_exe) = which::which("pwsh") {
-        if let Ok(pwsh_link) = fs::read_link(&pwsh_exe) {
-            return Some(pwsh_link);
-        } else {
-            return Some(pwsh_exe);
+fn hostfxr_file_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "hostfxr.dll"
+    } else if cfg!(target_os = "linux") {
+        "libhostfxr.so"
+    } else {
+        "libhostfxr.dylib"
+    }
+}
+
+fn resolve_link_target(path: &Path) -> PathBuf {
+    match fs::read_link(path) {
+        Ok(link) if link.is_relative() => path.parent().unwrap_or_else(|| Path::new("")).join(link),
+        Ok(link) => link,
+        Err(_) => path.to_path_buf(),
+    }
+}
+
+fn has_pwsh_runtime(dir: &Path) -> bool {
+    dir.join("pwsh.dll").exists() && dir.join(hostfxr_file_name()).exists()
+}
+
+fn select_pwsh_exe<I>(candidates: I) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    let mut fallback: Option<PathBuf> = None;
+
+    for candidate in candidates {
+        let resolved = resolve_link_target(&candidate);
+        let is_runtime_candidate = resolved.parent().map(has_pwsh_runtime).unwrap_or(false);
+
+        if is_runtime_candidate {
+            return Some(resolved);
+        }
+
+        if fallback.is_none() {
+            fallback = Some(resolved);
         }
     }
+
+    fallback
+}
+
+fn pwsh_candidates_from_path() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    let path = match std::env::var_os("PATH") {
+        Some(path) => path,
+        None => return candidates,
+    };
+
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(format!("pwsh{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            candidates.push(candidate);
+        }
+    }
+
+    candidates
+}
+
+pub fn find_pwsh_exe() -> Option<PathBuf> {
+    let candidates = pwsh_candidates_from_path();
+    if !candidates.is_empty() {
+        return select_pwsh_exe(candidates);
+    }
+
+    if let Ok(pwsh_exe) = which::which("pwsh") {
+        return Some(resolve_link_target(&pwsh_exe));
+    }
+
     None
 }
 
@@ -34,4 +97,93 @@ pub fn find_pwsh_dir() -> Option<PathBuf> {
 #[allow(dead_code)]
 pub fn pwsh_host_detect() -> Result<PathBuf, EnvError> {
     find_pwsh_dir().ok_or(EnvError::Missing)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::hostfxr_file_name;
+    use super::pwsh_candidates_from_path;
+    use super::select_pwsh_exe;
+
+    fn create_temp_dir(prefix: &str) -> PathBuf {
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let dir = std::env::temp_dir().join(format!("multi-pwsh-{}-{}", prefix, timestamp));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn select_pwsh_exe_prefers_runtime_candidate() {
+        let temp = create_temp_dir("prefer-runtime");
+
+        let shim_dir = temp.join("shim");
+        let runtime_dir = temp.join("runtime");
+        fs::create_dir_all(&shim_dir).unwrap();
+        fs::create_dir_all(&runtime_dir).unwrap();
+
+        let shim_pwsh = shim_dir.join(format!("pwsh{}", std::env::consts::EXE_SUFFIX));
+        fs::write(&shim_pwsh, "").unwrap();
+
+        let runtime_pwsh = runtime_dir.join(format!("pwsh{}", std::env::consts::EXE_SUFFIX));
+        fs::write(&runtime_pwsh, "").unwrap();
+        fs::write(runtime_dir.join("pwsh.dll"), "").unwrap();
+        fs::write(runtime_dir.join(hostfxr_file_name()), "").unwrap();
+
+        let selected = select_pwsh_exe(vec![shim_pwsh.clone(), runtime_pwsh.clone()]).unwrap();
+        assert_eq!(selected, runtime_pwsh);
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn select_pwsh_exe_falls_back_to_first_candidate() {
+        let temp = create_temp_dir("fallback-first");
+        let first_dir = temp.join("first");
+        let second_dir = temp.join("second");
+        fs::create_dir_all(&first_dir).unwrap();
+        fs::create_dir_all(&second_dir).unwrap();
+
+        let first_pwsh = first_dir.join(format!("pwsh{}", std::env::consts::EXE_SUFFIX));
+        let second_pwsh = second_dir.join(format!("pwsh{}", std::env::consts::EXE_SUFFIX));
+        fs::write(&first_pwsh, "").unwrap();
+        fs::write(&second_pwsh, "").unwrap();
+
+        let selected = select_pwsh_exe(vec![first_pwsh.clone(), second_pwsh]).unwrap();
+        assert_eq!(selected, first_pwsh);
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn pwsh_candidates_from_path_collects_candidates() {
+        let temp = create_temp_dir("path-candidates");
+        let first_dir = temp.join("first");
+        let second_dir = temp.join("second");
+        fs::create_dir_all(&first_dir).unwrap();
+        fs::create_dir_all(&second_dir).unwrap();
+
+        let first_pwsh = first_dir.join(format!("pwsh{}", std::env::consts::EXE_SUFFIX));
+        let second_pwsh = second_dir.join(format!("pwsh{}", std::env::consts::EXE_SUFFIX));
+        fs::write(&first_pwsh, "").unwrap();
+        fs::write(&second_pwsh, "").unwrap();
+
+        let original_path = std::env::var_os("PATH");
+        let composed = std::env::join_paths([first_dir.clone(), second_dir.clone()]).unwrap();
+        unsafe {
+            std::env::set_var("PATH", composed);
+        }
+
+        let candidates = pwsh_candidates_from_path();
+        assert_eq!(candidates, vec![first_pwsh, second_pwsh]);
+
+        match original_path {
+            Some(path) => unsafe { std::env::set_var("PATH", path) },
+            None => unsafe { std::env::remove_var("PATH") },
+        }
+        let _ = fs::remove_dir_all(temp);
+    }
 }

--- a/crates/pwsh-host/src/pdcstring/other.rs
+++ b/crates/pwsh-host/src/pdcstring/other.rs
@@ -82,7 +82,6 @@ impl PdCStr {
     pub fn to_os_str(&self) -> &OsStr {
         OsStr::from_bytes(self.0.to_bytes())
     }
-    // TODO: use abstract error type
     pub fn from_slice_with_nul(slice: &[u8]) -> Result<&Self, ffi::FromBytesWithNulError> {
         CStr::from_bytes_with_nul(slice).map(PdCStr::from_inner)
     }

--- a/crates/pwsh-host/src/pdcstring/windows.rs
+++ b/crates/pwsh-host/src/pdcstring/windows.rs
@@ -85,9 +85,8 @@ impl PdCStr {
 
 // methods not used by this crate
 impl PdCStr {
-    // TODO: use abstract error type
     pub fn from_slice_with_nul(slice: &[u16]) -> Result<&Self, widestring::MissingNulError<u16>> {
-        U16CStr::from_slice_with_nul(slice).map(|s| PdCStr::from_inner(s))
+        U16CStr::from_slice_with_nul(slice).map(PdCStr::from_inner)
     }
 
     pub fn to_slice(&self) -> &[u16] {

--- a/docs/host-and-venv.md
+++ b/docs/host-and-venv.md
@@ -1,0 +1,93 @@
+# Native host mode and virtual environments
+
+## Native host mode
+
+- `multi-pwsh host <selector> ...` runs PowerShell through native hosting (`pwsh-host`) instead of launching a `pwsh` subprocess.
+- `<selector>` supports `7`, `7.4`, `7.4.13`, or alias-form selectors such as `pwsh-7.4`.
+- `-VirtualEnvironment <name>` and `-venv <name>` are consumed by `multi-pwsh` before handing control to PowerShell and set `PSModulePath` to the selected venv module root for that launch.
+- `PSMODULE_VENV_PATH` can also be used as an explicit path-based venv selector for hosted launches. If it is already set in the environment, `multi-pwsh host` treats it as an intentional venv opt-in.
+- Alias lifecycle maintains native host shims as hard links to `multi-pwsh` during install, update, and `doctor --repair-aliases`.
+- On Windows, alias command paths are `pwsh-*.exe` host shims in `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`).
+- On Linux/macOS, alias command paths (`pwsh-*`) are hard links to `multi-pwsh`.
+- `multi-pwsh doctor --repair-aliases` performs a shim health check and re-links broken hard links automatically.
+- Copying or renaming `multi-pwsh.exe` to an alias-like name such as `pwsh-7.4.exe` also enters implicit host mode.
+- `-NamedPipeCommand <pipeName>` is supported in host mode on Windows.
+
+## Virtual environments
+
+`multi-pwsh` virtual environments provide isolated PowerShell module roots for hosted launches.
+
+By default, venvs live under `~/.pwsh/venv/<name>`. If `MULTI_PWSH_VENV_DIR` is set, they live under that directory instead.
+
+Available commands:
+
+- `multi-pwsh venv create <name>`
+- `multi-pwsh venv delete <name>`
+- `multi-pwsh venv export <name> <archive.zip>`
+- `multi-pwsh venv import <name> <archive.zip>`
+- `multi-pwsh venv list`
+
+### Create and use a venv
+
+```powershell
+multi-pwsh venv create msgraph
+multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile
+multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile -Command "$env:PSModulePath"
+```
+
+You can also opt into a venv by path:
+
+```powershell
+$env:PSMODULE_VENV_PATH = Join-Path $HOME ".pwsh/venv/msgraph"
+multi-pwsh host 7.4 -NoLogo -NoProfile
+```
+
+If both a venv flag and `PSMODULE_VENV_PATH` are present, the named flag wins for that launch.
+
+### Populate a venv with modules
+
+Modules should live under `<venv-root>\Modules\<ModuleName>`.
+
+```powershell
+$venvRoot = Join-Path $HOME ".pwsh/venv/msgraph"
+$venvModules = Join-Path $venvRoot "Modules"
+Save-Module -Name Microsoft.Graph.Authentication -Repository PSGallery -Path $venvModules -Force
+Save-Module -Name Microsoft.Graph.Users -Repository PSGallery -Path $venvModules -Force
+multi-pwsh host 7.4 -venv msgraph -NoLogo -NoProfile -Command "Get-Module -ListAvailable Microsoft.Graph.Authentication"
+```
+
+### Export and import a venv
+
+```powershell
+multi-pwsh venv export msgraph msgraph.zip
+multi-pwsh venv import msgraph-copy msgraph.zip
+multi-pwsh host 7.4 -venv msgraph-copy -NoLogo -NoProfile
+```
+
+Import is intentionally conservative: importing into an existing destination venv is rejected instead of merging archive contents.
+
+### Current behavior and limitations
+
+- Venv selection changes module discovery and import precedence for hosted launches.
+- `Install-Module` and `Install-PSResource` use the venv `Modules` directory during hosted launches.
+- PowerShell may still include some built-in or default module paths in the effective `PSModulePath`; the venv is a selected module root, not a full process sandbox.
+- The feature applies to `multi-pwsh host ...` and implicit host shims such as `pwsh-7.4.exe`, not to arbitrary external `pwsh` processes.
+
+## Managed paths
+
+- `MULTI_PWSH_HOME`: override the multi-pwsh home directory.
+- `MULTI_PWSH_BIN_DIR`: override the shim and launcher directory.
+- `MULTI_PWSH_CACHE_DIR`: override the archive cache directory.
+- `MULTI_PWSH_VENV_DIR`: override the virtual-environment root directory.
+- `MULTI_PWSH_CACHE_KEEP`: keep downloaded archives after extraction when set to a truthy value.
+
+CI cache example:
+
+```powershell
+$env:MULTI_PWSH_HOME = "$(Join-Path $HOME '.pwsh')"
+$env:MULTI_PWSH_BIN_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'bin')"
+$env:MULTI_PWSH_CACHE_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'cache')"
+$env:MULTI_PWSH_VENV_DIR = "$(Join-Path $env:MULTI_PWSH_HOME 'venv')"
+$env:MULTI_PWSH_CACHE_KEEP = "1"
+multi-pwsh install 7.4.x
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,45 @@
+# Testing
+
+## Scoped install smoke tests
+
+Run the cross-platform scoped install smoke harness:
+
+```powershell
+pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-ScopedInstallSmokeTest.ps1
+```
+
+## Venv cmdlet matrix tests
+
+Use the local Pester harness to validate venv-sensitive cmdlet behavior across installed version aliases (`pwsh-x.y.z`).
+
+Run all installed version aliases:
+
+```powershell
+pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1
+```
+
+Run one alias only:
+
+```powershell
+pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1 -Aliases pwsh-7.4.13
+```
+
+Include online install tests (`Install-PSResource` / `Install-Module`):
+
+```powershell
+pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1 -EnableOnlineTests
+```
+
+Online mode details:
+
+- The tests do not modify PSGallery trust policy.
+- `Install-PSResource` uses `-TrustRepository -Quiet`.
+- `Install-Module` uses `-Force -AcceptLicense -Confirm:$false`.
+- The install checks use `Yayaml` to keep downloads and execution lightweight.
+
+Useful flags:
+
+- `-KeepVenv` keeps the temporary venvs for troubleshooting.
+- `-ContinueOnFailure` keeps running after a failed alias.
+
+Pester must be available in the host PowerShell session.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,2 @@
 reorder_imports = true
-imports_granularity = "Module"
 max_width = 120
-group_imports = "StdExternalCrate"

--- a/scripts/Bump-CrateVersions.ps1
+++ b/scripts/Bump-CrateVersions.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $cratesRoot = Join-Path $repoRoot 'crates'
-$releaseWorkflow = Join-Path $repoRoot '.github/workflows/release.yml'
+$readmePath = Join-Path $repoRoot 'README.md'
 
 if (-not (Test-Path -Path $cratesRoot -PathType Container)) {
     throw "Crates directory not found: $cratesRoot"
@@ -28,13 +28,18 @@ if (-not $cargoFiles) {
 
 $encoding = New-Object System.Text.UTF8Encoding($false)
 $updated = @()
-$workflowUpdated = $false
+$readmeUpdated = $false
 
 foreach ($cargoFile in $cargoFiles) {
     $content = [System.IO.File]::ReadAllText($cargoFile)
 
-    $pattern = '(?ms)^(\[package\]\s*.*?^version\s*=\s*")(?<current>[^"\r\n]+)(")'
-    $match = [System.Text.RegularExpressions.Regex]::Match($content, $pattern)
+    $pattern = '(?ms)^(?<prefix>\[package\]\s*.*?^version\s*=\s*")(?<current>[^"\r\n]+)(?<suffix>")'
+    $regex = [System.Text.RegularExpressions.Regex]::new(
+        $pattern,
+        [System.Text.RegularExpressions.RegexOptions]::Multiline -bor [System.Text.RegularExpressions.RegexOptions]::Singleline,
+        [System.TimeSpan]::FromSeconds(5)
+    )
+    $match = $regex.Match($content)
     if (-not $match.Success) {
         throw "Could not find package version field in $cargoFile"
     }
@@ -44,12 +49,13 @@ foreach ($cargoFile in $cargoFiles) {
         continue
     }
 
-    $newContent = [System.Text.RegularExpressions.Regex]::Replace(
+    $newContent = $regex.Replace(
         $content,
-        $pattern,
-        ($match.Groups[1].Value + $Version + $match.Groups[3].Value),
-        [System.Text.RegularExpressions.RegexOptions]::Multiline -bor [System.Text.RegularExpressions.RegexOptions]::Singleline,
-        [System.TimeSpan]::FromSeconds(5)
+        [System.Text.RegularExpressions.MatchEvaluator] {
+            param($cargoMatch)
+            $cargoMatch.Groups['prefix'].Value + $Version + $cargoMatch.Groups['suffix'].Value
+        },
+        1
     )
 
     if (-not $DryRun) {
@@ -59,29 +65,51 @@ foreach ($cargoFile in $cargoFiles) {
     $updated += $cargoFile
 }
 
-if (Test-Path -Path $releaseWorkflow -PathType Leaf) {
-    $workflowContent = [System.IO.File]::ReadAllText($releaseWorkflow)
-    $workflowPattern = '(?m)(?<prefix>for example\s+v)(?<current>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)'
-    $workflowMatch = [System.Text.RegularExpressions.Regex]::Match($workflowContent, $workflowPattern)
-
-    if ($workflowMatch.Success -and $workflowMatch.Groups['current'].Value -ne $Version) {
-        $replacement = $workflowMatch.Groups['prefix'].Value + $Version
-        $newWorkflowContent = $workflowContent.Substring(0, $workflowMatch.Index) +
-            $replacement +
-            $workflowContent.Substring($workflowMatch.Index + $workflowMatch.Length)
-
-        if (-not $DryRun) {
-            [System.IO.File]::WriteAllText($releaseWorkflow, $newWorkflowContent, $encoding)
-        }
-
-        $workflowUpdated = $true
+if ($updated.Count -gt 0 -and -not $DryRun) {
+    Push-Location -Path $repoRoot
+    try {
+        cargo update -w
+    }
+    finally {
+        Pop-Location
     }
 }
 
-if ($updated.Count -eq 0 -and -not $workflowUpdated) {
+if (Test-Path -Path $readmePath -PathType Leaf) {
+    $readmeContent = [System.IO.File]::ReadAllText($readmePath)
+    $newReadmeContent = $readmeContent
+    $readmePatterns = @(
+        '(?m)(?<prefix>Install a specific tag \(example `v)(?<current>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?<suffix>`\):)',
+        '(?m)(?<prefix>bash -s -- v)(?<current>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)',
+        '(?m)(?<prefix>-Version v)(?<current>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)'
+    )
+
+    foreach ($pattern in $readmePatterns) {
+        $newReadmeContent = [System.Text.RegularExpressions.Regex]::Replace(
+            $newReadmeContent,
+            $pattern,
+            [System.Text.RegularExpressions.MatchEvaluator] {
+                param($readmeMatch)
+                $readmeMatch.Groups['prefix'].Value + $Version + $readmeMatch.Groups['suffix'].Value
+            },
+            [System.Text.RegularExpressions.RegexOptions]::Multiline,
+            [System.TimeSpan]::FromSeconds(5)
+        )
+    }
+
+    if ($newReadmeContent -ne $readmeContent) {
+        if (-not $DryRun) {
+            [System.IO.File]::WriteAllText($readmePath, $newReadmeContent, $encoding)
+        }
+
+        $readmeUpdated = $true
+    }
+}
+
+if ($updated.Count -eq 0 -and -not $readmeUpdated) {
     Write-Host "All crate package versions are already $Version"
-    if (Test-Path -Path $releaseWorkflow -PathType Leaf) {
-        Write-Host "No release workflow example tag needed updating"
+    if (Test-Path -Path $readmePath -PathType Leaf) {
+        Write-Host "No README release example tag needed updating"
     }
     exit 0
 }
@@ -89,8 +117,11 @@ if ($updated.Count -eq 0 -and -not $workflowUpdated) {
 if ($updated.Count -gt 0) {
     Write-Host "Updated crate versions to ${Version}:"
     $updated | ForEach-Object { Write-Host " - $_" }
+    if (-not $DryRun) {
+        Write-Host "Refreshed Cargo.lock"
+    }
 }
 
-if ($workflowUpdated) {
-    Write-Host "Updated release workflow example tag in: $releaseWorkflow"
+if ($readmeUpdated) {
+    Write-Host "Updated README release example tag in: $readmePath"
 }


### PR DESCRIPTION
## Summary
- harden the release workflow so dispatch validates the requested tag against crate versions and publishes from the selected commit
- refresh release docs, split host/testing details into dedicated docs pages, and update the README for 0.9.0
- expand CI coverage for stable/preview/lts alias flows and clear the current rustfmt/clippy cleanup items

## Notes
- the release workflow now creates the tag at the dispatched commit if it does not already exist
- scripts/Bump-CrateVersions.ps1 now updates the README release-tag example as part of release prep

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets
- cargo build --all-targets
- cargo test --all-targets
- dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj -p:PwshExePath="pwsh-7.4"
- dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build -p:PwshExePath="pwsh-7.4"