### PR TITLE
Fix Windows venv hint path and bump to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.10.0"
+version = "0.6.0"
 dependencies = [
  "flate2",
  "home",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.10.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/m
 irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.10.0`):
+Install a specific tag (example `v0.6.0`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.10.0
+curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.6.0
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.10.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.6.0
 ```
 
 Uninstall bootstrap scripts:

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.10.0"
+version = "0.6.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/multi-pwsh"

--- a/crates/multi-pwsh/src/package.rs
+++ b/crates/multi-pwsh/src/package.rs
@@ -260,6 +260,22 @@ pub fn package_layout(
     install_root: Option<PathBuf>,
 ) -> Result<InstallLayout> {
     match (os, scope, install_root) {
+        (HostOs::Windows, PackageScope::CurrentUser, None) => {
+            let root = default_install_root(os, PackageScope::CurrentUser, arch)?;
+            // Use the default layout's venvs_dir so that `multi-pwsh venv` commands and
+            // package install alias shims resolve venvs from the same directory.
+            let default_venvs_dir = InstallLayout::new(os)
+                .map(|l| l.venvs_dir())
+                .unwrap_or_else(|_| root.join("venv"));
+            InstallLayout::from_parts(
+                os,
+                root.clone(),
+                root.join("bin"),
+                root.join("cache"),
+                default_venvs_dir,
+                root,
+            )
+        }
         (HostOs::Windows, scope, install_root) => {
             let root = match install_root {
                 Some(root) => root,
@@ -886,6 +902,28 @@ fn remove_file_context_menu(scope: PackageScope) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env_var<T>(key: &str, value: Option<&Path>, action: impl FnOnce() -> T) -> T {
+        let previous = env::var_os(key);
+
+        match value {
+            Some(value) => unsafe { env::set_var(key, value) },
+            None => unsafe { env::remove_var(key) },
+        }
+
+        let result = action();
+
+        match previous {
+            Some(value) => unsafe { env::set_var(key, value) },
+            None => unsafe { env::remove_var(key) },
+        }
+
+        result
+    }
 
     #[test]
     fn package_scope_parses_aliases() {
@@ -1009,6 +1047,26 @@ mod tests {
             layout.version_install_dir(&Version::parse("7.4.13").unwrap()),
             PathBuf::from(r"C:\PowerShell\7.4.13")
         );
+    }
+
+    #[test]
+    fn package_layout_windows_user_default_uses_default_venv_root() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let local_app_data = temp_dir.path().join("local-app-data");
+        let default_home = temp_dir.path().join("pwsh-home");
+
+        with_env_var("LOCALAPPDATA", Some(&local_app_data), || {
+            with_env_var("MULTI_PWSH_HOME", Some(&default_home), || {
+                let layout = package_layout(HostOs::Windows, HostArch::X64, PackageScope::CurrentUser, None).unwrap();
+
+                let expected_install_root = local_app_data.join("PowerShell");
+                assert_eq!(layout.home(), expected_install_root.as_path());
+                assert_eq!(layout.bin_dir(), expected_install_root.join("bin"));
+                assert_eq!(layout.versions_dir(), expected_install_root);
+                assert_eq!(layout.venvs_dir(), default_home.join("venv"));
+            })
+        });
     }
 
     #[test]

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.10.0"
+version = "0.6.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/scripts/demo/PSConfEU-MultiPwsh.deck.md
+++ b/scripts/demo/PSConfEU-MultiPwsh.deck.md
@@ -34,7 +34,29 @@ paginationStyle: "progress"
 
 ---
 
-### 1. See the PowerShells
+### 1. Bootstrapping multi-pwsh
+
+Bootstrap multi-pwsh executable
+
+From bash (if you don't have pwsh):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash
+```
+
+From Windows PowerShell (if you don't have pwsh):
+
+```powershell
+irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1 | iex
+```
+
+multi-pwsh doesn't require PowerShell to install PowerShell
+
+---
+
+---
+
+### 2. Install PowerShell versions
 
 First, make version sprawl visible.
 
@@ -42,6 +64,15 @@ First, make version sprawl visible.
 multi-pwsh install 7.4.12
 multi-pwsh install 7.5.x
 multi-pwsh install 7.6
+```
+
+```powershell
+pwsh-7.4.12 -NoLogo -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion'
+pwsh-7.5 -NoLogo -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion'
+pwsh-7.6 -NoLogo -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion'
+```
+
+```powershell
 multi-pwsh list
 ```
 
@@ -49,25 +80,29 @@ Point: the installed PowerShell versions are explicit, named, and disposable.
 
 ---
 
-### 2. Keep release channels side by side
+### 3. Install PowerShell release channels
 
 The useful everyday aliases are the release channels.
 
 ```powershell
-multi-pwsh alias set pwsh stable
-multi-pwsh alias set pwsh-lts lts
-multi-pwsh alias set pwsh-preview preview
+multi-pwsh install stable
+multi-pwsh install lts
+multi-pwsh install preview
 
 pwsh -NoLogo -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion'
 pwsh-lts -NoLogo -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion'
 pwsh-preview -NoLogo -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion'
 ```
 
+```powershell
+multi-pwsh list
+```
+
 Keep latest stable as your default, with LTS and preview always handy.
 
 ---
 
-### 3. Upgrade and rollback without renaming scripts
+### 4. Upgrade and rollback without renaming scripts
 
 Version-specific aliases are still there when a script needs a fixed line.
 
@@ -77,37 +112,12 @@ pwsh-7.4 -NoLogo -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion'
 
 multi-pwsh alias set 7.4 7.4.12
 pwsh-7.4 -NoLogo -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion'
+
+multi-pwsh alias set stable 7.6
+pwsh -NoLogo -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion'
 ```
 
-* Upgrade is one command.
-* Rollback is one command.
-* Scripts and PATH do not need surgery.
-
----
-
-## Deterministic hosts
-
----
-
-### 4. Stop guessing what `pwsh` means
-
-Exact version
-
-```powershell
-multi-pwsh host 7.4.12 -NoLogo -NoProfile -NonInteractive `
-  -Command '$PSVersionTable.PSVersion.ToString()'
-```
-
-|||
-
-Channel selector
-
-```powershell
-multi-pwsh host 7.4 -NoLogo -NoProfile -NonInteractive `
-  -Command '$PSVersionTable.PSVersion.ToString()'
-```
-
-The caller chooses the runtime.
+No explicit launching of pwsh in a custom path - just use one of the aliases
 
 ---
 
@@ -124,80 +134,41 @@ That is useful in a shell, a test harness, and a GitHub Actions matrix.
 
 ---
 
-## Module worlds
+## Virtual Environments
 
 ---
 
-### 5. PowerShell module venvs
+### 5. Creating PowerShell venv
 
 Borrow the Python idea, apply it to PowerShell modules.
 
 ```powershell
-. .\scripts\demo\_DemoCommon.ps1
-$context = New-DemoContext -DemoName 'psconfeu-deck' -KeepArtifacts
-.\scripts\demo\Initialize-PSConfEUDemoWorlds.ps1
+multi-pwsh venv create jake
 multi-pwsh venv list
+```
+
+```powershell
+pwsh-lts -venv jake
+@('Deck','Stepper') | % { Install-Module -Name $_ -Force }
 ```
 
 Now a script can bring its dependencies with it, without polluting your real `PSModulePath`.
 
 ---
 
-### Cloud and on-prem side by side
-
-Cloud identity world
-
-```powershell
-multi-pwsh host 7.4.12 -venv cloud
-```
-
-Module: `Conference.CloudIdentity`
-
-|||
-
-On-prem automation world
-
-```powershell
-multi-pwsh host 7.4.12 -venv onprem
-```
-
-Module: `Conference.OnPremOps`
+## Environment Exportability
 
 ---
 
-### 6. Same command, different reality
-
-The selected venv decides what exists.
-
-```powershell
-$cmd = 'Import-Module Conference.CloudIdentity -ErrorAction SilentlyContinue; Import-Module Conference.OnPremOps -ErrorAction SilentlyContinue; Get-ConferenceReality'
-
-multi-pwsh host 7.4.12 -venv cloud -NoLogo -NoProfile -NonInteractive `
-  -Command $cmd
-
-multi-pwsh host 7.4.12 -venv onprem -NoLogo -NoProfile -NonInteractive `
-  -Command $cmd
-```
-
-Module conflicts become test data instead of laptop state.
-
----
-
-## Portable confidence
-
----
-
-### 7. Export what worked
+### 6. Exporting PowerShell venv
 
 The working module environment becomes a repeatable artifact.
 
 ```powershell
-$archive = Join-Path $env:TEMP 'multi-pwsh-cloud.zip'
-multi-pwsh venv export cloud $archive
-multi-pwsh venv import cloud-copy $archive
-
-multi-pwsh host 7.4.12 -venv cloud-copy -NoLogo -NoProfile -NonInteractive `
-  -Command $cmd
+$archive = Join-Path $env:TEMP 'jake-venv.zip'
+multi-pwsh venv export jake $archive
+multi-pwsh venv import horse $archive
+pwsh-lts -venv horse -Command { Get-Module }
 ```
 
 Now the dependency set can move to CI, a teammate, or tomorrow's Open Stage.
@@ -210,10 +181,12 @@ Before trusting a generated script or pipeline change:
 
 ```powershell
 foreach ($version in '7.4', '7.5') {
-  multi-pwsh host $version -venv cloud -NoLogo -NoProfile -File .\Invoke-SmokeTest.ps1
+  multi-pwsh host $version -venv jake -NoLogo -NoProfile -Command { .\Invoke-Deck.ps1 }
 }
+```
 
-multi-pwsh host 7.4 -venv onprem -NoLogo -NoProfile -File .\candidate.ps1
+```powershell
+pwsh-lts -venv jake -NoLogo -NoProfile -Command { .\Invoke-Stepper.ps1 }
 ```
 
 Same idea as a build matrix, but available locally first.
@@ -226,11 +199,9 @@ Same idea as a build matrix, but available locally first.
 
 ### The takeaways
 
-* PowerShell versions became named and disposable.
+* PowerShell versions and release channels easily available
 * Aliases made stable, LTS, and preview easy to keep side by side.
-* `host` made runtime selection explicit.
-* Venvs made module stacks disposable, isolated, and portable.
-* Export/import made dependencies shareable.
+* Venvs made script dependencies isolated, exportable, and portable.
 
 The real feature is confidence before you run someone else's PowerShell.
 


### PR DESCRIPTION
## Summary
- fix Windows current-user package layout so alias host shims resolve venvs from the same root as multi-pwsh venv commands
- add regression coverage for Windows user-scope default venv root resolution
- bump crate versions to 0.6.0 with the bump script and refresh lock/readme

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets
- cargo test --all-targets
- dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build