### PR TITLE
Add offline cache support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
           gh release view "$env:RELEASE_TAG" *> $null
 
           if ($LASTEXITCODE -eq 0) {
-            gh release upload "$env:RELEASE_TAG" @zipFiles "dist/checksums.txt" --clobber
+            gh release upload "$env:RELEASE_TAG" @zipFiles "dist/checksums.txt" "tools/install-multi-pwsh.ps1" "tools/install-multi-pwsh.sh" "tools/uninstall-multi-pwsh.ps1" "tools/uninstall-multi-pwsh.sh" --clobber
           }
           else {
             $createArgs = @(
@@ -268,6 +268,10 @@ jobs:
 
             $createArgs += $zipFiles
             $createArgs += "dist/checksums.txt"
+            $createArgs += "tools/install-multi-pwsh.ps1"
+            $createArgs += "tools/install-multi-pwsh.sh"
+            $createArgs += "tools/uninstall-multi-pwsh.ps1"
+            $createArgs += "tools/uninstall-multi-pwsh.sh"
             $createArgs += "--generate-notes"
             $createArgs += "--target"
             $createArgs += "$env:RELEASE_TARGET"

--- a/README.md
+++ b/README.md
@@ -9,31 +9,31 @@ Install and manage side-by-side PowerShell versions with aliases and native host
 Latest release bootstrap scripts:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.sh | bash
 ```
 
 ```powershell
-irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1 | iex
+irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.ps1 | iex
 ```
 
 Install a specific tag (example `v0.11.0`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash -s -- v0.11.0
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.11.0/install-multi-pwsh.sh | bash -s -- v0.11.0
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1))) -Version v0.11.0
+& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.11.0/install-multi-pwsh.ps1))) -Version v0.11.0
 ```
 
 Uninstall bootstrap scripts:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/uninstall-multi-pwsh.sh | bash
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/latest/download/uninstall-multi-pwsh.sh | bash
 ```
 
 ```powershell
-irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/uninstall-multi-pwsh.ps1 | iex
+irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/uninstall-multi-pwsh.ps1 | iex
 ```
 
 ## Install and verify aliases
@@ -53,6 +53,40 @@ pwsh-preview --version
 pwsh-lts --version
 pwsh-7.4 --version
 ```
+
+## Offline and network-share installs
+
+GitHub remains the default source, but you can prefetch release artifacts on a connected machine and use them from a disconnected machine.
+
+On a connected machine, warm an offline bundle into the same directory shape used by the download cache:
+
+```powershell
+multi-pwsh cache warm stable --os windows --arch x64 --output \\fileserver\multi-pwsh-cache
+multi-pwsh cache warm 7.4.x --os all --arch all --output \\fileserver\multi-pwsh-cache
+```
+
+The bundle includes PowerShell archives, PowerShell `hashes.sha256`, a relocatable manifest, and the current `multi-pwsh` release archive/checksums for the requested platform targets. Copy that directory locally or expose it as a read-only network share, then use it offline:
+
+```powershell
+$env:MULTI_PWSH_OFFLINE_CACHE = '\\fileserver\multi-pwsh-cache'
+multi-pwsh list --available
+multi-pwsh install stable
+multi-pwsh update 7.4
+```
+
+You can also pass `--offline-cache <path>` to `install`, `update`, `package install`, and `list --available`. Offline mode uses only the local manifest/artifacts and fails instead of falling back to GitHub when something is missing.
+
+Disconnected bootstrap uses the same bundle:
+
+```powershell
+.\install-multi-pwsh.ps1 -OfflineCache \\fileserver\multi-pwsh-cache -Version latest
+```
+
+```bash
+./install-multi-pwsh.sh --offline-cache /mnt/share/multi-pwsh-cache --version latest
+```
+
+Rerun the bootstrap script against a newer warmed bundle to update `multi-pwsh` itself. Archives are verified against the mirrored checksum files before installation.
 
 ## More docs
 
@@ -174,10 +208,11 @@ multi-pwsh venv list
 multi-pwsh --version
 multi-pwsh --help
 multi-pwsh help [command]
-multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
-multi-pwsh update <stable|preview|lts|major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
+multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--offline-cache <path>] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
+multi-pwsh update <stable|preview|lts|major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--offline-cache <path>] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]
+multi-pwsh cache warm <selector> [--os <windows|linux|macos|all>] [--arch <x64|x86|arm64|arm32|all>] [--include-prerelease] [--output <path>] [--product <powershell|multi-pwsh|all>]
 multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]
-multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease]
+multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease] [--offline-cache <path>]
 multi-pwsh venv create <name>
 multi-pwsh venv delete <name>
 multi-pwsh venv export <name> <archive.zip>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,7 @@ The workflow:
 - builds artifacts from the commit you dispatched the workflow from
 - creates the tag at that commit if needed
 - uploads archives and `checksums.txt` to the GitHub release
+- uploads install/uninstall bootstrap scripts to the GitHub release so users do not need `raw.githubusercontent.com`
 
 If the release already exists, the workflow uploads the refreshed assets with `--clobber`.
 
@@ -50,4 +51,6 @@ Confirm the release contains:
 
 - all platform zip archives
 - `checksums.txt`
+- `install-multi-pwsh.ps1` and `install-multi-pwsh.sh`
+- `uninstall-multi-pwsh.ps1` and `uninstall-multi-pwsh.sh`
 - generated release notes or any required manual edits

--- a/crates/multi-pwsh/src/install.rs
+++ b/crates/multi-pwsh/src/install.rs
@@ -12,7 +12,7 @@ use ureq::Agent;
 use crate::error::{MultiPwshError, Result};
 use crate::layout::InstallLayout;
 use crate::platform::HostOs;
-use crate::release::ResolvedRelease;
+use crate::release::{AssetSource, ResolvedRelease};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ChecksumSource {
@@ -24,7 +24,7 @@ pub enum ChecksumSource {
 
 pub fn ensure_installed(
     layout: &InstallLayout,
-    http: &Agent,
+    http: Option<&Agent>,
     os: HostOs,
     release: &ResolvedRelease,
     checksum_source: &ChecksumSource,
@@ -45,14 +45,14 @@ pub fn ensure_installed(
     let archive_path = cache_dir.join(&release.asset_name);
 
     if !archive_path.exists() {
-        download_with_retry(http, &release.asset_url, &archive_path, 8)?;
+        copy_asset_to_path(http, &release.asset_source, &archive_path)?;
     }
 
     validate_archive_checksum(http, release, checksum_source, &archive_path)?;
 
     extract_archive(&archive_path, &install_dir)?;
 
-    if !cache_keep_archives() {
+    if !cache_keep_archives() && !asset_source_matches_path(&release.asset_source, &archive_path) {
         let _ = fs::remove_file(&archive_path);
     }
 
@@ -69,6 +69,29 @@ pub fn ensure_installed(
     }
 
     Ok(executable)
+}
+
+pub fn copy_asset_to_path(http: Option<&Agent>, source: &AssetSource, destination: &Path) -> Result<()> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    match source {
+        AssetSource::Url(url) => {
+            let http = http.ok_or_else(|| {
+                MultiPwshError::Archive(format!("cannot download '{}' because no HTTP client is available", url))
+            })?;
+            download_with_retry(http, url, destination, 8)
+        }
+        AssetSource::File(source_path) => {
+            if asset_source_matches_path(source, destination) {
+                return Ok(());
+            }
+
+            fs::copy(source_path, destination)?;
+            Ok(())
+        }
+    }
 }
 
 fn download_with_retry(http: &Agent, url: &str, destination: &Path, retries: usize) -> Result<()> {
@@ -205,8 +228,8 @@ enum TextEncoding {
     Utf16BeNoBom,
 }
 
-fn validate_archive_checksum(
-    http: &Agent,
+pub fn validate_archive_checksum(
+    http: Option<&Agent>,
     release: &ResolvedRelease,
     checksum_source: &ChecksumSource,
     archive_path: &Path,
@@ -223,7 +246,9 @@ fn validate_archive_checksum(
         return Ok(());
     }
 
-    let _ = fs::remove_file(archive_path);
+    if !asset_source_matches_path(&release.asset_source, archive_path) {
+        let _ = fs::remove_file(archive_path);
+    }
     Err(MultiPwshError::Archive(format!(
         "checksum mismatch for '{}' using '{}': expected {}, got {}",
         release.asset_name, checksum_source_name, expected, actual
@@ -231,13 +256,13 @@ fn validate_archive_checksum(
 }
 
 fn load_checksum_text(
-    http: &Agent,
+    http: Option<&Agent>,
     release: &ResolvedRelease,
     checksum_source: &ChecksumSource,
 ) -> Result<(String, String)> {
     match checksum_source {
         ChecksumSource::ReleaseAsset => {
-            let checksum_url = release.checksum_asset_url.as_deref().ok_or_else(|| {
+            let checksum_source = release.checksum_asset_source.as_ref().ok_or_else(|| {
                 MultiPwshError::Archive(format!(
                     "release '{}' is missing checksum asset metadata; provide --hash-file <url-or-path> or use --skip-hash-verification to bypass verification",
                     release.asset_name
@@ -247,14 +272,55 @@ fn load_checksum_text(
                 .checksum_asset_name
                 .clone()
                 .unwrap_or_else(|| "hashes.sha256".to_string());
-            Ok((download_text_with_retry(http, checksum_url, 8)?, checksum_name))
+            Ok((load_text_from_asset_source(http, checksum_source)?, checksum_name))
         }
-        ChecksumSource::Url(url) => Ok((download_text_with_retry(http, url, 8)?, url.clone())),
+        ChecksumSource::Url(url) => {
+            let http = http.ok_or_else(|| {
+                MultiPwshError::Archive(format!(
+                    "cannot download checksum '{}' because no HTTP client is available",
+                    url
+                ))
+            })?;
+            Ok((download_text_with_retry(http, url, 8)?, url.clone()))
+        }
         ChecksumSource::File(path) => {
             let bytes = fs::read(path)?;
             Ok((decode_checksum_text(&bytes)?, path.display().to_string()))
         }
         ChecksumSource::Skip => Ok((String::new(), "checksum verification disabled".to_string())),
+    }
+}
+
+fn load_text_from_asset_source(http: Option<&Agent>, source: &AssetSource) -> Result<String> {
+    match source {
+        AssetSource::Url(url) => {
+            let http = http.ok_or_else(|| {
+                MultiPwshError::Archive(format!(
+                    "cannot download checksum '{}' because no HTTP client is available",
+                    url
+                ))
+            })?;
+            download_text_with_retry(http, url, 8)
+        }
+        AssetSource::File(path) => {
+            let bytes = fs::read(path)?;
+            decode_checksum_text(&bytes)
+        }
+    }
+}
+
+fn asset_source_matches_path(source: &AssetSource, path: &Path) -> bool {
+    let AssetSource::File(source_path) = source else {
+        return false;
+    };
+
+    paths_refer_to_same_location(source_path, path)
+}
+
+fn paths_refer_to_same_location(left: &Path, right: &Path) -> bool {
+    match (fs::canonicalize(left), fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
     }
 }
 
@@ -539,13 +605,13 @@ mod tests {
         let release = ResolvedRelease {
             version: semver::Version::parse("7.4.13").unwrap(),
             asset_name: "PowerShell-7.4.13-win-x64.zip".to_string(),
-            asset_url: "https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string(),
+            asset_source: AssetSource::Url("https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string()),
             checksum_asset_name: None,
-            checksum_asset_url: None,
+            checksum_asset_source: None,
         };
 
         let (content, source_name) =
-            load_checksum_text(&http, &release, &ChecksumSource::File(checksum_path.clone())).unwrap();
+            load_checksum_text(Some(&http), &release, &ChecksumSource::File(checksum_path.clone())).unwrap();
 
         assert!(content.contains("PowerShell-7.4.13-win-x64.zip"));
         assert_eq!(source_name, checksum_path.display().to_string());
@@ -557,12 +623,12 @@ mod tests {
         let release = ResolvedRelease {
             version: semver::Version::parse("7.4.13").unwrap(),
             asset_name: "PowerShell-7.4.13-win-x64.zip".to_string(),
-            asset_url: "https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string(),
+            asset_source: AssetSource::Url("https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string()),
             checksum_asset_name: None,
-            checksum_asset_url: None,
+            checksum_asset_source: None,
         };
 
-        let error = load_checksum_text(&http, &release, &ChecksumSource::ReleaseAsset).unwrap_err();
+        let error = load_checksum_text(Some(&http), &release, &ChecksumSource::ReleaseAsset).unwrap_err();
 
         assert!(error.to_string().contains("missing checksum asset metadata"));
     }

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -24,7 +24,7 @@ use aliases::{
     AliasSelector, PWSH_ALIAS, PWSH_LTS_ALIAS, PWSH_PREVIEW_ALIAS,
 };
 use error::{MultiPwshError, Result};
-use install::{ensure_installed, ChecksumSource};
+use install::{copy_asset_to_path, ensure_installed, validate_archive_checksum, ChecksumSource};
 use layout::InstallLayout;
 use package::{
     load_package_metadata, package_layout, persist_installed_version_registration, persist_installer_properties,
@@ -32,7 +32,10 @@ use package::{
     save_package_metadata, PackageInstallOptions, PackageScope, PACKAGE_METADATA_FILE,
 };
 use platform::{HostArch, HostOs};
-use release::ReleaseClient;
+use release::{
+    load_or_default_powershell_manifest, save_powershell_manifest, AssetSource, OfflinePowerShellAsset,
+    OfflinePowerShellManifest, OfflineReleaseClient, ReleaseClient, ResolvedRelease,
+};
 use versions::{
     is_current_lts_version, parse_exact_version, parse_install_selector, parse_major_minor_selector,
     parse_major_selector, MajorMinor, VersionSelector,
@@ -40,6 +43,8 @@ use versions::{
 
 const POWERSHELL_UPDATECHECK_ENV_VAR: &str = "POWERSHELL_UPDATECHECK";
 const POWERSHELL_UPDATECHECK_OFF: &str = "Off";
+const MULTI_PWSH_OFFLINE_CACHE_ENV_VAR: &str = "MULTI_PWSH_OFFLINE_CACHE";
+const MULTI_PWSH_RELEASE_SOURCE_ENV_VAR: &str = "MULTI_PWSH_RELEASE_SOURCE";
 const VIRTUAL_ENVIRONMENT_FLAG: &str = "-virtualenvironment";
 const VIRTUAL_ENVIRONMENT_SHORT_FLAG: &str = "-venv";
 const HELP_TOPICS: &[&str] = &[
@@ -51,12 +56,13 @@ const HELP_TOPICS: &[&str] = &[
     "alias",
     "host",
     "doctor",
+    "cache",
     "package",
     "version",
 ];
 
 fn usage_text() -> &'static str {
-    "Usage:\n  multi-pwsh --version\n  multi-pwsh --help\n  multi-pwsh help [command]\n  multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh update <stable|preview|lts|major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]\n  multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease]\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias set <pwsh|pwsh-preview|pwsh-lts> <stable|preview|lts|version>\n  multi-pwsh alias unset <major.minor|pwsh|pwsh-preview|pwsh-lts>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
+    "Usage:\n  multi-pwsh --version\n  multi-pwsh --help\n  multi-pwsh help [command]\n  multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--offline-cache <path>] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh update <stable|preview|lts|major.minor> [--scope <user|machine>] [--root <path>] [--arch <auto|x64|x86|arm64|arm32>] [--include-prerelease] [--offline-cache <path>] [--add-path|--no-add-path] [--register-manifest|--no-register-manifest] [--enable-psremoting] [--disable-telemetry] [--add-explorer-context-menu] [--add-file-context-menu]\n  multi-pwsh cache warm <selector> [--os <windows|linux|macos|all>] [--arch <x64|x86|arm64|arm32|all>] [--include-prerelease] [--output <path>]\n  multi-pwsh uninstall <version> [--scope <user|machine>] [--root <path>] [--force]\n  multi-pwsh list [--scope <user|machine|all>] [--root <path>] [--available] [--include-prerelease] [--offline-cache <path>]\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list\n  multi-pwsh alias set <major.minor> <version|latest>\n  multi-pwsh alias set <pwsh|pwsh-preview|pwsh-lts> <stable|preview|lts|version>\n  multi-pwsh alias unset <major.minor|pwsh|pwsh-preview|pwsh-lts>\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]\n  multi-pwsh doctor --repair-aliases"
 }
 
 fn print_usage() {
@@ -78,16 +84,16 @@ fn is_help_flag(value: &str) -> bool {
 fn help_topic_text(topic: &str) -> Option<&'static str> {
     match topic {
         "install" => Some(
-            "Usage:\n  multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [options]\n\nOptions:\n  --scope <user|machine>\n  --root <path>\n  --arch <auto|x64|x86|arm64|arm32>\n  --include-prerelease\n  --add-path | --no-add-path\n  --register-manifest | --no-register-manifest\n  --enable-psremoting\n  --disable-telemetry\n  --add-explorer-context-menu\n  --add-file-context-menu\n  --skip-hash-verification\n  --hash-file <url-or-path>",
+            "Usage:\n  multi-pwsh install <stable|preview|lts|version|major|major.minor|major.minor.x> [options]\n\nOptions:\n  --scope <user|machine>\n  --root <path>\n  --arch <auto|x64|x86|arm64|arm32>\n  --include-prerelease\n  --offline-cache <path>\n  --add-path | --no-add-path\n  --register-manifest | --no-register-manifest\n  --enable-psremoting\n  --disable-telemetry\n  --add-explorer-context-menu\n  --add-file-context-menu\n  --skip-hash-verification\n  --hash-file <url-or-path>",
         ),
         "update" => Some(
-            "Usage:\n  multi-pwsh update <stable|preview|lts|major.minor> [options]\n\nOptions:\n  --scope <user|machine>\n  --root <path>\n  --arch <auto|x64|x86|arm64|arm32>\n  --include-prerelease\n  --add-path | --no-add-path\n  --register-manifest | --no-register-manifest\n  --enable-psremoting\n  --disable-telemetry\n  --add-explorer-context-menu\n  --add-file-context-menu\n  --skip-hash-verification\n  --hash-file <url-or-path>",
+            "Usage:\n  multi-pwsh update <stable|preview|lts|major.minor> [options]\n\nOptions:\n  --scope <user|machine>\n  --root <path>\n  --arch <auto|x64|x86|arm64|arm32>\n  --include-prerelease\n  --offline-cache <path>\n  --add-path | --no-add-path\n  --register-manifest | --no-register-manifest\n  --enable-psremoting\n  --disable-telemetry\n  --add-explorer-context-menu\n  --add-file-context-menu\n  --skip-hash-verification\n  --hash-file <url-or-path>",
         ),
         "uninstall" => Some(
             "Usage:\n  multi-pwsh uninstall <version> [options]\n\nOptions:\n  --scope <user|machine>\n  --root <path>\n  --force",
         ),
         "list" => Some(
-            "Usage:\n  multi-pwsh list [options]\n\nOptions:\n  --scope <user|machine|all>\n  --root <path>\n  --available\n  --include-prerelease",
+            "Usage:\n  multi-pwsh list [options]\n\nOptions:\n  --scope <user|machine|all>\n  --root <path>\n  --available\n  --include-prerelease\n  --offline-cache <path>",
         ),
         "venv" => Some(
             "Usage:\n  multi-pwsh venv create <name>\n  multi-pwsh venv delete <name>\n  multi-pwsh venv export <name> <archive.zip>\n  multi-pwsh venv import <name> <archive.zip>\n  multi-pwsh venv list",
@@ -99,6 +105,9 @@ fn help_topic_text(topic: &str) -> Option<&'static str> {
             "Usage:\n  multi-pwsh host <version|major|major.minor|pwsh-alias> [-VirtualEnvironment <name>|-venv <name>] [pwsh arguments...]",
         ),
         "doctor" => Some("Usage:\n  multi-pwsh doctor --repair-aliases"),
+        "cache" => Some(
+            "Usage:\n  multi-pwsh cache warm <selector> [options]\n\nOptions:\n  --os <windows|linux|macos|all>\n  --arch <x64|x86|arm64|arm32|all>\n  --include-prerelease\n  --output <path>\n  --product <powershell|multi-pwsh|all>",
+        ),
         "package" => Some(
             "Usage:\n  multi-pwsh package install <selector> [options]\n  multi-pwsh package uninstall <version> [--scope <user|machine>] [--root <path>] [--force]\n  multi-pwsh package list [--scope <user|machine>] [--root <path>]",
         ),
@@ -137,12 +146,14 @@ struct ReleaseSelectionOptions {
     arch: Option<HostArch>,
     include_prerelease: bool,
     checksum_source: ChecksumSource,
+    offline_cache: Option<PathBuf>,
 }
 
 #[derive(Debug)]
 struct InstallCommandOptions {
     package: PackageInstallOptions,
     checksum_source: ChecksumSource,
+    offline_cache: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug)]
@@ -183,7 +194,68 @@ enum ListOption {
     },
     Available {
         include_prerelease: bool,
+        offline_cache: Option<PathBuf>,
     },
+}
+
+enum ReleaseResolver {
+    Github(ReleaseClient),
+    Offline(OfflineReleaseClient),
+}
+
+impl ReleaseResolver {
+    fn new(offline_cache: Option<PathBuf>) -> Result<Self> {
+        if let Some(path) = effective_offline_cache(offline_cache) {
+            return Ok(ReleaseResolver::Offline(OfflineReleaseClient::new(path)?));
+        }
+
+        let token = env::var("GITHUB_TOKEN").ok();
+        Ok(ReleaseResolver::Github(ReleaseClient::new(token)?))
+    }
+
+    fn http_client(&self) -> Option<&ureq::Agent> {
+        match self {
+            ReleaseResolver::Github(client) => Some(client.http_client()),
+            ReleaseResolver::Offline(_) => None,
+        }
+    }
+
+    fn resolve_selector(
+        &self,
+        selector: VersionSelector,
+        os: HostOs,
+        arch: HostArch,
+        include_prerelease: bool,
+    ) -> Result<ResolvedRelease> {
+        match self {
+            ReleaseResolver::Github(client) => client.resolve_selector(selector, os, arch, include_prerelease),
+            ReleaseResolver::Offline(client) => client.resolve_selector(selector, os, arch, include_prerelease),
+        }
+    }
+
+    fn resolve_all_in_line(
+        &self,
+        line: MajorMinor,
+        os: HostOs,
+        arch: HostArch,
+        include_prerelease: bool,
+    ) -> Result<Vec<ResolvedRelease>> {
+        match self {
+            ReleaseResolver::Github(client) => client.resolve_all_in_line(line, os, arch, include_prerelease),
+            ReleaseResolver::Offline(client) => client.resolve_all_in_line(line, os, arch, include_prerelease),
+        }
+    }
+
+    fn list_available_versions(&self, include_prerelease: bool) -> Result<Vec<Version>> {
+        match self {
+            ReleaseResolver::Github(client) => client.list_available_versions(include_prerelease),
+            ReleaseResolver::Offline(client) => Ok(client.list_available_versions(include_prerelease)),
+        }
+    }
+
+    fn is_offline(&self) -> bool {
+        matches!(self, ReleaseResolver::Offline(_))
+    }
 }
 
 #[derive(Debug, Default, Eq, PartialEq)]
@@ -1004,6 +1076,492 @@ fn parse_update_selector(value: &str) -> Result<VersionSelector> {
     }
 }
 
+fn offline_cache_from_env() -> Option<PathBuf> {
+    if let Some(path) = env::var_os(MULTI_PWSH_OFFLINE_CACHE_ENV_VAR) {
+        if !path.is_empty() {
+            return Some(PathBuf::from(path));
+        }
+    }
+
+    let value = env::var_os(MULTI_PWSH_RELEASE_SOURCE_ENV_VAR)?;
+    if value.is_empty() {
+        return None;
+    }
+
+    let text = value.to_string_lossy();
+    if text.eq_ignore_ascii_case("github") || text.eq_ignore_ascii_case("online") {
+        return None;
+    }
+
+    Some(PathBuf::from(value))
+}
+
+fn effective_offline_cache(cli_value: Option<PathBuf>) -> Option<PathBuf> {
+    cli_value.or_else(offline_cache_from_env)
+}
+
+fn parse_offline_cache_option(
+    args: &[String],
+    index: usize,
+    offline_cache: &mut Option<PathBuf>,
+) -> Result<Option<usize>> {
+    match args[index].as_str() {
+        "--offline-cache" => {
+            if index + 1 >= args.len() {
+                return Err(MultiPwshError::InvalidArguments(
+                    "expected value after --offline-cache".to_string(),
+                ));
+            }
+
+            if offline_cache.is_some() {
+                return Err(MultiPwshError::InvalidArguments(
+                    "--offline-cache can only be specified once".to_string(),
+                ));
+            }
+
+            *offline_cache = Some(PathBuf::from(&args[index + 1]));
+            Ok(Some(index + 2))
+        }
+        _ => Ok(None),
+    }
+}
+
+struct CacheWarmOptions {
+    target_oses: Vec<HostOs>,
+    target_arches: Vec<HostArch>,
+    include_prerelease: bool,
+    output: Option<PathBuf>,
+    product: CacheProduct,
+    os_wildcard: bool,
+    arch_wildcard: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CacheProduct {
+    PowerShell,
+    MultiPwsh,
+    All,
+}
+
+impl CacheProduct {
+    fn includes_powershell(self) -> bool {
+        matches!(self, CacheProduct::PowerShell | CacheProduct::All)
+    }
+
+    fn includes_multi_pwsh(self) -> bool {
+        matches!(self, CacheProduct::MultiPwsh | CacheProduct::All)
+    }
+}
+
+fn all_host_oses() -> Vec<HostOs> {
+    vec![HostOs::Windows, HostOs::Macos, HostOs::Linux]
+}
+
+fn all_host_arches() -> Vec<HostArch> {
+    vec![HostArch::X64, HostArch::X86, HostArch::Arm64, HostArch::Arm32]
+}
+
+fn parse_cache_warm_options(args: &[String]) -> Result<CacheWarmOptions> {
+    let mut target_oses = vec![HostOs::detect()?];
+    let mut target_arches = vec![HostArch::detect()];
+    let mut os_specified = false;
+    let mut arch_specified = false;
+    let mut os_wildcard = false;
+    let mut arch_wildcard = false;
+    let mut include_prerelease = false;
+    let mut output = None;
+    let mut product = CacheProduct::All;
+    let mut product_specified = false;
+    let mut index = 0usize;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--os" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --os".to_string(),
+                    ));
+                }
+                if os_specified {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--os can only be specified once".to_string(),
+                    ));
+                }
+                if args[index + 1].eq_ignore_ascii_case("all") {
+                    target_oses = all_host_oses();
+                    os_wildcard = true;
+                } else {
+                    target_oses = vec![HostOs::parse(&args[index + 1]).ok_or_else(|| {
+                        MultiPwshError::InvalidArguments(format!(
+                            "unsupported operating system '{}', expected one of: windows, linux, macos, all",
+                            args[index + 1]
+                        ))
+                    })?];
+                }
+                os_specified = true;
+                index += 2;
+            }
+            "--arch" | "-a" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --arch".to_string(),
+                    ));
+                }
+                if arch_specified {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--arch can only be specified once".to_string(),
+                    ));
+                }
+                if args[index + 1].eq_ignore_ascii_case("all") {
+                    target_arches = all_host_arches();
+                    arch_wildcard = true;
+                } else {
+                    target_arches = vec![HostArch::parse(&args[index + 1]).ok_or_else(|| {
+                        MultiPwshError::InvalidArguments(format!(
+                            "unsupported architecture '{}', expected one of: x64, x86, arm64, arm32, all",
+                            args[index + 1]
+                        ))
+                    })?];
+                }
+                arch_specified = true;
+                index += 2;
+            }
+            "--include-prerelease" | "--prerelease" => {
+                include_prerelease = true;
+                index += 1;
+            }
+            "--output" | "-o" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --output".to_string(),
+                    ));
+                }
+                if output.is_some() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--output can only be specified once".to_string(),
+                    ));
+                }
+                output = Some(PathBuf::from(&args[index + 1]));
+                index += 2;
+            }
+            "--product" => {
+                if index + 1 >= args.len() {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "expected value after --product".to_string(),
+                    ));
+                }
+                if product_specified {
+                    return Err(MultiPwshError::InvalidArguments(
+                        "--product can only be specified once".to_string(),
+                    ));
+                }
+                product = match args[index + 1].to_ascii_lowercase().as_str() {
+                    "powershell" | "pwsh" => CacheProduct::PowerShell,
+                    "multi-pwsh" | "multipwsh" | "self" => CacheProduct::MultiPwsh,
+                    "all" => CacheProduct::All,
+                    value => {
+                        return Err(MultiPwshError::InvalidArguments(format!(
+                            "unsupported product '{}', expected one of: powershell, multi-pwsh, all",
+                            value
+                        )));
+                    }
+                };
+                product_specified = true;
+                index += 2;
+            }
+            _ => {
+                return Err(MultiPwshError::InvalidArguments(
+                    "expected optional --os <windows|linux|macos|all>, --arch <x64|x86|arm64|arm32|all>, --include-prerelease, --output <path>, and/or --product <powershell|multi-pwsh|all>".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(CacheWarmOptions {
+        target_oses,
+        target_arches,
+        include_prerelease,
+        output,
+        product,
+        os_wildcard,
+        arch_wildcard,
+    })
+}
+
+fn bundle_relative_path(parts: &[String]) -> String {
+    parts.join("/")
+}
+
+fn bundle_path(root: &Path, relative_path: &str) -> PathBuf {
+    let mut path = root.to_path_buf();
+    for part in relative_path.split('/') {
+        path.push(part);
+    }
+    path
+}
+
+fn cache_target_error_can_be_skipped(error: &MultiPwshError) -> bool {
+    matches!(
+        error,
+        MultiPwshError::UnsupportedPlatform(_) | MultiPwshError::AssetNotFound(_) | MultiPwshError::ReleaseNotFound(_)
+    )
+}
+
+fn resolve_cache_releases(
+    client: &ReleaseClient,
+    selector: VersionSelector,
+    target_os: HostOs,
+    target_arch: HostArch,
+    include_prerelease: bool,
+) -> Result<Vec<ResolvedRelease>> {
+    match selector {
+        VersionSelector::MajorMinorWildcard(line) => {
+            client.resolve_all_in_line(line, target_os, target_arch, include_prerelease)
+        }
+        _ => Ok(vec![client.resolve_selector(
+            selector,
+            target_os,
+            target_arch,
+            include_prerelease,
+        )?]),
+    }
+}
+
+fn cache_release_artifacts(
+    client: &ReleaseClient,
+    output_root: &Path,
+    manifest: &mut OfflinePowerShellManifest,
+    release: &ResolvedRelease,
+    target_os: HostOs,
+    target_arch: HostArch,
+) -> Result<()> {
+    let release_dir = format!("v{}", release.version);
+    let asset_relative_path = bundle_relative_path(&[
+        "PowerShell".to_string(),
+        release_dir.clone(),
+        release.asset_name.clone(),
+    ]);
+    let asset_path = bundle_path(output_root, &asset_relative_path);
+    if !asset_path.exists() {
+        copy_asset_to_path(Some(client.http_client()), &release.asset_source, &asset_path)?;
+    }
+
+    let checksum_name = release.checksum_asset_name.clone().ok_or_else(|| {
+        MultiPwshError::Archive(format!(
+            "release '{}' is missing checksum asset metadata and cannot be mirrored safely",
+            release.asset_name
+        ))
+    })?;
+    let checksum_source = release.checksum_asset_source.as_ref().ok_or_else(|| {
+        MultiPwshError::Archive(format!(
+            "release '{}' is missing checksum asset source and cannot be mirrored safely",
+            release.asset_name
+        ))
+    })?;
+    let checksum_relative_path = bundle_relative_path(&["PowerShell".to_string(), release_dir, checksum_name.clone()]);
+    let checksum_path = bundle_path(output_root, &checksum_relative_path);
+    if !checksum_path.exists() {
+        copy_asset_to_path(Some(client.http_client()), checksum_source, &checksum_path)?;
+    }
+
+    let cached_release = ResolvedRelease {
+        version: release.version.clone(),
+        asset_name: release.asset_name.clone(),
+        asset_source: AssetSource::File(asset_path.clone()),
+        checksum_asset_name: Some(checksum_name.clone()),
+        checksum_asset_source: Some(AssetSource::File(checksum_path)),
+    };
+    validate_archive_checksum(None, &cached_release, &ChecksumSource::ReleaseAsset, &asset_path)?;
+
+    manifest.upsert_asset(
+        &release.version,
+        !release.version.pre.is_empty(),
+        OfflinePowerShellAsset {
+            name: release.asset_name.clone(),
+            path: asset_relative_path,
+            os: target_os.as_manifest_value().to_string(),
+            arch: target_arch.as_manifest_value().to_string(),
+            checksum_name: Some(checksum_name),
+            checksum_path: Some(checksum_relative_path),
+        },
+    );
+
+    println!(
+        "Cached PowerShell {} for {} {}: {}",
+        release.version, target_os, target_arch, release.asset_name
+    );
+    Ok(())
+}
+
+fn multi_pwsh_asset_name(target_os: HostOs, target_arch: HostArch) -> Result<String> {
+    let os = match target_os {
+        HostOs::Windows => "windows",
+        HostOs::Macos => "macos",
+        HostOs::Linux => "linux",
+    };
+
+    let arch = match (target_os, target_arch) {
+        (_, HostArch::X64) => "x64",
+        (HostOs::Windows | HostOs::Macos | HostOs::Linux, HostArch::Arm64) => "arm64",
+        _ => {
+            return Err(MultiPwshError::UnsupportedPlatform(format!(
+                "multi-pwsh does not publish an archive for {} {}",
+                target_os, target_arch
+            )));
+        }
+    };
+
+    Ok(format!("multi-pwsh-{}-{}.zip", os, arch))
+}
+
+fn cache_multi_pwsh_artifact(
+    client: &ReleaseClient,
+    output_root: &Path,
+    target_os: HostOs,
+    target_arch: HostArch,
+) -> Result<()> {
+    let version = Version::parse(env!("CARGO_PKG_VERSION"))?;
+    let tag = format!("v{}", version);
+    let asset_name = multi_pwsh_asset_name(target_os, target_arch)?;
+    let asset_relative_path = bundle_relative_path(&["multi-pwsh".to_string(), tag.clone(), asset_name.clone()]);
+    let checksum_relative_path =
+        bundle_relative_path(&["multi-pwsh".to_string(), tag.clone(), "checksums.txt".to_string()]);
+    let asset_path = bundle_path(output_root, &asset_relative_path);
+    let checksum_path = bundle_path(output_root, &checksum_relative_path);
+    let release_base = format!("https://github.com/Devolutions/multi-pwsh/releases/download/{}", tag);
+
+    if !asset_path.exists() {
+        copy_asset_to_path(
+            Some(client.http_client()),
+            &AssetSource::Url(format!("{}/{}", release_base, asset_name)),
+            &asset_path,
+        )?;
+    }
+
+    if !checksum_path.exists() {
+        copy_asset_to_path(
+            Some(client.http_client()),
+            &AssetSource::Url(format!("{}/checksums.txt", release_base)),
+            &checksum_path,
+        )?;
+    }
+
+    let cached_release = ResolvedRelease {
+        version,
+        asset_name: asset_name.clone(),
+        asset_source: AssetSource::File(asset_path.clone()),
+        checksum_asset_name: Some("checksums.txt".to_string()),
+        checksum_asset_source: Some(AssetSource::File(checksum_path)),
+    };
+    validate_archive_checksum(None, &cached_release, &ChecksumSource::ReleaseAsset, &asset_path)?;
+
+    println!(
+        "Cached multi-pwsh {} for {} {}",
+        env!("CARGO_PKG_VERSION"),
+        target_os,
+        target_arch
+    );
+    Ok(())
+}
+
+fn run_cache_warm(selector_input: &str, options: CacheWarmOptions) -> Result<()> {
+    let selector = parse_install_selector(selector_input)?;
+    let output_root = options.output.unwrap_or_else(|| {
+        InstallLayout::new(HostOs::detect().unwrap_or(HostOs::Windows))
+            .map(|layout| layout.cache_dir())
+            .unwrap_or_else(|_| PathBuf::from("."))
+    });
+    fs::create_dir_all(&output_root)?;
+
+    let token = env::var("GITHUB_TOKEN").ok();
+    let release_client = ReleaseClient::new(token)?;
+    let mut manifest = load_or_default_powershell_manifest(&output_root)?;
+    let mut cached_count = 0usize;
+    let mut multi_pwsh_count = 0usize;
+
+    if options.product.includes_powershell() {
+        for target_os in &options.target_oses {
+            for target_arch in &options.target_arches {
+                let releases = match resolve_cache_releases(
+                    &release_client,
+                    selector.clone(),
+                    *target_os,
+                    *target_arch,
+                    options.include_prerelease,
+                ) {
+                    Ok(releases) => releases,
+                    Err(error)
+                        if (options.os_wildcard || options.arch_wildcard)
+                            && cache_target_error_can_be_skipped(&error) =>
+                    {
+                        eprintln!("Skipping {} {}: {}", target_os, target_arch, error);
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                };
+
+                for release in releases {
+                    cache_release_artifacts(
+                        &release_client,
+                        &output_root,
+                        &mut manifest,
+                        &release,
+                        *target_os,
+                        *target_arch,
+                    )?;
+                    cached_count += 1;
+                }
+            }
+        }
+        save_powershell_manifest(&output_root, &manifest)?;
+    }
+
+    if options.product.includes_multi_pwsh() {
+        for target_os in &options.target_oses {
+            for target_arch in &options.target_arches {
+                match cache_multi_pwsh_artifact(&release_client, &output_root, *target_os, *target_arch) {
+                    Ok(()) => multi_pwsh_count += 1,
+                    Err(error)
+                        if (options.os_wildcard || options.arch_wildcard)
+                            && cache_target_error_can_be_skipped(&error) =>
+                    {
+                        eprintln!("Skipping multi-pwsh {} {}: {}", target_os, target_arch, error);
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+        }
+    }
+
+    println!("Offline cache root: {}", output_root.display());
+    println!("PowerShell artifacts cached: {}", cached_count);
+    println!("multi-pwsh artifacts cached: {}", multi_pwsh_count);
+    Ok(())
+}
+
+fn run_cache(args: &[String]) -> Result<()> {
+    if args.is_empty() {
+        return Err(MultiPwshError::InvalidArguments(
+            "cache requires: warm <selector>".to_string(),
+        ));
+    }
+
+    match args[0].as_str() {
+        "warm" => {
+            if args.len() < 2 {
+                return Err(MultiPwshError::InvalidArguments(
+                    "cache warm requires <stable|preview|lts|version|major|major.minor|major.minor.x>".to_string(),
+                ));
+            }
+            let options = parse_cache_warm_options(&args[2..])?;
+            run_cache_warm(&args[1], options)
+        }
+        _ => Err(MultiPwshError::InvalidArguments(
+            "cache requires: warm <selector>".to_string(),
+        )),
+    }
+}
+
 fn run_venv(args: &[String]) -> Result<()> {
     if args.is_empty() {
         return Err(MultiPwshError::InvalidArguments(
@@ -1240,9 +1798,15 @@ fn parse_release_selection_options(args: &[String]) -> Result<ReleaseSelectionOp
     let mut include_prerelease = false;
     let mut checksum_source = ChecksumSource::ReleaseAsset;
     let mut checksum_source_specified = false;
+    let mut offline_cache = None;
 
     let mut index = 0usize;
     while index < args.len() {
+        if let Some(next_index) = parse_offline_cache_option(args, index, &mut offline_cache)? {
+            index = next_index;
+            continue;
+        }
+
         if let Some(next_index) =
             parse_checksum_cli_option(args, index, &mut checksum_source, &mut checksum_source_specified)?
         {
@@ -1284,7 +1848,7 @@ fn parse_release_selection_options(args: &[String]) -> Result<ReleaseSelectionOp
             }
             _ => {
                 return Err(MultiPwshError::InvalidArguments(
-                    "expected optional --arch <value>, --include-prerelease, --skip-hash-verification, and/or --hash-file <url-or-path>".to_string(),
+                    "expected optional --arch <value>, --include-prerelease, --offline-cache <path>, --skip-hash-verification, and/or --hash-file <url-or-path>".to_string(),
                 ));
             }
         }
@@ -1294,6 +1858,7 @@ fn parse_release_selection_options(args: &[String]) -> Result<ReleaseSelectionOp
         arch,
         include_prerelease,
         checksum_source,
+        offline_cache,
     })
 }
 
@@ -1420,9 +1985,15 @@ fn parse_package_install_options(args: &[String]) -> Result<InstallCommandOption
     let mut arch_specified = false;
     let mut checksum_source = ChecksumSource::ReleaseAsset;
     let mut checksum_source_specified = false;
+    let mut offline_cache = None;
     let mut index = 0usize;
 
     while index < args.len() {
+        if let Some(next_index) = parse_offline_cache_option(args, index, &mut offline_cache)? {
+            index = next_index;
+            continue;
+        }
+
         if let Some(next_index) =
             parse_checksum_cli_option(args, index, &mut checksum_source, &mut checksum_source_specified)?
         {
@@ -1568,6 +2139,7 @@ fn parse_package_install_options(args: &[String]) -> Result<InstallCommandOption
     Ok(InstallCommandOptions {
         package: options,
         checksum_source,
+        offline_cache,
     })
 }
 
@@ -1720,17 +2292,17 @@ fn run_package_install(selector_input: &str, install_options: InstallCommandOpti
     let os = HostOs::detect()?;
     let options = install_options.package;
     let checksum_source = install_options.checksum_source;
+    let offline_cache = install_options.offline_cache;
     let arch = options.arch.unwrap_or_else(HostArch::detect);
     let layout = package_layout(os, arch, options.scope, options.install_root.clone())?;
     layout.ensure_base_dirs()?;
 
-    let token = env::var("GITHUB_TOKEN").ok();
-    let release_client = ReleaseClient::new(token)?;
+    let release_resolver = ReleaseResolver::new(offline_cache)?;
     let releases = match selector.clone() {
         VersionSelector::MajorMinorWildcard(line) => {
-            release_client.resolve_all_in_line(line, os, arch, options.include_prerelease)?
+            release_resolver.resolve_all_in_line(line, os, arch, options.include_prerelease)?
         }
-        _ => vec![release_client.resolve_selector(selector.clone(), os, arch, options.include_prerelease)?],
+        _ => vec![release_resolver.resolve_selector(selector.clone(), os, arch, options.include_prerelease)?],
     };
 
     let mut metadata = load_package_metadata(&layout)?;
@@ -1738,7 +2310,8 @@ fn run_package_install(selector_input: &str, install_options: InstallCommandOpti
     let mut touched_majors: Vec<u64> = Vec::new();
 
     for release in releases {
-        let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release, &checksum_source)?;
+        let executable_path =
+            ensure_installed(&layout, release_resolver.http_client(), os, &release, &checksum_source)?;
         let patch_alias = create_or_update_patch_alias(&layout, os, &release.version, &executable_path)?;
         let version_path = executable_path.parent().unwrap_or_else(|| Path::new(""));
 
@@ -2105,6 +2678,7 @@ fn run_install(
     arch: Option<HostArch>,
     include_prerelease: bool,
     checksum_source: ChecksumSource,
+    offline_cache: Option<PathBuf>,
 ) -> Result<()> {
     let selector = parse_install_selector(selector_input)?;
     let os = HostOs::detect()?;
@@ -2113,20 +2687,20 @@ fn run_install(
     let layout = InstallLayout::new(os)?;
     layout.ensure_base_dirs()?;
 
-    let token = env::var("GITHUB_TOKEN").ok();
-    let release_client = ReleaseClient::new(token)?;
+    let release_resolver = ReleaseResolver::new(offline_cache)?;
     let releases = match selector.clone() {
         VersionSelector::MajorMinorWildcard(line) => {
-            release_client.resolve_all_in_line(line, os, arch, include_prerelease)?
+            release_resolver.resolve_all_in_line(line, os, arch, include_prerelease)?
         }
-        _ => vec![release_client.resolve_selector(selector.clone(), os, arch, include_prerelease)?],
+        _ => vec![release_resolver.resolve_selector(selector.clone(), os, arch, include_prerelease)?],
     };
 
     let mut touched_lines: Vec<MajorMinor> = Vec::new();
     let mut touched_majors: Vec<u64> = Vec::new();
 
     for release in releases {
-        let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release, &checksum_source)?;
+        let executable_path =
+            ensure_installed(&layout, release_resolver.http_client(), os, &release, &checksum_source)?;
         let patch_alias = create_or_update_patch_alias(&layout, os, &release.version, &executable_path)?;
         let version_path = executable_path.parent().unwrap_or_else(|| Path::new(""));
 
@@ -2187,6 +2761,7 @@ fn run_update(
     arch: Option<HostArch>,
     include_prerelease: bool,
     checksum_source: ChecksumSource,
+    offline_cache: Option<PathBuf>,
 ) -> Result<()> {
     let line = parse_major_minor_selector(line_input)?;
     let os = HostOs::detect()?;
@@ -2195,10 +2770,9 @@ fn run_update(
     let layout = InstallLayout::new(os)?;
     layout.ensure_base_dirs()?;
 
-    let token = env::var("GITHUB_TOKEN").ok();
-    let release_client = ReleaseClient::new(token)?;
-    let release = release_client.resolve_latest_in_line(line, os, arch, include_prerelease)?;
-    let executable_path = ensure_installed(&layout, release_client.http_client(), os, &release, &checksum_source)?;
+    let release_resolver = ReleaseResolver::new(offline_cache)?;
+    let release = release_resolver.resolve_selector(VersionSelector::MajorMinor(line), os, arch, include_prerelease)?;
+    let executable_path = ensure_installed(&layout, release_resolver.http_client(), os, &release, &checksum_source)?;
     let patch_alias_path = create_or_update_patch_alias(&layout, os, &release.version, &executable_path)?;
     let version_path = executable_path.parent().unwrap_or_else(|| Path::new(""));
 
@@ -2335,11 +2909,17 @@ fn parse_force_option(args: &[String]) -> Result<bool> {
 fn parse_list_option(args: &[String]) -> Result<ListOption> {
     let mut available = false;
     let mut include_prerelease = false;
+    let mut offline_cache = None;
     let mut scope = None;
     let mut root = None;
     let mut index = 0usize;
 
     while index < args.len() {
+        if let Some(next_index) = parse_offline_cache_option(args, index, &mut offline_cache)? {
+            index = next_index;
+            continue;
+        }
+
         match args[index].as_str() {
             "--available" | "--online" => {
                 available = true;
@@ -2388,7 +2968,7 @@ fn parse_list_option(args: &[String]) -> Result<ListOption> {
             }
             _ => {
                 return Err(MultiPwshError::InvalidArguments(
-                    "expected optional --scope <user|machine|all>, --root <path>, --available, and/or --include-prerelease"
+                    "expected optional --scope <user|machine|all>, --root <path>, --available, --include-prerelease, and/or --offline-cache <path>"
                         .to_string(),
                 ));
             }
@@ -2407,7 +2987,16 @@ fn parse_list_option(args: &[String]) -> Result<ListOption> {
                 "--scope and --root are only supported for installed-version listings".to_string(),
             ));
         }
-        return Ok(ListOption::Available { include_prerelease });
+        return Ok(ListOption::Available {
+            include_prerelease,
+            offline_cache,
+        });
+    }
+
+    if offline_cache.is_some() {
+        return Err(MultiPwshError::InvalidArguments(
+            "--offline-cache requires --available".to_string(),
+        ));
     }
 
     Ok(ListOption::Installed { scope, root })
@@ -2448,17 +3037,29 @@ fn run_list(option: ListOption) -> Result<()> {
 
             run_scoped_list(scope, root)
         }
-        ListOption::Available { include_prerelease } => {
-            let token = env::var("GITHUB_TOKEN").ok();
-            let release_client = ReleaseClient::new(token)?;
-            let versions = release_client.list_available_versions(include_prerelease)?;
+        ListOption::Available {
+            include_prerelease,
+            offline_cache,
+        } => {
+            let release_resolver = ReleaseResolver::new(offline_cache)?;
+            let versions = release_resolver.list_available_versions(include_prerelease)?;
 
             if versions.is_empty() {
-                println!("Available online versions: (none)");
+                if release_resolver.is_offline() {
+                    println!("Available offline bundle versions: (none)");
+                } else {
+                    println!("Available online versions: (none)");
+                }
                 return Ok(());
             }
 
-            if include_prerelease {
+            if release_resolver.is_offline() {
+                if include_prerelease {
+                    println!("Available offline bundle versions (including prerelease):");
+                } else {
+                    println!("Available offline bundle versions:");
+                }
+            } else if include_prerelease {
                 println!("Available online versions (including prerelease):");
             } else {
                 println!("Available online versions:");
@@ -2622,6 +3223,7 @@ fn run() -> Result<()> {
                     options.arch,
                     options.include_prerelease,
                     options.checksum_source,
+                    options.offline_cache,
                 )
             }
         }
@@ -2643,6 +3245,7 @@ fn run() -> Result<()> {
                     options.arch,
                     options.include_prerelease,
                     options.checksum_source,
+                    options.offline_cache,
                 )
             } else {
                 let options = parse_release_selection_options(&args[2..])?;
@@ -2651,6 +3254,7 @@ fn run() -> Result<()> {
                     options.arch,
                     options.include_prerelease,
                     options.checksum_source,
+                    options.offline_cache,
                 )
             }
         }
@@ -2668,6 +3272,7 @@ fn run() -> Result<()> {
             run_list(list_option)
         }
         "package" => run_package(&args[1..]),
+        "cache" => run_cache(&args[1..]),
         "venv" => run_venv(&args[1..]),
         "alias" => run_alias(&args[1..]),
         "host" => {
@@ -2676,7 +3281,7 @@ fn run() -> Result<()> {
         }
         "doctor" => run_doctor(&args[1..]),
         command => Err(MultiPwshError::InvalidArguments(format!(
-            "unknown command '{}'. expected: install, update, uninstall, list, venv, alias, host, doctor, package, version",
+            "unknown command '{}'. expected: install, update, uninstall, list, cache, venv, alias, host, doctor, package, version",
             command
         ))),
     }
@@ -2760,7 +3365,8 @@ mod tests {
         assert!(matches!(
             parse_list_option(&args).unwrap(),
             ListOption::Available {
-                include_prerelease: false
+                include_prerelease: false,
+                offline_cache: None
             }
         ));
     }
@@ -2771,9 +3377,32 @@ mod tests {
         assert!(matches!(
             parse_list_option(&args).unwrap(),
             ListOption::Available {
-                include_prerelease: true
+                include_prerelease: true,
+                offline_cache: None
             }
         ));
+    }
+
+    #[test]
+    fn parse_list_option_accepts_available_with_offline_cache() {
+        let args = vec![
+            "--available".to_string(),
+            "--offline-cache".to_string(),
+            "C:\\cache".to_string(),
+        ];
+        assert!(matches!(
+            parse_list_option(&args).unwrap(),
+            ListOption::Available {
+                include_prerelease: false,
+                offline_cache: Some(path)
+            } if path == Path::new("C:\\cache")
+        ));
+    }
+
+    #[test]
+    fn parse_list_option_rejects_offline_cache_without_available() {
+        let args = vec!["--offline-cache".to_string(), "C:\\cache".to_string()];
+        assert!(parse_list_option(&args).is_err());
     }
 
     #[test]
@@ -2813,6 +3442,50 @@ mod tests {
         assert!(error
             .to_string()
             .contains("Microsoft Update integration is not supported for archive installs yet"));
+    }
+
+    #[test]
+    fn parse_release_selection_options_accepts_offline_cache() {
+        let args = vec!["--offline-cache".to_string(), "C:\\cache".to_string()];
+        let options = parse_release_selection_options(&args).unwrap();
+
+        assert_eq!(options.offline_cache, Some(PathBuf::from("C:\\cache")));
+    }
+
+    #[test]
+    fn parse_package_install_options_accepts_offline_cache() {
+        let args = vec![
+            "--scope".to_string(),
+            "user".to_string(),
+            "--offline-cache".to_string(),
+            "C:\\cache".to_string(),
+        ];
+        let options = parse_package_install_options(&args).unwrap();
+
+        assert_eq!(options.offline_cache, Some(PathBuf::from("C:\\cache")));
+        assert_eq!(options.package.scope, PackageScope::CurrentUser);
+    }
+
+    #[test]
+    fn parse_cache_warm_options_accepts_cross_platform_all_products() {
+        let args = vec![
+            "--os".to_string(),
+            "all".to_string(),
+            "--arch".to_string(),
+            "all".to_string(),
+            "--product".to_string(),
+            "all".to_string(),
+            "--output".to_string(),
+            "C:\\cache".to_string(),
+        ];
+        let options = parse_cache_warm_options(&args).unwrap();
+
+        assert_eq!(options.target_oses, all_host_oses());
+        assert_eq!(options.target_arches, all_host_arches());
+        assert_eq!(options.product, CacheProduct::All);
+        assert_eq!(options.output, Some(PathBuf::from("C:\\cache")));
+        assert!(options.os_wildcard);
+        assert!(options.arch_wildcard);
     }
 
     #[test]

--- a/crates/multi-pwsh/src/platform.rs
+++ b/crates/multi-pwsh/src/platform.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::error::{MultiPwshError, Result};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -25,6 +27,29 @@ impl HostOs {
             HostOs::Windows => "pwsh.exe",
             HostOs::Macos | HostOs::Linux => "pwsh",
         }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "windows" | "win" => Some(HostOs::Windows),
+            "macos" | "osx" | "darwin" => Some(HostOs::Macos),
+            "linux" => Some(HostOs::Linux),
+            _ => None,
+        }
+    }
+
+    pub fn as_manifest_value(self) -> &'static str {
+        match self {
+            HostOs::Windows => "windows",
+            HostOs::Macos => "macos",
+            HostOs::Linux => "linux",
+        }
+    }
+}
+
+impl fmt::Display for HostOs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_manifest_value())
     }
 }
 
@@ -55,5 +80,20 @@ impl HostArch {
             "arm32" => Some(HostArch::Arm32),
             _ => None,
         }
+    }
+
+    pub fn as_manifest_value(self) -> &'static str {
+        match self {
+            HostArch::X64 => "x64",
+            HostArch::X86 => "x86",
+            HostArch::Arm64 => "arm64",
+            HostArch::Arm32 => "arm32",
+        }
+    }
+}
+
+impl fmt::Display for HostArch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_manifest_value())
     }
 }

--- a/crates/multi-pwsh/src/release.rs
+++ b/crates/multi-pwsh/src/release.rs
@@ -1,5 +1,8 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
 use semver::Version;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use ureq::Agent;
 
 use crate::error::{MultiPwshError, Result};
@@ -7,14 +10,21 @@ use crate::platform::{HostArch, HostOs};
 use crate::versions::{is_current_lts_version, MajorMinor, VersionSelector};
 
 const CHECKSUM_ASSET_NAME: &str = "hashes.sha256";
+pub const POWERSHELL_MANIFEST_RELATIVE_PATH: &str = "manifests/powershell-releases.json";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AssetSource {
+    Url(String),
+    File(PathBuf),
+}
 
 #[derive(Clone, Debug)]
 pub struct ResolvedRelease {
     pub version: Version,
     pub asset_name: String,
-    pub asset_url: String,
+    pub asset_source: AssetSource,
     pub checksum_asset_name: Option<String>,
-    pub checksum_asset_url: Option<String>,
+    pub checksum_asset_source: Option<AssetSource>,
 }
 
 impl ResolvedRelease {
@@ -54,17 +64,8 @@ impl ReleaseClient {
         arch: HostArch,
         include_prerelease: bool,
     ) -> Result<ResolvedRelease> {
-        match selector {
-            VersionSelector::Stable => self.resolve_latest_stable(os, arch),
-            VersionSelector::Preview => self.resolve_latest_preview(os, arch),
-            VersionSelector::Lts => self.resolve_latest_lts(os, arch),
-            VersionSelector::Major(major) => self.resolve_latest_in_major(major, os, arch, include_prerelease),
-            VersionSelector::Exact(version) => self.resolve_exact(version, os, arch),
-            VersionSelector::MajorMinor(line) => self.resolve_latest_in_line(line, os, arch, include_prerelease),
-            VersionSelector::MajorMinorWildcard(line) => {
-                self.resolve_latest_in_line(line, os, arch, include_prerelease)
-            }
-        }
+        let releases = parse_github_releases(self.fetch_releases()?);
+        resolve_selector_from_parsed(releases, selector, os, arch, include_prerelease)
     }
 
     pub fn resolve_all_in_line(
@@ -74,131 +75,13 @@ impl ReleaseClient {
         arch: HostArch,
         include_prerelease: bool,
     ) -> Result<Vec<ResolvedRelease>> {
-        let releases = self.fetch_releases()?;
-        let mut candidates: Vec<ParsedRelease> = releases
-            .into_iter()
-            .filter(|release| include_prerelease || !release.prerelease)
-            .filter_map(ParsedRelease::from_github_release)
-            .filter(|release| release.version.major == line.major && release.version.minor == line.minor)
-            .collect();
-
-        candidates.sort_by(|a, b| b.version.cmp(&a.version));
-
-        let mut resolved = Vec::new();
-        for candidate in candidates {
-            if let Ok(release) = resolve_release_asset(candidate, os, arch) {
-                resolved.push(release);
-            }
-        }
-
-        if resolved.is_empty() {
-            return Err(MultiPwshError::ReleaseNotFound(format!(
-                "no release found for line {}",
-                line
-            )));
-        }
-
-        Ok(resolved)
-    }
-
-    pub fn resolve_latest_in_major(
-        &self,
-        major: u64,
-        os: HostOs,
-        arch: HostArch,
-        include_prerelease: bool,
-    ) -> Result<ResolvedRelease> {
-        let releases = self.fetch_releases()?;
-        let mut candidates: Vec<ParsedRelease> = releases
-            .into_iter()
-            .filter(|release| include_prerelease || !release.prerelease)
-            .filter_map(ParsedRelease::from_github_release)
-            .filter(|release| release.version.major == major)
-            .collect();
-
-        candidates.sort_by(|a, b| b.version.cmp(&a.version));
-        let release = candidates
-            .into_iter()
-            .next()
-            .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("no release found for major {}", major)))?;
-
-        resolve_release_asset(release, os, arch)
-    }
-
-    pub fn resolve_latest_stable(&self, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
-        let releases = self.fetch_releases()?;
-        let candidates = sorted_candidates(releases, |github_release, parsed| {
-            !github_release.prerelease && parsed.version.pre.is_empty()
-        });
-
-        resolve_first_candidate_asset(candidates, os, arch, "no stable release found")
-    }
-
-    pub fn resolve_latest_preview(&self, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
-        let releases = self.fetch_releases()?;
-        let candidates = sorted_candidates(releases, |github_release, parsed| {
-            github_release.prerelease && !parsed.version.pre.is_empty()
-        });
-
-        resolve_first_candidate_asset(candidates, os, arch, "no preview release found")
-    }
-
-    pub fn resolve_latest_lts(&self, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
-        let releases = self.fetch_releases()?;
-        let candidates = sorted_candidates(releases, |github_release, parsed| {
-            !github_release.prerelease && parsed.version.pre.is_empty() && is_current_lts_version(&parsed.version)
-        });
-
-        resolve_first_candidate_asset(candidates, os, arch, "no current LTS release found")
-    }
-
-    pub fn resolve_latest_in_line(
-        &self,
-        line: MajorMinor,
-        os: HostOs,
-        arch: HostArch,
-        include_prerelease: bool,
-    ) -> Result<ResolvedRelease> {
-        let releases = self.fetch_releases()?;
-        let mut candidates: Vec<ParsedRelease> = releases
-            .into_iter()
-            .filter(|release| include_prerelease || !release.prerelease)
-            .filter_map(ParsedRelease::from_github_release)
-            .filter(|release| release.version.major == line.major && release.version.minor == line.minor)
-            .collect();
-
-        candidates.sort_by(|a, b| b.version.cmp(&a.version));
-        let release = candidates
-            .into_iter()
-            .next()
-            .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("no release found for line {}", line)))?;
-
-        resolve_release_asset(release, os, arch)
+        let releases = parse_github_releases(self.fetch_releases()?);
+        resolve_all_in_line_from_parsed(releases, line, os, arch, include_prerelease)
     }
 
     pub fn list_available_versions(&self, include_prerelease: bool) -> Result<Vec<Version>> {
-        let releases = self.fetch_releases()?;
-        let mut versions: Vec<Version> = releases
-            .into_iter()
-            .filter(|release| include_prerelease || !release.prerelease)
-            .filter_map(ParsedRelease::from_github_release)
-            .map(|release| release.version)
-            .collect();
-
-        versions.sort_by(|a, b| b.cmp(a));
-        versions.dedup();
-        Ok(versions)
-    }
-
-    fn resolve_exact(&self, version: Version, os: HostOs, arch: HostArch) -> Result<ResolvedRelease> {
-        let releases = self.fetch_releases()?;
-        let release = releases
-            .into_iter()
-            .filter_map(ParsedRelease::from_github_release)
-            .find(|release| release.version == version)
-            .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("version {}", version)))?;
-
-        resolve_release_asset(release, os, arch)
+        let releases = parse_github_releases(self.fetch_releases()?);
+        Ok(list_available_versions_from_parsed(releases, include_prerelease))
     }
 
     fn fetch_releases(&self) -> Result<Vec<GithubRelease>> {
@@ -235,29 +118,167 @@ impl ReleaseClient {
                 break;
             }
         }
-
         Ok(all_releases)
     }
 }
 
-fn sorted_candidates(
-    releases: Vec<GithubRelease>,
-    predicate: impl Fn(&GithubRelease, &ParsedRelease) -> bool,
-) -> Vec<ParsedRelease> {
-    let mut candidates: Vec<ParsedRelease> = releases
+#[derive(Clone)]
+pub struct OfflineReleaseClient {
+    releases: Vec<ParsedRelease>,
+}
+
+impl OfflineReleaseClient {
+    pub fn new(root: impl AsRef<Path>) -> Result<Self> {
+        let root = root.as_ref();
+        let manifest_path = powershell_manifest_path(root);
+        let bundle_root = offline_bundle_root(root, &manifest_path);
+        let manifest = load_powershell_manifest(root)?;
+        let releases = manifest
+            .releases
+            .into_iter()
+            .map(|release| ParsedRelease::from_offline_release(release, &bundle_root))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self { releases })
+    }
+
+    pub fn resolve_selector(
+        &self,
+        selector: VersionSelector,
+        os: HostOs,
+        arch: HostArch,
+        include_prerelease: bool,
+    ) -> Result<ResolvedRelease> {
+        resolve_selector_from_parsed(self.releases.clone(), selector, os, arch, include_prerelease)
+    }
+
+    pub fn resolve_all_in_line(
+        &self,
+        line: MajorMinor,
+        os: HostOs,
+        arch: HostArch,
+        include_prerelease: bool,
+    ) -> Result<Vec<ResolvedRelease>> {
+        resolve_all_in_line_from_parsed(self.releases.clone(), line, os, arch, include_prerelease)
+    }
+
+    pub fn list_available_versions(&self, include_prerelease: bool) -> Vec<Version> {
+        list_available_versions_from_parsed(self.releases.clone(), include_prerelease)
+    }
+}
+
+fn parse_github_releases(releases: Vec<GithubRelease>) -> Vec<ParsedRelease> {
+    releases
         .into_iter()
-        .filter_map(|github_release| {
-            let parsed = ParsedRelease::from_github_release(github_release)?;
-            if predicate(&parsed.source, &parsed) {
-                Some(parsed)
-            } else {
-                None
-            }
-        })
-        .collect();
+        .filter_map(ParsedRelease::from_github_release)
+        .collect()
+}
+
+fn sorted_candidates(releases: Vec<ParsedRelease>, predicate: impl Fn(&ParsedRelease) -> bool) -> Vec<ParsedRelease> {
+    let mut candidates: Vec<ParsedRelease> = releases.into_iter().filter(|parsed| predicate(parsed)).collect();
 
     candidates.sort_by(|a, b| b.version.cmp(&a.version));
     candidates
+}
+
+fn resolve_selector_from_parsed(
+    releases: Vec<ParsedRelease>,
+    selector: VersionSelector,
+    os: HostOs,
+    arch: HostArch,
+    include_prerelease: bool,
+) -> Result<ResolvedRelease> {
+    match selector {
+        VersionSelector::Stable => {
+            let candidates = sorted_candidates(releases, |parsed| !parsed.prerelease && parsed.version.pre.is_empty());
+            resolve_first_candidate_asset(candidates, os, arch, "no stable release found")
+        }
+        VersionSelector::Preview => {
+            let candidates = sorted_candidates(releases, |parsed| parsed.prerelease && !parsed.version.pre.is_empty());
+            resolve_first_candidate_asset(candidates, os, arch, "no preview release found")
+        }
+        VersionSelector::Lts => {
+            let candidates = sorted_candidates(releases, |parsed| {
+                !parsed.prerelease && parsed.version.pre.is_empty() && is_current_lts_version(&parsed.version)
+            });
+            resolve_first_candidate_asset(candidates, os, arch, "no current LTS release found")
+        }
+        VersionSelector::Major(major) => {
+            let mut candidates: Vec<_> = releases
+                .into_iter()
+                .filter(|release| include_prerelease || !release.prerelease)
+                .filter(|release| release.version.major == major)
+                .collect();
+            candidates.sort_by(|a, b| b.version.cmp(&a.version));
+            let release = candidates
+                .into_iter()
+                .next()
+                .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("no release found for major {}", major)))?;
+            resolve_release_asset(release, os, arch)
+        }
+        VersionSelector::Exact(version) => {
+            let release = releases
+                .into_iter()
+                .find(|release| release.version == version)
+                .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("version {}", version)))?;
+            resolve_release_asset(release, os, arch)
+        }
+        VersionSelector::MajorMinor(line) | VersionSelector::MajorMinorWildcard(line) => {
+            let mut candidates: Vec<_> = releases
+                .into_iter()
+                .filter(|release| include_prerelease || !release.prerelease)
+                .filter(|release| release.version.major == line.major && release.version.minor == line.minor)
+                .collect();
+            candidates.sort_by(|a, b| b.version.cmp(&a.version));
+            let release = candidates
+                .into_iter()
+                .next()
+                .ok_or_else(|| MultiPwshError::ReleaseNotFound(format!("no release found for line {}", line)))?;
+            resolve_release_asset(release, os, arch)
+        }
+    }
+}
+
+fn resolve_all_in_line_from_parsed(
+    releases: Vec<ParsedRelease>,
+    line: MajorMinor,
+    os: HostOs,
+    arch: HostArch,
+    include_prerelease: bool,
+) -> Result<Vec<ResolvedRelease>> {
+    let mut candidates: Vec<_> = releases
+        .into_iter()
+        .filter(|release| include_prerelease || !release.prerelease)
+        .filter(|release| release.version.major == line.major && release.version.minor == line.minor)
+        .collect();
+    candidates.sort_by(|a, b| b.version.cmp(&a.version));
+
+    let mut resolved = Vec::new();
+    for candidate in candidates {
+        if let Ok(release) = resolve_release_asset(candidate, os, arch) {
+            resolved.push(release);
+        }
+    }
+
+    if resolved.is_empty() {
+        return Err(MultiPwshError::ReleaseNotFound(format!(
+            "no release found for line {}",
+            line
+        )));
+    }
+
+    Ok(resolved)
+}
+
+fn list_available_versions_from_parsed(releases: Vec<ParsedRelease>, include_prerelease: bool) -> Vec<Version> {
+    let mut versions: Vec<_> = releases
+        .into_iter()
+        .filter(|release| include_prerelease || !release.prerelease)
+        .map(|release| release.version)
+        .collect();
+    versions.sort_by(|a, b| b.cmp(a));
+    versions.dedup();
+    versions
 }
 
 fn resolve_first_candidate_asset(
@@ -297,9 +318,9 @@ fn resolve_release_asset(release: ParsedRelease, os: HostOs, arch: HostArch) -> 
     Ok(ResolvedRelease {
         version: release.version,
         asset_name: asset.name,
-        asset_url: asset.browser_download_url,
+        asset_source: asset.source,
         checksum_asset_name: checksum_asset.as_ref().map(|asset| asset.name.clone()),
-        checksum_asset_url: checksum_asset.map(|asset| asset.browser_download_url),
+        checksum_asset_source: checksum_asset.map(|asset| asset.source),
     })
 }
 
@@ -377,25 +398,100 @@ fn wildcard_match(pattern: &str, text: &str) -> bool {
     true
 }
 
-#[derive(Clone, Debug, Deserialize)]
-struct GithubRelease {
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GithubRelease {
+    pub tag_name: String,
+    pub prerelease: bool,
+    pub assets: Vec<GithubAsset>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GithubAsset {
+    pub name: String,
+    pub browser_download_url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OfflinePowerShellManifest {
+    pub schema_version: u32,
+    pub releases: Vec<OfflinePowerShellRelease>,
+}
+
+impl Default for OfflinePowerShellManifest {
+    fn default() -> Self {
+        Self {
+            schema_version: 1,
+            releases: Vec::new(),
+        }
+    }
+}
+
+impl OfflinePowerShellManifest {
+    pub fn upsert_asset(&mut self, version: &Version, prerelease: bool, new_asset: OfflinePowerShellAsset) {
+        let tag_name = format!("v{}", version);
+        let release = match self
+            .releases
+            .iter_mut()
+            .find(|release| release.version == version.to_string())
+        {
+            Some(release) => release,
+            None => {
+                self.releases.push(OfflinePowerShellRelease {
+                    tag_name,
+                    version: version.to_string(),
+                    prerelease,
+                    assets: Vec::new(),
+                });
+                self.releases.last_mut().expect("release was just inserted")
+            }
+        };
+
+        release.tag_name = format!("v{}", version);
+        release.prerelease = prerelease;
+
+        if let Some(existing) = release
+            .assets
+            .iter_mut()
+            .find(|asset| asset.name == new_asset.name && asset.os == new_asset.os && asset.arch == new_asset.arch)
+        {
+            *existing = new_asset;
+            return;
+        }
+
+        release.assets.push(new_asset);
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OfflinePowerShellRelease {
+    pub tag_name: String,
+    pub version: String,
+    pub prerelease: bool,
+    pub assets: Vec<OfflinePowerShellAsset>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OfflinePowerShellAsset {
+    pub name: String,
+    pub path: String,
+    pub os: String,
+    pub arch: String,
+    pub checksum_name: Option<String>,
+    pub checksum_path: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct ReleaseAsset {
+    name: String,
+    source: AssetSource,
+}
+
+#[derive(Clone, Debug)]
+struct ParsedRelease {
     tag_name: String,
     prerelease: bool,
-    assets: Vec<GithubAsset>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-struct GithubAsset {
-    name: String,
-    browser_download_url: String,
-}
-
-#[derive(Debug)]
-struct ParsedRelease {
-    source: GithubRelease,
-    tag_name: String,
     version: Version,
-    assets: Vec<GithubAsset>,
+    assets: Vec<ReleaseAsset>,
 }
 
 impl ParsedRelease {
@@ -405,11 +501,113 @@ impl ParsedRelease {
 
         Some(ParsedRelease {
             tag_name: release.tag_name.clone(),
+            prerelease: release.prerelease,
             version,
-            assets: release.assets.clone(),
-            source: release,
+            assets: release
+                .assets
+                .into_iter()
+                .map(|asset| ReleaseAsset {
+                    name: asset.name,
+                    source: AssetSource::Url(asset.browser_download_url),
+                })
+                .collect(),
         })
     }
+
+    fn from_offline_release(release: OfflinePowerShellRelease, bundle_root: &Path) -> Result<Self> {
+        let version = Version::parse(release.version.trim_start_matches('v'))?;
+        let mut assets = Vec::new();
+
+        for asset in release.assets {
+            assets.push(ReleaseAsset {
+                name: asset.name,
+                source: AssetSource::File(bundle_root.join(asset.path)),
+            });
+
+            if let (Some(checksum_name), Some(checksum_path)) = (asset.checksum_name, asset.checksum_path) {
+                if !assets.iter().any(|existing| existing.name == checksum_name) {
+                    assets.push(ReleaseAsset {
+                        name: checksum_name,
+                        source: AssetSource::File(bundle_root.join(checksum_path)),
+                    });
+                }
+            }
+        }
+
+        Ok(ParsedRelease {
+            tag_name: release.tag_name,
+            prerelease: release.prerelease,
+            version,
+            assets,
+        })
+    }
+}
+
+pub fn powershell_manifest_path(root: &Path) -> PathBuf {
+    if root.is_file() {
+        return root.to_path_buf();
+    }
+
+    root.join(POWERSHELL_MANIFEST_RELATIVE_PATH)
+}
+
+fn offline_bundle_root(root: &Path, manifest_path: &Path) -> PathBuf {
+    if root.is_dir() {
+        return root.to_path_buf();
+    }
+
+    let Some(parent) = manifest_path.parent() else {
+        return PathBuf::from(".");
+    };
+
+    if parent
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.eq_ignore_ascii_case("manifests"))
+        .unwrap_or(false)
+    {
+        parent.parent().unwrap_or(parent).to_path_buf()
+    } else {
+        parent.to_path_buf()
+    }
+}
+
+pub fn load_powershell_manifest(root: &Path) -> Result<OfflinePowerShellManifest> {
+    let manifest_path = powershell_manifest_path(root);
+    let bytes = fs::read(&manifest_path).map_err(|error| {
+        MultiPwshError::Io(std::io::Error::new(
+            error.kind(),
+            format!(
+                "failed to read offline PowerShell manifest '{}': {}",
+                manifest_path.display(),
+                error
+            ),
+        ))
+    })?;
+    let manifest = serde_json::from_slice(&bytes)?;
+    Ok(manifest)
+}
+
+pub fn save_powershell_manifest(root: &Path, manifest: &OfflinePowerShellManifest) -> Result<()> {
+    let manifest_path = powershell_manifest_path(root);
+    if let Some(parent) = manifest_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let temp_path = manifest_path.with_extension("json.tmp");
+    let json = serde_json::to_vec_pretty(manifest)?;
+    fs::write(&temp_path, json)?;
+    fs::rename(temp_path, manifest_path)?;
+    Ok(())
+}
+
+pub fn load_or_default_powershell_manifest(root: &Path) -> Result<OfflinePowerShellManifest> {
+    let manifest_path = powershell_manifest_path(root);
+    if !manifest_path.exists() {
+        return Ok(OfflinePowerShellManifest::default());
+    }
+
+    load_powershell_manifest(root)
 }
 
 #[cfg(test)]
@@ -435,21 +633,17 @@ mod tests {
     #[test]
     fn resolve_release_asset_includes_checksum_asset() {
         let release = ParsedRelease {
-            source: GithubRelease {
-                tag_name: "v7.4.13".to_string(),
-                prerelease: false,
-                assets: Vec::new(),
-            },
             tag_name: "v7.4.13".to_string(),
+            prerelease: false,
             version: Version::parse("7.4.13").unwrap(),
             assets: vec![
-                GithubAsset {
+                ReleaseAsset {
                     name: CHECKSUM_ASSET_NAME.to_string(),
-                    browser_download_url: "https://example.invalid/hashes.sha256".to_string(),
+                    source: AssetSource::Url("https://example.invalid/hashes.sha256".to_string()),
                 },
-                GithubAsset {
+                ReleaseAsset {
                     name: "PowerShell-7.4.13-win-x64.zip".to_string(),
-                    browser_download_url: "https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string(),
+                    source: AssetSource::Url("https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string()),
                 },
             ],
         };
@@ -459,31 +653,27 @@ mod tests {
         assert_eq!(resolved.asset_name, "PowerShell-7.4.13-win-x64.zip");
         assert_eq!(resolved.checksum_asset_name.as_deref(), Some(CHECKSUM_ASSET_NAME));
         assert_eq!(
-            resolved.checksum_asset_url.as_deref(),
-            Some("https://example.invalid/hashes.sha256")
+            resolved.checksum_asset_source,
+            Some(AssetSource::Url("https://example.invalid/hashes.sha256".to_string()))
         );
     }
 
     #[test]
     fn resolve_release_asset_allows_missing_checksum_asset() {
         let release = ParsedRelease {
-            source: GithubRelease {
-                tag_name: "v7.4.13".to_string(),
-                prerelease: false,
-                assets: Vec::new(),
-            },
             tag_name: "v7.4.13".to_string(),
+            prerelease: false,
             version: Version::parse("7.4.13").unwrap(),
-            assets: vec![GithubAsset {
+            assets: vec![ReleaseAsset {
                 name: "PowerShell-7.4.13-win-x64.zip".to_string(),
-                browser_download_url: "https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string(),
+                source: AssetSource::Url("https://example.invalid/PowerShell-7.4.13-win-x64.zip".to_string()),
             }],
         };
 
         let resolved = resolve_release_asset(release, HostOs::Windows, HostArch::X64).unwrap();
 
         assert!(resolved.checksum_asset_name.is_none());
-        assert!(resolved.checksum_asset_url.is_none());
+        assert!(resolved.checksum_asset_source.is_none());
     }
 
     fn github_release(tag_name: &str, prerelease: bool) -> GithubRelease {
@@ -500,12 +690,12 @@ mod tests {
     #[test]
     fn sorted_candidates_can_filter_stable_releases() {
         let candidates = sorted_candidates(
-            vec![
+            parse_github_releases(vec![
                 github_release("v7.7.0-preview.1", true),
                 github_release("v7.6.2", false),
                 github_release("v7.5.7", false),
-            ],
-            |github_release, parsed| !github_release.prerelease && parsed.version.pre.is_empty(),
+            ]),
+            |parsed| !parsed.prerelease && parsed.version.pre.is_empty(),
         );
 
         assert_eq!(candidates[0].version, Version::parse("7.6.2").unwrap());
@@ -515,17 +705,50 @@ mod tests {
     #[test]
     fn sorted_candidates_can_filter_current_lts_releases() {
         let candidates = sorted_candidates(
-            vec![
+            parse_github_releases(vec![
                 github_release("v7.7.0-preview.1", true),
                 github_release("v7.6.2", false),
                 github_release("v7.4.16", false),
-            ],
-            |github_release, parsed| {
-                !github_release.prerelease && parsed.version.pre.is_empty() && is_current_lts_version(&parsed.version)
-            },
+            ]),
+            |parsed| !parsed.prerelease && parsed.version.pre.is_empty() && is_current_lts_version(&parsed.version),
         );
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].version, Version::parse("7.6.2").unwrap());
+    }
+
+    #[test]
+    fn offline_release_client_resolves_relative_artifact_paths() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = temp_dir.path();
+        let mut manifest = OfflinePowerShellManifest::default();
+        manifest.upsert_asset(
+            &Version::parse("7.6.2").unwrap(),
+            false,
+            OfflinePowerShellAsset {
+                name: "PowerShell-7.6.2-win-x64.zip".to_string(),
+                path: "PowerShell/v7.6.2/PowerShell-7.6.2-win-x64.zip".to_string(),
+                os: HostOs::Windows.as_manifest_value().to_string(),
+                arch: HostArch::X64.as_manifest_value().to_string(),
+                checksum_name: Some(CHECKSUM_ASSET_NAME.to_string()),
+                checksum_path: Some("PowerShell/v7.6.2/hashes.sha256".to_string()),
+            },
+        );
+        save_powershell_manifest(root, &manifest).unwrap();
+
+        let client = OfflineReleaseClient::new(root).unwrap();
+        let release = client
+            .resolve_selector(VersionSelector::Stable, HostOs::Windows, HostArch::X64, false)
+            .unwrap();
+
+        assert_eq!(release.version, Version::parse("7.6.2").unwrap());
+        assert_eq!(
+            release.asset_source,
+            AssetSource::File(root.join("PowerShell/v7.6.2/PowerShell-7.6.2-win-x64.zip"))
+        );
+        assert_eq!(
+            release.checksum_asset_source,
+            Some(AssetSource::File(root.join("PowerShell/v7.6.2/hashes.sha256")))
+        );
     }
 }

--- a/scripts/demo/PSConfEU-MultiPwsh.deck.md
+++ b/scripts/demo/PSConfEU-MultiPwsh.deck.md
@@ -41,13 +41,13 @@ Bootstrap multi-pwsh executable
 From bash (if you don't have pwsh):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.sh | bash
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.sh | bash
 ```
 
 From Windows PowerShell (if you don't have pwsh):
 
 ```powershell
-irm https://raw.githubusercontent.com/Devolutions/multi-pwsh/refs/heads/master/tools/install-multi-pwsh.ps1 | iex
+irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.ps1 | iex
 ```
 
 multi-pwsh doesn't require PowerShell to install PowerShell

--- a/tools/install-multi-pwsh.ps1
+++ b/tools/install-multi-pwsh.ps1
@@ -7,7 +7,16 @@ param(
     [string]$Owner = 'Devolutions',
 
     [Parameter(Mandatory = $false)]
-    [string]$Repository = 'multi-pwsh'
+    [string]$Repository = 'multi-pwsh',
+
+    [Parameter(Mandatory = $false)]
+    [string]$OfflineCache,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ArchivePath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ChecksumPath
 )
 
 $ErrorActionPreference = 'Stop'
@@ -67,6 +76,88 @@ function Get-MultiPwshBinDir {
     return (Join-Path (Get-MultiPwshHome) 'bin')
 }
 
+function Resolve-ReleaseVersionDirectory {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CacheRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RequestedVersion,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AssetName
+    )
+
+    $multiPwshRoot = Join-Path $CacheRoot 'multi-pwsh'
+    if (-not (Test-Path -LiteralPath $multiPwshRoot -PathType Container)) {
+        throw "Offline cache does not contain a multi-pwsh directory: $multiPwshRoot"
+    }
+
+    if ($RequestedVersion -eq 'latest') {
+        $candidates = Get-ChildItem -LiteralPath $multiPwshRoot -Directory |
+            Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName $AssetName) -PathType Leaf } |
+            Sort-Object Name -Descending
+
+        if (-not $candidates) {
+            throw "Offline cache does not contain $AssetName under $multiPwshRoot"
+        }
+
+        return $candidates[0].FullName
+    }
+
+    $versionDirectoryName = if ($RequestedVersion.StartsWith('v', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $RequestedVersion
+    }
+    else {
+        "v$RequestedVersion"
+    }
+    $versionDirectory = Join-Path $multiPwshRoot $versionDirectoryName
+    if (-not (Test-Path -LiteralPath (Join-Path $versionDirectory $AssetName) -PathType Leaf)) {
+        throw "Offline cache does not contain $AssetName under $versionDirectory"
+    }
+
+    return $versionDirectory
+}
+
+function Assert-ArchiveChecksum {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ArchivePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ChecksumPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AssetName
+    )
+
+    if (-not (Test-Path -LiteralPath $ChecksumPath -PathType Leaf)) {
+        throw "Checksum file was not found: $ChecksumPath"
+    }
+
+    $expected = $null
+    foreach ($line in Get-Content -LiteralPath $ChecksumPath) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith('#')) {
+            continue
+        }
+
+        if ($trimmed -match '^([0-9a-fA-F]{64})\s+\*?(.+)$' -and $Matches[2].Trim() -eq $AssetName) {
+            $expected = $Matches[1].ToLowerInvariant()
+            break
+        }
+    }
+
+    if (-not $expected) {
+        throw "Checksum entry for $AssetName was not found in $ChecksumPath"
+    }
+
+    $actual = (Get-FileHash -LiteralPath $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $expected) {
+        throw "Checksum mismatch for $AssetName`: expected $expected, got $actual"
+    }
+}
+
 $arch = Get-ReleaseArch
 $assetName = "multi-pwsh-windows-$arch.zip"
 
@@ -84,29 +175,57 @@ else {
 }
 
 $downloadUrl = "https://github.com/$Owner/$Repository/releases/$releasePath/$assetName"
+$checksumUrl = "https://github.com/$Owner/$Repository/releases/$releasePath/checksums.txt"
 $installHome = Get-MultiPwshHome
 $binDir = Get-MultiPwshBinDir
 $targetExe = Join-Path $binDir 'multi-pwsh.exe'
 
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("multi-pwsh-install-" + [System.Guid]::NewGuid().ToString('N'))
-$archivePath = Join-Path $tempRoot $assetName
+$archivePath = if ([string]::IsNullOrWhiteSpace($ArchivePath)) { Join-Path $tempRoot $assetName } else { $ArchivePath }
+$localChecksumPath = if ([string]::IsNullOrWhiteSpace($ChecksumPath)) { Join-Path $tempRoot 'checksums.txt' } else { $ChecksumPath }
 $extractDir = Join-Path $tempRoot 'extract'
 
 New-Item -Path $extractDir -ItemType Directory -Force | Out-Null
 
 try {
-    Write-Host "Downloading $assetName ($displayVersion)..."
+    if (-not [string]::IsNullOrWhiteSpace($OfflineCache)) {
+        $versionDirectory = Resolve-ReleaseVersionDirectory -CacheRoot $OfflineCache -RequestedVersion $Version -AssetName $assetName
+        $sourceArchive = Join-Path $versionDirectory $assetName
+        $sourceChecksum = if ([string]::IsNullOrWhiteSpace($ChecksumPath)) { Join-Path $versionDirectory 'checksums.txt' } else { $ChecksumPath }
+        Write-Host "Using offline $assetName from $sourceArchive"
+        if (-not [string]::Equals([System.IO.Path]::GetFullPath($sourceArchive), [System.IO.Path]::GetFullPath($archivePath), [System.StringComparison]::OrdinalIgnoreCase)) {
+            Copy-Item -LiteralPath $sourceArchive -Destination $archivePath -Force
+        }
+        if (-not [string]::Equals([System.IO.Path]::GetFullPath($sourceChecksum), [System.IO.Path]::GetFullPath($localChecksumPath), [System.StringComparison]::OrdinalIgnoreCase)) {
+            Copy-Item -LiteralPath $sourceChecksum -Destination $localChecksumPath -Force
+        }
+    }
+    elseif ([string]::IsNullOrWhiteSpace($ArchivePath)) {
+        Write-Host "Downloading $assetName ($displayVersion)..."
 
-    $invokeParams = @{
-        Uri = $downloadUrl
-        OutFile = $archivePath
+        $invokeParams = @{
+            Uri = $downloadUrl
+            OutFile = $archivePath
+        }
+
+        $checksumInvokeParams = @{
+            Uri = $checksumUrl
+            OutFile = $localChecksumPath
+        }
+
+        if ($PSVersionTable.PSEdition -eq 'Desktop') {
+            $invokeParams['UseBasicParsing'] = $true
+            $checksumInvokeParams['UseBasicParsing'] = $true
+        }
+
+        Invoke-WebRequest @invokeParams
+        Invoke-WebRequest @checksumInvokeParams
+    }
+    elseif ([string]::IsNullOrWhiteSpace($ChecksumPath)) {
+        throw '-ChecksumPath is required when -ArchivePath is used without -OfflineCache'
     }
 
-    if ($PSVersionTable.PSEdition -eq 'Desktop') {
-        $invokeParams['UseBasicParsing'] = $true
-    }
-
-    Invoke-WebRequest @invokeParams
+    Assert-ArchiveChecksum -ArchivePath $archivePath -ChecksumPath $localChecksumPath -AssetName $assetName
 
     Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
 

--- a/tools/install-multi-pwsh.sh
+++ b/tools/install-multi-pwsh.sh
@@ -5,6 +5,52 @@ repo_owner="Devolutions"
 repo_name="multi-pwsh"
 
 version="${1:-latest}"
+offline_cache=""
+archive_path=""
+checksum_path=""
+
+if [[ $# -gt 0 && "${1}" == --* ]]; then
+  version="latest"
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version|-v)
+      version="$2"
+      shift 2
+      ;;
+    --owner)
+      repo_owner="$2"
+      shift 2
+      ;;
+    --repository)
+      repo_name="$2"
+      shift 2
+      ;;
+    --offline-cache)
+      offline_cache="$2"
+      shift 2
+      ;;
+    --archive-path)
+      archive_path="$2"
+      shift 2
+      ;;
+    --checksum-path)
+      checksum_path="$2"
+      shift 2
+      ;;
+    *)
+      if [[ "${version}" == "latest" ]]; then
+        version="$1"
+        shift
+      else
+        echo "Unexpected argument: $1" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
 install_home="${MULTI_PWSH_HOME:-${HOME}/.pwsh}"
 bin_dir="${MULTI_PWSH_BIN_DIR:-${install_home}/bin}"
 
@@ -39,11 +85,6 @@ case "${uname_m}" in
     ;;
 esac
 
-if ! command -v curl >/dev/null 2>&1; then
-  echo "curl is required but was not found in PATH." >&2
-  exit 1
-fi
-
 if ! command -v unzip >/dev/null 2>&1; then
   echo "unzip is required but was not found in PATH." >&2
   exit 1
@@ -51,6 +92,7 @@ fi
 
 asset="multi-pwsh-${os}-${arch}.zip"
 download_url="https://github.com/${repo_owner}/${repo_name}/releases/${release_path}/${asset}"
+checksum_url="https://github.com/${repo_owner}/${repo_name}/releases/${release_path}/checksums.txt"
 
 tmp_dir="$(mktemp -d)"
 cleanup() {
@@ -58,11 +100,76 @@ cleanup() {
 }
 trap cleanup EXIT
 
-archive_path="${tmp_dir}/${asset}"
+if [[ -z "${archive_path}" ]]; then
+  archive_path="${tmp_dir}/${asset}"
+fi
+checksum_path_provided=1
+if [[ -z "${checksum_path}" ]]; then
+  checksum_path_provided=0
+fi
+if [[ -z "${checksum_path}" ]]; then
+  checksum_path="${tmp_dir}/checksums.txt"
+fi
 extract_dir="${tmp_dir}/extract"
 
-echo "Downloading ${asset} (${display_version})..."
-curl -fsSL "${download_url}" -o "${archive_path}"
+if [[ -n "${offline_cache}" ]]; then
+  multi_root="${offline_cache}/multi-pwsh"
+  if [[ "${version}" == "latest" ]]; then
+    version_dir="$(find "${multi_root}" -mindepth 1 -maxdepth 1 -type d -exec test -f "{}/${asset}" \; -print | sort -r | head -n 1)"
+    if [[ -z "${version_dir}" ]]; then
+      echo "Offline cache does not contain ${asset} under ${multi_root}" >&2
+      exit 1
+    fi
+  else
+    version_dir="${multi_root}/${version}"
+  fi
+
+  source_archive="${version_dir}/${asset}"
+  source_checksum="${version_dir}/checksums.txt"
+  if [[ ! -f "${source_archive}" ]]; then
+    echo "Offline archive was not found: ${source_archive}" >&2
+    exit 1
+  fi
+  if [[ ! -f "${source_checksum}" ]]; then
+    echo "Offline checksum file was not found: ${source_checksum}" >&2
+    exit 1
+  fi
+  echo "Using offline ${asset} from ${source_archive}"
+  if [[ "$(cd "$(dirname "${source_archive}")" && pwd -P)/$(basename "${source_archive}")" != "$(cd "$(dirname "${archive_path}")" && pwd -P)/$(basename "${archive_path}")" ]]; then
+    cp "${source_archive}" "${archive_path}"
+  fi
+  if [[ "$(cd "$(dirname "${source_checksum}")" && pwd -P)/$(basename "${source_checksum}")" != "$(cd "$(dirname "${checksum_path}")" && pwd -P)/$(basename "${checksum_path}")" ]]; then
+    cp "${source_checksum}" "${checksum_path}"
+  fi
+elif [[ "${archive_path}" == "${tmp_dir}/"* ]]; then
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required but was not found in PATH." >&2
+    exit 1
+  fi
+  echo "Downloading ${asset} (${display_version})..."
+  curl -fsSL "${download_url}" -o "${archive_path}"
+  curl -fsSL "${checksum_url}" -o "${checksum_path}"
+elif [[ "${checksum_path_provided}" -eq 0 ]]; then
+  echo "--checksum-path is required when --archive-path is used without --offline-cache" >&2
+  exit 1
+fi
+
+expected_checksum="$(awk -v asset="${asset}" 'tolower($1) ~ /^[0-9a-f]{64}$/ { name=$2; sub(/^\*/, "", name); if (name == asset) { print tolower($1); exit } }' "${checksum_path}")"
+if [[ -z "${expected_checksum}" ]]; then
+  echo "Checksum entry for ${asset} was not found in ${checksum_path}" >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_checksum="$(sha256sum "${archive_path}" | awk '{ print tolower($1) }')"
+else
+  actual_checksum="$(shasum -a 256 "${archive_path}" | awk '{ print tolower($1) }')"
+fi
+
+if [[ "${actual_checksum}" != "${expected_checksum}" ]]; then
+  echo "Checksum mismatch for ${asset}: expected ${expected_checksum}, got ${actual_checksum}" >&2
+  exit 1
+fi
 
 mkdir -p "${extract_dir}"
 unzip -q "${archive_path}" -d "${extract_dir}"


### PR DESCRIPTION
## Summary

This adds first-class offline support for environments where `multi-pwsh` cannot reach GitHub directly, while keeping the existing GitHub-backed behavior as the default.

The new workflow lets a connected machine pre-populate an offline cache/bundle with the PowerShell release archives, checksum files, release metadata, and `multi-pwsh` bootstrap artifacts. That bundle can then be copied locally or exposed on a network share and used by disconnected machines for install, update, package install, and available-version listing without falling back to GitHub.

## What changed

### Offline cache warming

- Added `multi-pwsh cache warm <selector>` to build a relocatable offline bundle.
- Supports exact versions, channels, major/minor selectors, and wildcard selectors through the existing version selection logic.
- Supports cross-machine warming with target options:
  - `--os <windows|linux|macos|all>`
  - `--arch <x64|x86|arm64|arm32|all>`
  - `--output <path>`
  - `--product <powershell|multi-pwsh|all>`
  - `--include-prerelease`
- Stores PowerShell archives, hash files, and generated manifests under the cache output using relative paths so the bundle remains usable after being copied or mounted elsewhere.

### Offline release resolution

- Added a typed asset-source model so release assets can come from either URLs or local files.
- Added a local offline manifest resolver for PowerShell releases.
- Added offline source selection through:
  - `--offline-cache <path>` on supported commands
  - `MULTI_PWSH_OFFLINE_CACHE=<path>`
  - `MULTI_PWSH_RELEASE_SOURCE=<path>`
- `MULTI_PWSH_RELEASE_SOURCE=github` or `online` keeps the online behavior explicit.
- Offline mode does not silently fall back to GitHub if an artifact is missing from the bundle.

### Offline install/update/list support

- Wired offline cache support into:
  - `multi-pwsh install`
  - `multi-pwsh update`
  - `multi-pwsh package install`
  - `multi-pwsh list --available`
- Local offline source files are treated as read-only inputs and copied into the normal local cache/install locations.
- Checksum validation continues to use the release checksum files, whether they came from GitHub or the offline bundle.

### Bootstrap and self-update path

- Updated PowerShell and POSIX bootstrap scripts to support disconnected installs via:
  - `-OfflineCache` / `--offline-cache`
  - `-ArchivePath` / `--archive-path`
  - `-ChecksumPath` / `--checksum-path`
- Bootstrap scripts now verify archives against checksum files before installing.
- Direct local archive bootstrap requires an explicit checksum path unless the checksum is available from the offline cache.
- Updated release packaging so install/uninstall bootstrap scripts are published as release assets, avoiding the need to bootstrap from raw GitHub repository URLs.

### Documentation and release process

- Updated README examples for online bootstrap URLs, offline cache warming, disconnected install/update usage, and environment-variable configuration.
- Updated release documentation to include bootstrap script assets in release verification.
- Updated demo material to reference release assets instead of raw GitHub script URLs.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets -- --test-threads=1`
- `dotnet build dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj`
- `dotnet test dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj --no-build`
- PowerShell parser check for `tools\install-multi-pwsh.ps1`
- `bash -n tools/install-multi-pwsh.sh`
