### PR TITLE
Improve multi-pwsh CLI ergonomics and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "flate2",
  "home",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/m
 irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.9.0`):
+Install a specific tag (example `v0.10.0`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.9.0
+curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.10.0
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.9.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.10.0
 ```
 
 Uninstall bootstrap scripts:
@@ -57,6 +57,7 @@ pwsh-7.4 --version
 ## More docs
 
 - [Native host mode and virtual environments](docs/host-and-venv.md)
+- [Feature matrix and roadmap](docs/feature-matrix.md)
 - [Testing guide](docs/testing.md)
 - [Release process](RELEASE.md)
 
@@ -170,6 +171,9 @@ multi-pwsh venv list
 `multi-pwsh` usage reference:
 
 ```text
+multi-pwsh --version
+multi-pwsh --help
+multi-pwsh help [command]
 multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
 multi-pwsh update <stable|preview|lts|major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
 multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]
@@ -185,6 +189,8 @@ multi-pwsh alias unset <major.minor|pwsh|pwsh-preview|pwsh-lts>
 multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]
 multi-pwsh doctor --repair-aliases
 ```
+
+Use `multi-pwsh <command> --help` or `multi-pwsh help <command>` for focused command usage, for example `multi-pwsh install --help`.
 
 The Windows integration flags in the `install` and `update` forms are limited to archive-friendly behaviors; on macOS/Linux, use `--scope`, `--root`, `--arch`, `--include-prerelease`, and `--add-path` controls. Legacy scope aliases such as `current-user` and `all-users` are still accepted for compatibility.
 
@@ -206,6 +212,8 @@ If a pinned target version is not installed, the pin remains in metadata and the
 
 The bare `pwsh` alias is a managed policy alias. Configure it with `multi-pwsh alias set pwsh stable`, `multi-pwsh alias set pwsh lts`, `multi-pwsh alias set pwsh preview`, or an exact version. `pwsh-preview` tracks preview by default, and `pwsh-lts` tracks LTS by default. Policy aliases resolve only to installed versions; install or update the desired channel before pointing an alias at it.
 
+Use `multi-pwsh list` to inspect both resolved aliases and managed named alias policies. The policy section shows whether aliases such as `pwsh`, `pwsh-preview`, and `pwsh-lts` currently resolve to an installed version or remain configured but unresolved.
+
 The current LTS line is encoded in the tool; at the moment that is `7.6`.
 
 ## Native host mode and virtual environments
@@ -222,4 +230,3 @@ See [docs/host-and-venv.md](docs/host-and-venv.md) for host shims, venv layout, 
 - Venv matrix tests: `pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-VenvTestMatrix.ps1`
 
 See [docs/testing.md](docs/testing.md) for online test mode, alias-targeted runs, and troubleshooting flags.
-

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/multi-pwsh"

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -7,6 +7,7 @@ mod platform;
 mod release;
 mod versions;
 
+use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs;
@@ -41,11 +42,95 @@ const POWERSHELL_UPDATECHECK_ENV_VAR: &str = "POWERSHELL_UPDATECHECK";
 const POWERSHELL_UPDATECHECK_OFF: &str = "Off";
 const VIRTUAL_ENVIRONMENT_FLAG: &str = "-virtualenvironment";
 const VIRTUAL_ENVIRONMENT_SHORT_FLAG: &str = "-venv";
+const HELP_TOPICS: &[&str] = &[
+    "install",
+    "update",
+    "uninstall",
+    "list",
+    "venv",
+    "alias",
+    "host",
+    "doctor",
+    "package",
+    "version",
+];
+
+fn usage_text() -> &'static str {
+    "Usage:\n  multi-pwsh --version\n  multi-pwsh --help\n  multi-pwsh help [command]\n  multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh update <stable|preview|lts|major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]\n  multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease]\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias set <pwsh|pwsh-preview|pwsh-lts> <stable|preview|lts|version>\n  multi-pwsh alias unset <major.minor|pwsh|pwsh-preview|pwsh-lts>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
+}
 
 fn print_usage() {
-    eprintln!(
-        "Usage:\n  multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh update <stable|preview|lts|major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]\n  multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease]\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias set <pwsh|pwsh-preview|pwsh-lts> <stable|preview|lts|version>\n  multi-pwsh alias unset <major.minor|pwsh|pwsh-preview|pwsh-lts>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
-    );
+    eprintln!("{}", usage_text());
+}
+
+fn print_global_help() {
+    println!("{}", usage_text());
+}
+
+fn print_version() {
+    println!("multi-pwsh {}", env!("CARGO_PKG_VERSION"));
+}
+
+fn is_help_flag(value: &str) -> bool {
+    matches!(value, "-h" | "--help")
+}
+
+fn help_topic_text(topic: &str) -> Option<&'static str> {
+    match topic {
+        "install" => Some(
+            "Usage:\n  multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [options]\n\nOptions:\n  --scope <user|machine>\n  --root <path>\n  --arch <auto|x64|x86|arm64|arm32>\n  --include-prerelease\n  --add-path | --no-add-path\n  --register-manifest | --no-register-manifest\n  --enable-psremoting\n  --disable-telemetry\n  --add-explorer-context-menu\n  --add-file-context-menu\n  --skip-hash-verification\n  --hash-file <url-or-path>",
+        ),
+        "update" => Some(
+            "Usage:\n  multi-pwsh update <stable|preview|lts|major.minor> [options]\n\nOptions:\n  --scope <user|machine>\n  --root <path>\n  --arch <auto|x64|x86|arm64|arm32>\n  --include-prerelease\n  --add-path | --no-add-path\n  --register-manifest | --no-register-manifest\n  --enable-psremoting\n  --disable-telemetry\n  --add-explorer-context-menu\n  --add-file-context-menu\n  --skip-hash-verification\n  --hash-file <url-or-path>",
+        ),
+        "uninstall" => Some(
+            "Usage:\n  multi-pwsh uninstall <version> [options]\n\nOptions:\n  --scope <user|machine>\n  --root <path>\n  --force",
+        ),
+        "list" => Some(
+            "Usage:\n  multi-pwsh list [options]\n\nOptions:\n  --scope <user|machine|all>\n  --root <path>\n  --available\n  --include-prerelease",
+        ),
+        "venv" => Some(
+            "Usage:\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list",
+        ),
+        "alias" => Some(
+            "Usage:\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias set <pwsh|pwsh-preview|pwsh-lts> <stable|preview|lts|version>\n  multi-pwsh alias unset <major.minor|pwsh|pwsh-preview|pwsh-lts>",
+        ),
+        "host" => Some(
+            "Usage:\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]",
+        ),
+        "doctor" => Some("Usage:\n  multi-pwsh doctor --repair-aliases"),
+        "package" => Some(
+            "Usage:\n  multi-pwsh package install <selector> [options]\n  multi-pwsh package uninstall <version> [--scope <user|machine>] [--root <path>] [--force]\n  multi-pwsh package list [--scope <user|machine>] [--root <path>]",
+        ),
+        "version" => Some("Usage:\n  multi-pwsh --version\n  multi-pwsh -V\n  multi-pwsh version"),
+        _ => None,
+    }
+}
+
+fn print_help_topic(topic: &str) -> Result<()> {
+    let Some(text) = help_topic_text(topic) else {
+        return Err(MultiPwshError::InvalidArguments(format!(
+            "unknown help topic '{}'. expected one of: {}",
+            topic,
+            HELP_TOPICS.join(", ")
+        )));
+    };
+
+    println!("{}", text);
+    Ok(())
+}
+
+fn run_help(args: &[String]) -> Result<()> {
+    match args {
+        [] => {
+            print_global_help();
+            Ok(())
+        }
+        [topic] => print_help_topic(topic),
+        _ => Err(MultiPwshError::InvalidArguments(
+            "help accepts at most one command topic".to_string(),
+        )),
+    }
 }
 
 struct ReleaseSelectionOptions {
@@ -1772,6 +1857,7 @@ fn run_package_list(layout_options: PackageLayoutOptions) -> Result<()> {
     let records = metadata.resolved_records()?;
     if records.is_empty() {
         println!("Installed versions: (none)");
+        print_alias_metadata(&layout)?;
         return Ok(());
     }
 
@@ -1791,6 +1877,8 @@ fn run_package_list(layout_options: PackageLayoutOptions) -> Result<()> {
             record.record.enable_mu
         );
     }
+
+    print_alias_metadata(&layout)?;
 
     Ok(())
 }
@@ -1873,8 +1961,6 @@ fn run_current_user_list(os: HostOs, root: Option<PathBuf>) -> Result<()> {
         None => InstallLayout::new(os)?,
     };
     let versions = layout.installed_versions()?;
-    let aliases = aliases::read_alias_metadata(&layout)?;
-    let pins = read_minor_pins(&layout)?;
 
     println!("Home: {}", layout.home().display());
     println!("Alias bin: {}", layout.bin_dir().display());
@@ -1892,15 +1978,44 @@ fn run_current_user_list(os: HostOs, root: Option<PathBuf>) -> Result<()> {
         }
     }
 
+    print_alias_metadata(&layout)?;
+
+    Ok(())
+}
+
+fn format_special_alias_policy_line(alias_name: &str, policy_text: &str, aliases: &HashMap<String, String>) -> String {
+    match aliases.get(alias_name) {
+        Some(version) => format!("  - {} follows {} -> {}", alias_name, policy_text, version),
+        None => format!("  - {} follows {} -> unresolved", alias_name, policy_text),
+    }
+}
+
+fn print_alias_metadata(layout: &InstallLayout) -> Result<()> {
+    let aliases = aliases::read_alias_metadata(layout)?;
+    let policies = aliases::read_special_alias_policies(layout)?;
+    let pins = read_minor_pins(layout)?;
+
     println!();
     if aliases.is_empty() {
         println!("Aliases: (none)");
     } else {
         println!("Aliases:");
-        let mut items: Vec<_> = aliases.into_iter().collect();
-        items.sort_by(|a, b| a.0.cmp(&b.0));
+        let mut items: Vec<_> = aliases.iter().collect();
+        items.sort_by(|a, b| a.0.cmp(b.0));
         for (alias, version) in items {
             println!("  - {} -> {}", alias, version);
+        }
+    }
+
+    println!();
+    if policies.is_empty() {
+        println!("Named alias policies: (none)");
+    } else {
+        println!("Named alias policies:");
+        let mut items: Vec<_> = policies.into_iter().collect();
+        items.sort_by(|a, b| a.0.cmp(&b.0));
+        for (alias, policy) in items {
+            println!("{}", format_special_alias_policy_line(&alias, &policy, &aliases));
         }
     }
 
@@ -2109,6 +2224,7 @@ fn run_update(
     if let Some(path) = major_alias_path {
         println!("Updated major alias: {}", path.display());
     }
+    refresh_special_aliases(&layout, os)?;
     println!("Add to PATH once: {}", layout.bin_dir().display());
 
     Ok(())
@@ -2449,11 +2565,45 @@ fn run_doctor(args: &[String]) -> Result<()> {
 
 fn run() -> Result<()> {
     let args: Vec<String> = env::args().skip(1).collect();
-    let os = HostOs::detect()?;
     if args.is_empty() {
         print_usage();
         return Err(MultiPwshError::InvalidArguments("missing command".to_string()));
     }
+
+    if is_help_flag(&args[0]) {
+        if args.len() != 1 {
+            return Err(MultiPwshError::InvalidArguments(
+                "--help does not accept additional arguments; use: multi-pwsh help <command>".to_string(),
+            ));
+        }
+        print_global_help();
+        return Ok(());
+    }
+
+    if args[0] == "help" {
+        return run_help(&args[1..]);
+    }
+
+    if args[0] == "version" && args.len() == 2 && is_help_flag(&args[1]) {
+        return print_help_topic("version");
+    }
+
+    if matches!(args[0].as_str(), "--version" | "-V" | "version") {
+        if args.len() != 1 {
+            return Err(MultiPwshError::InvalidArguments(format!(
+                "{} does not accept additional arguments",
+                args[0]
+            )));
+        }
+        print_version();
+        return Ok(());
+    }
+
+    if args.len() == 2 && is_help_flag(&args[1]) {
+        return print_help_topic(&args[0]);
+    }
+
+    let os = HostOs::detect()?;
 
     match args[0].as_str() {
         "install" => {
@@ -2525,12 +2675,8 @@ fn run() -> Result<()> {
             process::exit(exit_code);
         }
         "doctor" => run_doctor(&args[1..]),
-        "-h" | "--help" | "help" => {
-            print_usage();
-            Ok(())
-        }
         command => Err(MultiPwshError::InvalidArguments(format!(
-            "unknown command '{}'. expected: install, update, uninstall, list, venv, alias, host, doctor",
+            "unknown command '{}'. expected: install, update, uninstall, list, venv, alias, host, doctor, package, version",
             command
         ))),
     }
@@ -3018,6 +3164,41 @@ mod tests {
             resolve_special_alias_policy_from_installed(&versions, &SpecialAliasPolicy::Lts),
             Some(Version::parse("7.6.2").unwrap())
         );
+    }
+
+    #[test]
+    fn format_special_alias_policy_line_shows_resolved_and_unresolved_state() {
+        let mut aliases = HashMap::new();
+        aliases.insert(PWSH_LTS_ALIAS.to_string(), "7.6.2".to_string());
+
+        assert_eq!(
+            format_special_alias_policy_line(PWSH_LTS_ALIAS, "lts", &aliases),
+            "  - pwsh-lts follows lts -> 7.6.2"
+        );
+        assert_eq!(
+            format_special_alias_policy_line(PWSH_PREVIEW_ALIAS, "preview", &aliases),
+            "  - pwsh-preview follows preview -> unresolved"
+        );
+    }
+
+    #[test]
+    fn refresh_special_aliases_updates_policy_to_newest_matching_installed_version() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = InstallLayout::from_root(HostOs::detect().unwrap(), temp_dir.path().join("home")).unwrap();
+        layout.ensure_base_dirs().unwrap();
+
+        for version in ["7.6.1", "7.6.2"] {
+            let version = Version::parse(version).unwrap();
+            let executable = layout.version_executable(&version);
+            fs::create_dir_all(executable.parent().unwrap()).unwrap();
+            fs::write(executable, b"").unwrap();
+        }
+
+        set_special_alias_policy(&layout, PWSH_LTS_ALIAS, Some("lts")).unwrap();
+        refresh_special_aliases(&layout, layout.os()).unwrap();
+
+        let aliases = aliases::read_alias_metadata(&layout).unwrap();
+        assert_eq!(aliases.get(PWSH_LTS_ALIAS).map(String::as_str), Some("7.6.2"));
     }
 
     #[test]

--- a/crates/multi-pwsh/tests/cli_args.rs
+++ b/crates/multi-pwsh/tests/cli_args.rs
@@ -74,6 +74,141 @@ fn normalize_output(bytes: &[u8]) -> String {
     String::from_utf8_lossy(bytes).replace("\r\n", "\n").trim().to_string()
 }
 
+#[test]
+fn top_level_help_prints_usage() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    for flag in ["--help", "-h", "help"] {
+        let output = run_multi_pwsh(&[flag], temp_dir.path());
+
+        assert!(
+            output.status.success(),
+            "expected {} to succeed: {}",
+            flag,
+            normalize_output(&output.stderr)
+        );
+        let stdout = normalize_output(&output.stdout);
+        assert!(stdout.contains("Usage:"), "unexpected stdout: {}", stdout);
+        assert!(
+            stdout.contains("multi-pwsh help [command]"),
+            "unexpected stdout: {}",
+            stdout
+        );
+    }
+}
+
+#[test]
+fn subcommand_help_prints_focused_usage() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    for args in [
+        &["install", "--help"][..],
+        &["install", "-h"][..],
+        &["help", "install"][..],
+    ] {
+        let output = run_multi_pwsh(args, temp_dir.path());
+
+        assert!(
+            output.status.success(),
+            "expected {:?} to succeed: {}",
+            args,
+            normalize_output(&output.stderr)
+        );
+        let stdout = normalize_output(&output.stdout);
+        assert!(
+            stdout.contains("multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x>"),
+            "unexpected stdout: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("--hash-file <url-or-path>"),
+            "unexpected stdout: {}",
+            stdout
+        );
+    }
+}
+
+#[test]
+fn version_command_help_prints_focused_usage() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let output = run_multi_pwsh(&["version", "--help"], temp_dir.path());
+
+    assert!(
+        output.status.success(),
+        "expected version help to succeed: {}",
+        normalize_output(&output.stderr)
+    );
+    let stdout = normalize_output(&output.stdout);
+    assert!(stdout.contains("multi-pwsh --version"), "unexpected stdout: {}", stdout);
+}
+
+#[test]
+fn help_rejects_unknown_topic() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let output = run_multi_pwsh(&["help", "missing"], temp_dir.path());
+
+    assert!(!output.status.success(), "expected unknown help topic to fail");
+    let stderr = normalize_output(&output.stderr);
+    assert!(
+        stderr.contains("unknown help topic 'missing'"),
+        "unexpected stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn version_flag_prints_package_version() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    for flag in ["--version", "-V"] {
+        let output = run_multi_pwsh(&[flag], temp_dir.path());
+
+        assert!(
+            output.status.success(),
+            "expected {} to succeed: {}",
+            flag,
+            normalize_output(&output.stderr)
+        );
+        assert_eq!(
+            normalize_output(&output.stdout),
+            format!("multi-pwsh {}", env!("CARGO_PKG_VERSION"))
+        );
+    }
+}
+
+#[test]
+fn version_command_prints_package_version() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let output = run_multi_pwsh(&["version"], temp_dir.path());
+
+    assert!(
+        output.status.success(),
+        "expected version command to succeed: {}",
+        normalize_output(&output.stderr)
+    );
+    assert_eq!(
+        normalize_output(&output.stdout),
+        format!("multi-pwsh {}", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
+fn version_rejects_extra_arguments() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    for args in [
+        &["--version", "extra"][..],
+        &["-V", "extra"][..],
+        &["version", "extra"][..],
+    ] {
+        let output = run_multi_pwsh(args, temp_dir.path());
+
+        assert!(!output.status.success(), "expected {:?} to fail", args);
+        let stderr = normalize_output(&output.stderr);
+        assert!(
+            stderr.contains("does not accept additional arguments"),
+            "unexpected stderr: {}",
+            stderr
+        );
+    }
+}
+
 fn split_module_path_entries(module_path: &str) -> Vec<PathBuf> {
     std::env::split_paths(&std::ffi::OsString::from(module_path)).collect()
 }
@@ -1077,6 +1212,39 @@ fn list_uses_explicit_root_and_scope() {
     assert!(
         stdout.contains(&package_root_text),
         "expected package root in output: {}",
+        stdout
+    );
+}
+
+#[test]
+fn list_reports_named_alias_policy_resolution() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let home_text = temp_dir.path().display().to_string();
+    let configure_output = run_multi_pwsh(&["alias", "set", "pwsh", "stable"], temp_dir.path());
+
+    assert!(
+        configure_output.status.success(),
+        "expected alias policy configuration to succeed: {}",
+        normalize_output(&configure_output.stderr)
+    );
+
+    let output = run_multi_pwsh(&["list", "--scope", "user", "--root", &home_text], temp_dir.path());
+
+    assert!(
+        output.status.success(),
+        "expected list to succeed: {}",
+        normalize_output(&output.stderr)
+    );
+
+    let stdout = normalize_output(&output.stdout);
+    assert!(
+        stdout.contains("Named alias policies:"),
+        "expected named alias policy section: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("  - pwsh follows stable -> unresolved"),
+        "expected unresolved pwsh stable policy: {}",
         stdout
     );
 }

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -1,0 +1,91 @@
+# Feature matrix and roadmap
+
+This matrix reflects the current command surface and known gaps for `multi-pwsh`.
+
+## CLI surface
+
+| Area | Supported today | Notes and limitations |
+| --- | --- | --- |
+| Version info | `multi-pwsh --version`, `multi-pwsh -V`, `multi-pwsh version` | Prints the `multi-pwsh` package version without inspecting local install state. Extra arguments are rejected. |
+| Help | `multi-pwsh --help`, `multi-pwsh -h`, `multi-pwsh help [command]`, `multi-pwsh <command> --help` | Focused command help is available without platform detection or local install state. |
+| Install | `multi-pwsh install <stable\|preview\|lts\|version\|major\|major.minor\|major.minor.x>` | `stable`, `preview`, and `lts` resolve against GitHub PowerShell releases. `major.minor.x` installs every available patch release in that line. |
+| Update | `multi-pwsh update <stable\|preview\|lts\|major.minor>` | Channel updates behave like installing the newest matching channel. Line updates refresh line, major, and managed named alias policies after installing the newest patch. |
+| Uninstall | `multi-pwsh uninstall <version> [--scope <user\|machine>] [--root <path>] [--force]` | Removes managed files and updates aliases that referenced the removed version. |
+| List | `multi-pwsh list [--scope <user\|machine\|all>] [--root <path>] [--available] [--include-prerelease]` | Installed listing shows paths, resolved aliases, named alias policies, and minor pins. Available listing queries GitHub releases. |
+| Alias | `multi-pwsh alias set/unset` for `major.minor`, `pwsh`, `pwsh-preview`, and `pwsh-lts` | Minor aliases can be pinned or follow latest in line. Named aliases store policies and resolve only to installed versions. |
+| Host | `multi-pwsh host <version\|major\|major.minor\|pwsh-alias> [pwsh arguments...]` | Runs through the native host. Alias shims can also invoke host mode implicitly when `pwsh-*` names are used from the managed bin directory. |
+| Virtual environments | `multi-pwsh venv create/delete/export/import/list` plus host `-VirtualEnvironment` / `-venv` | Provides a managed module root for hosted PowerShell launches. |
+| Doctor | `multi-pwsh doctor --repair-aliases` | Repairs host shims, alias files, and managed named alias policy resolutions. |
+| Package subcommand | `multi-pwsh package install/uninstall/list` | Lower-level scoped install backend retained for explicit package-style operations. |
+
+## Version selectors and channels
+
+| Selector | Meaning | Alias side effects |
+| --- | --- | --- |
+| `stable` | Latest GA/non-preview PowerShell release with a matching platform asset. | Ensures `pwsh` follows `stable` if no `pwsh` policy exists, then refreshes policy aliases. |
+| `preview` | Latest prerelease PowerShell release with a matching platform asset. | Ensures `pwsh-preview` follows `preview` if no policy exists, then refreshes policy aliases. |
+| `lts` | Latest patch in the current encoded LTS line. | Ensures `pwsh-lts` follows `lts` if no policy exists, then refreshes policy aliases. |
+| `<major>` | Latest matching major release. | Updates `pwsh-<major>` and patch aliases. |
+| `<major>.<minor>` | Latest matching line release. | Updates `pwsh-<major>.<minor>`, `pwsh-<major>`, patch aliases, and named alias policies. |
+| `<major>.<minor>.x` | Every available release in a line. | Updates patch aliases for all installed versions and line/major aliases. |
+| Exact version | A specific PowerShell version, including normalized preview/RC shorthand. | Updates the exact patch alias plus line/major aliases. |
+
+The current LTS line is encoded in source so LTS selection remains deterministic. Update that table when PowerShell changes the active LTS line.
+
+## Alias behavior
+
+| Alias | Default policy | Allowed policies | Resolution behavior |
+| --- | --- | --- | --- |
+| `pwsh` | `stable` after `install stable` | `stable`, `preview`, `lts`, or exact version | Resolves to the newest installed version matching the policy. |
+| `pwsh-preview` | `preview` after `install preview` | `preview` or exact prerelease | Refuses stable/LTS policies to avoid accidentally launching GA builds. |
+| `pwsh-lts` | `lts` after `install lts` | `lts` or exact current-LTS version | Refuses non-LTS policies. |
+| `pwsh-<major>` | Latest installed version in the major | Managed automatically | Recomputed after install/update/uninstall. |
+| `pwsh-<major>.<minor>` | Latest installed version in the line | Can be pinned to an exact version or unpinned with `latest` | Pinned aliases remain configured but unresolved if their target is not installed. |
+| `pwsh-<exact>` | Exact installed version | Managed automatically | Removed when the exact version is uninstalled. |
+
+Named alias policies are stored separately from resolved alias metadata. `list` shows both the currently resolved aliases and whether each named alias policy is resolved or unresolved.
+
+## Platform and scope support
+
+| Platform | User scope | Machine scope | Notes |
+| --- | --- | --- | --- |
+| Windows | Supported | Supported | Uses official ZIP assets with MSI-like install roots. Archive-safe integration flags are supported; Microsoft Update registration is intentionally not supported. |
+| macOS | Supported | Supported | Machine installs use `/usr/local/microsoft/powershell` with aliases in `/usr/local/bin`; callers must provide elevation when needed. |
+| Linux | Supported | Supported | Machine installs use `/opt/microsoft/powershell` with aliases in `/usr/local/bin`; callers must provide elevation when needed. |
+
+Architectures are `auto`, `x64`, `x86`, `arm64`, and `arm32`, subject to platform asset availability. Unsupported OS/architecture combinations fail before download.
+
+## State, lifecycle, and diagnostics
+
+| State file or directory | Purpose |
+| --- | --- |
+| Install root | Stores side-by-side PowerShell payloads and package metadata. |
+| `bin` directory | Contains hard-linked or copied `multi-pwsh` host shims named as aliases. Add this directory to `PATH` once per scope. |
+| `aliases.json` | Stores resolved aliases, minor pins, and named alias policies. |
+| `cache` directory | Stores downloaded release assets and checksum assets. |
+| `venv` directory | Stores managed virtual environment module roots. |
+| `multi-pwsh-layout.json` | Lets host shims recover their layout when the bin directory is shared or overridden. |
+
+Install, update, uninstall, and `doctor --repair-aliases` all reconcile aliases. `list` is the primary status surface for local state; `list --available` is the online release inventory surface.
+
+## Host and startup-hook support
+
+| Feature | Supported today | Notes |
+| --- | --- | --- |
+| Native host launch | Yes | `multi-pwsh host` resolves selectors to installed executables and runs through `pwsh-host`. |
+| Implicit shim host mode | Yes | Alias shims detect their own name and layout, then run the matching selector. |
+| Virtual environment module path | Yes | Host mode sets startup-hook environment variables and bootstraps module cmdlet aliases for `-Command` and stdin `-File -` scenarios. |
+| Venv archive import/export | Yes | ZIP import rejects absolute paths and parent-directory traversal. |
+
+## Practical roadmap gaps
+
+| Gap | Value | Notes |
+| --- | --- | --- |
+| Dry-run planning for install/update/uninstall | High | Would let users preview selected release, download URL, alias changes, and integration changes without mutating state. |
+| Dedicated `status` command | High | `list` now includes policy state, but a purpose-built status command could add PATH checks, shim link health, stale cache information, and recommended repairs. |
+| Shell integration diagnostics | Medium | Detect whether the managed bin directory is on `PATH` for the current shell and scope. |
+| LTS metadata source | Medium | The active LTS line is encoded in source. A release-time check or metadata source would reduce manual updates. |
+| Rich uninstall selectors | Medium | Uninstall currently requires an exact version. Channel or line uninstall would need careful safety prompts or dry-run first. |
+| Machine-scope privilege guidance | Medium | Unix machine installs intentionally do not invoke `sudo`; diagnostics could make permission failures more actionable. |
+| Structured output | Low | JSON output for `list`, `status`, and `--available` would help automation. |
+| Shell completions | Low | Completion script generation is not implemented yet. |


### PR DESCRIPTION
## Summary
- add a feature matrix/roadmap document and link it from the README
- improve alias/update diagnostics and managed alias refresh behavior
- add conventional `--version`, `version`, and focused help support
- bump Cargo package versions and README release examples to `0.10.0`

## Validation
- `rustup toolchain install stable --profile minimal`
- `rustup default stable`
- `rustup component add rustfmt clippy --toolchain stable`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets -- --test-threads=1`
- `dotnet build dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj`
- `dotnet test dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj --no-build`