### PR TITLE
Add NuGet package for multi-pwsh CLI runtime assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,3 +157,82 @@ jobs:
       - name: Run .NET tests
         shell: pwsh
         run: dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build -p:PwshExePath="pwsh-7.4"
+
+  nuget-cli:
+    name: NuGet CLI package smoke (Windows)
+    runs-on: windows-latest
+    needs: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install Rust toolchain
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal --target x86_64-pc-windows-msvc
+          rustup default stable
+
+      - name: Build and pack CLI NuGet package
+        shell: pwsh
+        run: |
+          pwsh -NoLogo -NoProfile -File (Resolve-Path 'scripts\Build-CliNativeNuGetPackage.ps1') `
+            -RuntimeIdentifiers 'win-x64' `
+            -Clean
+
+      - name: Smoke test PackageReference copy targets
+        shell: pwsh
+        run: |
+          $packageSource = (Resolve-Path 'artifacts\cli-nuget').Path
+          $smokeRoot = Join-Path $env:RUNNER_TEMP 'multi-pwsh-cli-package-smoke'
+          $env:NUGET_PACKAGES = Join-Path $env:RUNNER_TEMP 'multi-pwsh-cli-package-smoke-nuget-cache'
+          New-Item -Path $smokeRoot -ItemType Directory -Force | Out-Null
+          New-Item -Path $env:NUGET_PACKAGES -ItemType Directory -Force | Out-Null
+
+          $package = Get-ChildItem -Path $packageSource -Filter 'Devolutions.MultiPwsh.Cli.*.nupkg' | Select-Object -First 1
+          if ($null -eq $package) {
+            throw 'Smoke test package was not found.'
+          }
+
+          $version = $package.BaseName.Substring('Devolutions.MultiPwsh.Cli.'.Length)
+
+          dotnet new console --framework net8.0 --output $smokeRoot
+          if ($LASTEXITCODE -ne 0) { throw 'Smoke project creation failed.' }
+
+          $projectPath = Join-Path $smokeRoot 'multi-pwsh-cli-package-smoke.csproj'
+          $project = Get-Content -Path $projectPath -Raw
+          $project = $project -replace '</Project>', @"
+            <PropertyGroup>
+              <DevolutionsMultiPwshCliWindowsOutputName>multi-pwsh-ci.exe</DevolutionsMultiPwshCliWindowsOutputName>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="$version" />
+            </ItemGroup>
+          </Project>
+          "@
+          Set-Content -Path $projectPath -Value $project -Encoding utf8
+
+          $nugetConfig = Join-Path $smokeRoot 'NuGet.Config'
+          @"
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local" value="$packageSource" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+            </packageSources>
+          </configuration>
+          "@ | Set-Content -Path $nugetConfig -Encoding utf8
+
+          dotnet build $projectPath --configfile $nugetConfig
+          if ($LASTEXITCODE -ne 0) { throw 'Smoke project build failed.' }
+
+          $expected = Join-Path $smokeRoot 'bin\Debug\net8.0\runtimes\win-x64\native\multi-pwsh-ci.exe'
+          if (-not (Test-Path -Path $expected -PathType Leaf)) {
+            throw "Expected smoke output file was not found: $expected"
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,9 +207,6 @@ jobs:
           $projectPath = Join-Path $smokeRoot 'multi-pwsh-cli-package-smoke.csproj'
           $project = Get-Content -Path $projectPath -Raw
           $project = $project -replace '</Project>', @"
-            <PropertyGroup>
-              <DevolutionsMultiPwshCliWindowsOutputName>multi-pwsh-ci.exe</DevolutionsMultiPwshCliWindowsOutputName>
-            </PropertyGroup>
             <ItemGroup>
               <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="$version" />
             </ItemGroup>
@@ -232,7 +229,7 @@ jobs:
           dotnet build $projectPath --configfile $nugetConfig
           if ($LASTEXITCODE -ne 0) { throw 'Smoke project build failed.' }
 
-          $expected = Join-Path $smokeRoot 'bin\Debug\net8.0\runtimes\win-x64\native\multi-pwsh-ci.exe'
+          $expected = Join-Path $smokeRoot 'bin\Debug\net8.0\runtimes\win-x64\native\multi-pwsh.exe'
           if (-not (Test-Path -Path $expected -PathType Leaf)) {
             throw "Expected smoke output file was not found: $expected"
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,13 @@ on:
     inputs:
       tag:
         description: Release tag to create/update when publishing
-        required: true
+        required: false
         type: string
+      dry_run:
+        description: Build and package only, then upload downloadable workflow artifacts (no GitHub release publish).
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -20,6 +25,7 @@ jobs:
       release_tag: ${{ steps.validate.outputs.release_tag }}
       release_target: ${{ steps.validate.outputs.release_target }}
       release_version: ${{ steps.validate.outputs.release_version }}
+      dry_run: ${{ steps.validate.outputs.dry_run }}
 
     steps:
       - name: Checkout selected ref
@@ -35,15 +41,15 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event.inputs.tag }}
           CHECKOUT_REF: ${{ github.ref }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
-          tag="${RELEASE_TAG}"
-
-          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Release tag must match vX.Y.Z or vX.Y.Z-suffix. Got: ${tag}" >&2
-            exit 1
+          dry_run="$(echo "${DRY_RUN}" | tr '[:upper:]' '[:lower:]')"
+          if [[ "${dry_run}" != "true" && "${dry_run}" != "false" ]]; then
+            dry_run="false"
           fi
 
-          release_version="${tag#v}"
+          tag="${RELEASE_TAG}"
+
           multi_version="$(sed -n 's/^version = "\(.*\)"/\1/p' crates/multi-pwsh/Cargo.toml | head -n 1)"
           host_version="$(sed -n 's/^version = "\(.*\)"/\1/p' crates/pwsh-host/Cargo.toml | head -n 1)"
 
@@ -57,9 +63,25 @@ jobs:
             exit 1
           fi
 
-          if [[ "${multi_version}" != "${release_version}" ]]; then
-            echo "Release tag ${tag} does not match crate version ${multi_version}" >&2
-            exit 1
+          release_version="${multi_version}"
+
+          if [[ "${dry_run}" != "true" ]]; then
+            if [[ -z "${tag}" ]]; then
+              echo "Release tag is required when dry_run is false." >&2
+              exit 1
+            fi
+
+            if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "Release tag must match vX.Y.Z or vX.Y.Z-suffix. Got: ${tag}" >&2
+              exit 1
+            fi
+
+            if [[ "${multi_version}" != "${tag#v}" ]]; then
+              echo "Release tag ${tag} does not match crate version ${multi_version}" >&2
+              exit 1
+            fi
+          elif [[ -z "${tag}" ]]; then
+            tag="v${release_version}"
           fi
 
           release_target="$(git rev-parse HEAD)"
@@ -68,6 +90,7 @@ jobs:
           echo "release_tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "release_target=${release_target}" >> "$GITHUB_OUTPUT"
           echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
+          echo "dry_run=${dry_run}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build ${{ matrix.name }}
@@ -289,6 +312,13 @@ jobs:
             -NoBuild `
             -Clean:$false
 
+      - name: Upload CLI NuGet package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-nuget
+          path: artifacts/cli-nuget/*.nupkg
+          if-no-files-found: error
+
       - name: Generate checksums
         shell: pwsh
         working-directory: dist
@@ -312,6 +342,7 @@ jobs:
           Get-Content -Path checksums.txt
 
       - name: Publish release assets
+        if: ${{ needs.validate.outputs.dry_run != 'true' }}
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,36 +80,42 @@ jobs:
           - name: linux-x64
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            runtime_id: linux-x64
             multi_archive: multi-pwsh-linux-x64.zip
             multi_binary: multi-pwsh
 
           - name: linux-arm64
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            runtime_id: linux-arm64
             multi_archive: multi-pwsh-linux-arm64.zip
             multi_binary: multi-pwsh
 
           - name: windows-x64
             os: windows-latest
             target: x86_64-pc-windows-msvc
+            runtime_id: win-x64
             multi_archive: multi-pwsh-windows-x64.zip
             multi_binary: multi-pwsh.exe
 
           - name: windows-arm64
             os: windows-latest
             target: aarch64-pc-windows-msvc
+            runtime_id: win-arm64
             multi_archive: multi-pwsh-windows-arm64.zip
             multi_binary: multi-pwsh.exe
 
           - name: macos-x64
             os: macos-14
             target: x86_64-apple-darwin
+            runtime_id: osx-x64
             multi_archive: multi-pwsh-macos-x64.zip
             multi_binary: multi-pwsh
 
           - name: macos-arm64
             os: macos-14
             target: aarch64-apple-darwin
+            runtime_id: osx-arm64
             multi_archive: multi-pwsh-macos-arm64.zip
             multi_binary: multi-pwsh
 
@@ -199,6 +205,29 @@ jobs:
           path: ${{ matrix.multi_archive }}
           if-no-files-found: error
 
+      - name: Stage NuGet runtime artifact
+        shell: pwsh
+        env:
+          TARGET: ${{ matrix.target }}
+          MULTI_BIN_NAME: ${{ matrix.multi_binary }}
+          RUNTIME_ID: ${{ matrix.runtime_id }}
+        run: |
+          $binaryPath = [System.IO.Path]::Combine("target", $env:TARGET, "release", $env:MULTI_BIN_NAME)
+          if (-not (Test-Path -Path $binaryPath -PathType Leaf)) {
+            throw "Binary not found: $binaryPath"
+          }
+
+          $stageDir = Join-Path "nuget-stage" $env:RUNTIME_ID
+          New-Item -Path $stageDir -ItemType Directory -Force | Out-Null
+          Copy-Item -Path $binaryPath -Destination (Join-Path $stageDir $env:MULTI_BIN_NAME) -Force
+
+      - name: Upload NuGet runtime artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-pwsh-nuget-${{ matrix.runtime_id }}
+          path: nuget-stage/${{ matrix.runtime_id }}/*
+          if-no-files-found: error
+
   publish:
     name: Publish GitHub release
     runs-on: ubuntu-latest
@@ -216,6 +245,49 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Arrange staged NuGet runtime artifacts
+        shell: pwsh
+        run: |
+          $Mappings = @(
+            @{ Artifact = 'multi-pwsh-nuget-win-x64'; Rid = 'win-x64'; Binary = 'multi-pwsh.exe' },
+            @{ Artifact = 'multi-pwsh-nuget-win-arm64'; Rid = 'win-arm64'; Binary = 'multi-pwsh.exe' },
+            @{ Artifact = 'multi-pwsh-nuget-linux-x64'; Rid = 'linux-x64'; Binary = 'multi-pwsh' },
+            @{ Artifact = 'multi-pwsh-nuget-linux-arm64'; Rid = 'linux-arm64'; Binary = 'multi-pwsh' },
+            @{ Artifact = 'multi-pwsh-nuget-osx-x64'; Rid = 'osx-x64'; Binary = 'multi-pwsh' },
+            @{ Artifact = 'multi-pwsh-nuget-osx-arm64'; Rid = 'osx-arm64'; Binary = 'multi-pwsh' }
+          )
+
+          foreach ($mapping in $Mappings) {
+            $source = Join-Path 'dist' $mapping.Artifact
+            if (-not (Test-Path -Path $source -PathType Container)) {
+              throw "Downloaded NuGet runtime artifact directory not found: $source"
+            }
+
+            $binaryPath = Join-Path $source $mapping.Binary
+            if (-not (Test-Path -Path $binaryPath -PathType Leaf)) {
+              throw "Runtime binary not found in artifact: $binaryPath"
+            }
+
+            $targetDir = Join-Path 'artifacts\cli\multi-pwsh' $mapping.Rid
+            New-Item -Path $targetDir -ItemType Directory -Force | Out-Null
+            Copy-Item -Path $binaryPath -Destination (Join-Path $targetDir $mapping.Binary) -Force
+          }
+
+      - name: Pack CLI NuGet package
+        shell: pwsh
+        env:
+          PACKAGE_VERSION: ${{ needs.validate.outputs.release_version }}
+        run: |
+          pwsh -NoLogo -NoProfile -File (Resolve-Path 'scripts\Build-CliNativeNuGetPackage.ps1') `
+            -Version $env:PACKAGE_VERSION `
+            -NoBuild `
+            -Clean:$false
 
       - name: Generate checksums
         shell: pwsh
@@ -251,15 +323,22 @@ jobs:
             Where-Object { $_.Name -like 'multi-pwsh-*.zip' } |
             Sort-Object Name |
             ForEach-Object { $_.FullName }
+          $nugetPackages = Get-ChildItem -Path artifacts/cli-nuget -Filter 'Devolutions.MultiPwsh.Cli.*.nupkg' |
+            Sort-Object Name |
+            ForEach-Object { $_.FullName }
 
           if (-not $zipFiles) {
             throw 'No release archives found under dist'
           }
 
+          if (-not $nugetPackages) {
+            throw 'No CLI NuGet package was produced.'
+          }
+
           gh release view "$env:RELEASE_TAG" *> $null
 
           if ($LASTEXITCODE -eq 0) {
-            gh release upload "$env:RELEASE_TAG" @zipFiles "dist/checksums.txt" "tools/install-multi-pwsh.ps1" "tools/install-multi-pwsh.sh" "tools/uninstall-multi-pwsh.ps1" "tools/uninstall-multi-pwsh.sh" --clobber
+            gh release upload "$env:RELEASE_TAG" @zipFiles @nugetPackages "dist/checksums.txt" "tools/install-multi-pwsh.ps1" "tools/install-multi-pwsh.sh" "tools/uninstall-multi-pwsh.ps1" "tools/uninstall-multi-pwsh.sh" --clobber
           }
           else {
             $createArgs = @(
@@ -267,6 +346,7 @@ jobs:
             )
 
             $createArgs += $zipFiles
+            $createArgs += $nugetPackages
             $createArgs += "dist/checksums.txt"
             $createArgs += "tools/install-multi-pwsh.ps1"
             $createArgs += "tools/install-multi-pwsh.sh"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -144,12 +144,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.validate.outputs.checkout_ref }}
 
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -260,7 +260,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.validate.outputs.checkout_ref }}
 
@@ -270,7 +270,7 @@ jobs:
           path: dist
 
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,15 @@ on:
         required: false
         default: false
         type: boolean
+      github-env:
+        description: GitHub environment for code signing secrets (auto, test, or prod).
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - test
+          - prod
 
 permissions:
   contents: write
@@ -26,6 +35,7 @@ jobs:
       release_target: ${{ steps.validate.outputs.release_target }}
       release_version: ${{ steps.validate.outputs.release_version }}
       dry_run: ${{ steps.validate.outputs.dry_run }}
+      publish_env: ${{ steps.validate.outputs.publish_env }}
 
     steps:
       - name: Checkout selected ref
@@ -41,12 +51,35 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event.inputs.tag }}
           CHECKOUT_REF: ${{ github.ref }}
+          SOURCE_BRANCH: ${{ github.ref_name }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
+          REQUESTED_ENVIRONMENT: ${{ inputs['github-env'] }}
         run: |
           dry_run="$(echo "${DRY_RUN}" | tr '[:upper:]' '[:lower:]')"
           if [[ "${dry_run}" != "true" && "${dry_run}" != "false" ]]; then
             dry_run="false"
           fi
+
+          requested_environment="$(echo "${REQUESTED_ENVIRONMENT:-auto}" | tr '[:upper:]' '[:lower:]')"
+          case "${requested_environment}" in
+            auto)
+              if [[ "${SOURCE_BRANCH}" == "master" ]]; then
+                publish_env="publish-prod"
+              else
+                publish_env="publish-test"
+              fi
+              ;;
+            test)
+              publish_env="publish-test"
+              ;;
+            prod)
+              publish_env="publish-prod"
+              ;;
+            *)
+              echo "Unsupported github-env value: ${requested_environment}. Expected auto, test, or prod." >&2
+              exit 1
+              ;;
+          esac
 
           tag="${RELEASE_TAG}"
 
@@ -91,6 +124,7 @@ jobs:
           echo "release_target=${release_target}" >> "$GITHUB_OUTPUT"
           echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
           echo "dry_run=${dry_run}" >> "$GITHUB_OUTPUT"
+          echo "publish_env=${publish_env}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build ${{ matrix.name }}
@@ -179,6 +213,7 @@ jobs:
           cargo build --locked --release --package multi-pwsh --bin multi-pwsh --target "${{ matrix.target }}"
 
       - name: Package artifacts
+        if: ${{ !contains(matrix.target, 'windows-msvc') }}
         shell: pwsh
         env:
           TARGET: ${{ matrix.target }}
@@ -222,13 +257,23 @@ jobs:
           New-BinaryArchive -BinaryName $env:MULTI_BIN_NAME -ArchiveName $env:MULTI_ARCHIVE_NAME
 
       - name: Upload multi-pwsh artifact
+        if: ${{ !contains(matrix.target, 'windows-msvc') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.multi_archive }}
           path: ${{ matrix.multi_archive }}
           if-no-files-found: error
 
+      - name: Upload unsigned Windows binary
+        if: ${{ contains(matrix.target, 'windows-msvc') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-pwsh-unsigned-${{ matrix.runtime_id }}
+          path: target/${{ matrix.target }}/release/${{ matrix.multi_binary }}
+          if-no-files-found: error
+
       - name: Stage NuGet runtime artifact
+        if: ${{ !contains(matrix.target, 'windows-msvc') }}
         shell: pwsh
         env:
           TARGET: ${{ matrix.target }}
@@ -245,10 +290,202 @@ jobs:
           Copy-Item -Path $binaryPath -Destination (Join-Path $stageDir $env:MULTI_BIN_NAME) -Force
 
       - name: Upload NuGet runtime artifact
+        if: ${{ !contains(matrix.target, 'windows-msvc') }}
         uses: actions/upload-artifact@v4
         with:
           name: multi-pwsh-nuget-${{ matrix.runtime_id }}
           path: nuget-stage/${{ matrix.runtime_id }}/*
+          if-no-files-found: error
+
+  sign-windows:
+    name: Sign Windows artifacts
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+      - build
+    environment: ${{ needs.validate.outputs.publish_env }}
+
+    steps:
+      - name: Download unsigned Windows x64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: multi-pwsh-unsigned-win-x64
+          path: work/win-x64
+
+      - name: Download unsigned Windows arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: multi-pwsh-unsigned-win-arm64
+          path: work/win-arm64
+
+      - name: Resolve signing mode
+        id: signing_mode
+        shell: pwsh
+        env:
+          CODE_SIGNING_KEYVAULT_URL: ${{ secrets.CODE_SIGNING_KEYVAULT_URL }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          CODE_SIGNING_CLIENT_ID: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
+          CODE_SIGNING_CLIENT_SECRET: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
+          CODE_SIGNING_CERTIFICATE_NAME: ${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}
+          CODE_SIGNING_TIMESTAMP_SERVER: ${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}
+        run: |
+          $dryRun = [System.Boolean]::Parse('${{ needs.validate.outputs.dry_run }}')
+          $requiredValues = @(
+            $env:CODE_SIGNING_KEYVAULT_URL,
+            $env:AZURE_TENANT_ID,
+            $env:CODE_SIGNING_CLIENT_ID,
+            $env:CODE_SIGNING_CLIENT_SECRET,
+            $env:CODE_SIGNING_CERTIFICATE_NAME,
+            $env:CODE_SIGNING_TIMESTAMP_SERVER
+          )
+
+          $hasSigningSecrets = $true
+          foreach ($value in $requiredValues) {
+            if ([string]::IsNullOrWhiteSpace($value)) {
+              $hasSigningSecrets = $false
+              break
+            }
+          }
+
+          if (-not $dryRun -and -not $hasSigningSecrets) {
+            throw 'Code signing secrets are required for non-dry-run release jobs.'
+          }
+
+          $shouldSign = $hasSigningSecrets
+          "should_sign=$($shouldSign.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          if ($shouldSign) {
+            Write-Host 'Windows binaries will be signed with Linux psign-tool.'
+          }
+          else {
+            Write-Host '::warning::Code signing secrets were not available. Dry-run Windows binaries will remain unsigned.'
+          }
+
+      - name: Install Linux psign-tool
+        if: steps.signing_mode.outputs.should_sign == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $toolRoot = Join-Path $env:RUNNER_TEMP 'psign-tool'
+          $extractRoot = Join-Path $toolRoot 'expanded'
+
+          if (Test-Path -Path $toolRoot) {
+            Remove-Item -Path $toolRoot -Recurse -Force
+          }
+
+          New-Item -Path $extractRoot -ItemType Directory -Force | Out-Null
+          gh release download --repo Devolutions/psign --pattern 'psign-tool-linux-x64.zip' --dir $toolRoot --clobber
+
+          $toolArchivePath = Join-Path $toolRoot 'psign-tool-linux-x64.zip'
+          if (-not (Test-Path -Path $toolArchivePath -PathType Leaf)) {
+            throw "psign-tool archive was not found at $toolArchivePath"
+          }
+
+          Expand-Archive -Path $toolArchivePath -DestinationPath $extractRoot -Force
+
+          $toolPath = Join-Path $extractRoot 'psign-tool'
+          if (-not (Test-Path -Path $toolPath -PathType Leaf)) {
+            throw "psign-tool executable was not found at $toolPath"
+          }
+
+          chmod +x $toolPath
+          $extractRoot | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & $toolPath --version
+
+      - name: Code sign Windows executables
+        if: steps.signing_mode.outputs.should_sign == 'true'
+        shell: pwsh
+        env:
+          CODE_SIGNING_KEYVAULT_URL: ${{ secrets.CODE_SIGNING_KEYVAULT_URL }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          CODE_SIGNING_CLIENT_ID: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
+          CODE_SIGNING_CLIENT_SECRET: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
+          CODE_SIGNING_CERTIFICATE_NAME: ${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}
+          CODE_SIGNING_TIMESTAMP_SERVER: ${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}
+        run: |
+          $binaries = @(
+            @{ Rid = 'win-x64'; Path = 'work/win-x64/multi-pwsh.exe' },
+            @{ Rid = 'win-arm64'; Path = 'work/win-arm64/multi-pwsh.exe' }
+          )
+
+          foreach ($binary in $binaries) {
+            if (-not (Test-Path -Path $binary.Path -PathType Leaf)) {
+              throw "Windows binary not found: $($binary.Path)"
+            }
+
+            psign-tool --mode portable --verbose sign `
+              --azure-key-vault-tenant-id "$env:AZURE_TENANT_ID" `
+              --azure-key-vault-url "$env:CODE_SIGNING_KEYVAULT_URL" `
+              --azure-key-vault-client-id "$env:CODE_SIGNING_CLIENT_ID" `
+              --azure-key-vault-client-secret "$env:CODE_SIGNING_CLIENT_SECRET" `
+              --azure-key-vault-certificate "$env:CODE_SIGNING_CERTIFICATE_NAME" `
+              --timestamp-url "$env:CODE_SIGNING_TIMESTAMP_SERVER" `
+              --timestamp-digest sha256 `
+              --digest sha256 `
+              --exit-codes azure `
+              "$($binary.Path)"
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "psign-tool signing failed for $($binary.Rid) with exit code $LASTEXITCODE"
+            }
+          }
+
+      - name: Package signed Windows artifacts
+        shell: pwsh
+        run: |
+          $artifacts = @(
+            @{
+              Rid = 'win-x64'
+              WorkDir = 'work/win-x64'
+              Archive = 'multi-pwsh-windows-x64.zip'
+            },
+            @{
+              Rid = 'win-arm64'
+              WorkDir = 'work/win-arm64'
+              Archive = 'multi-pwsh-windows-arm64.zip'
+            }
+          )
+
+          foreach ($artifact in $artifacts) {
+            $binaryPath = Join-Path $artifact.WorkDir 'multi-pwsh.exe'
+            if (-not (Test-Path -Path $binaryPath -PathType Leaf)) {
+              throw "Windows binary not found: $binaryPath"
+            }
+
+            Compress-Archive -Path $binaryPath -DestinationPath $artifact.Archive -Force
+
+            $stageDir = Join-Path 'nuget-stage' $artifact.Rid
+            New-Item -Path $stageDir -ItemType Directory -Force | Out-Null
+            Copy-Item -Path $binaryPath -Destination (Join-Path $stageDir 'multi-pwsh.exe') -Force
+          }
+
+      - name: Upload signed Windows x64 archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-pwsh-windows-x64.zip
+          path: multi-pwsh-windows-x64.zip
+          if-no-files-found: error
+
+      - name: Upload signed Windows arm64 archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-pwsh-windows-arm64.zip
+          path: multi-pwsh-windows-arm64.zip
+          if-no-files-found: error
+
+      - name: Upload signed Windows x64 NuGet runtime artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-pwsh-nuget-win-x64
+          path: nuget-stage/win-x64/*
+          if-no-files-found: error
+
+      - name: Upload signed Windows arm64 NuGet runtime artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-pwsh-nuget-win-arm64
+          path: nuget-stage/win-arm64/*
           if-no-files-found: error
 
   publish:
@@ -257,6 +494,7 @@ jobs:
     needs:
       - validate
       - build
+      - sign-windows
 
     steps:
       - name: Checkout

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,6 +35,7 @@ Dispatch `.github/workflows/release.yml` from the branch or commit you want to r
 
 - For an actual publish, set `dry_run` to `false` and provide the matching `tag` value, for example `v0.9.0`.
 - For an inspection build, set `dry_run` to `true`. This builds and packs artifacts, uploads the `.nupkg` as a workflow artifact, and skips GitHub release publishing.
+- Set `github-env` to `auto` unless you need to force signing secrets from `publish-test` or `publish-prod`. In `auto`, runs from `master` use `publish-prod`; other branches use `publish-test`.
 
 You do **not** need to create the tag ahead of time. If the tag does not exist yet, the workflow creates it at the dispatched commit when it creates the GitHub release.
 
@@ -42,12 +43,15 @@ The workflow:
 
 - validates that the tag input matches both crate versions
 - builds artifacts from the commit you dispatched the workflow from
+- signs Windows executables on a Linux runner with Devolutions `psign` and the selected environment's Key Vault secrets
 - creates the tag at that commit if needed
-- uploads archives and `checksums.txt` to the GitHub release
-- builds and uploads `Devolutions.MultiPwsh.Cli.<version>.nupkg` to the GitHub release
+- uploads archives and `checksums.txt` to the GitHub release, with Windows archives containing signed executables
+- builds and uploads `Devolutions.MultiPwsh.Cli.<version>.nupkg` to the GitHub release, with signed Windows payloads under `runtimes\win-*\native`
 - uploads install/uninstall bootstrap scripts to the GitHub release so users do not need `raw.githubusercontent.com`
 
 If the release already exists, the workflow uploads the refreshed assets with `--clobber`.
+
+Non-dry-run releases fail if code-signing secrets are unavailable. Dry runs sign Windows executables when the selected environment exposes the signing secrets; otherwise the dry-run logs an explicit warning and produces unsigned Windows payloads for inspection only.
 
 ### Dry-run artifact download
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,7 +31,10 @@ dotnet test dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj --no-buil
 
 ## 3. Publish the release
 
-Dispatch `.github/workflows/release.yml` from the branch or commit you want to release, with the matching tag value, for example `v0.9.0`.
+Dispatch `.github/workflows/release.yml` from the branch or commit you want to release.
+
+- For an actual publish, set `dry_run` to `false` and provide the matching `tag` value, for example `v0.9.0`.
+- For an inspection build, set `dry_run` to `true`. This builds and packs artifacts, uploads the `.nupkg` as a workflow artifact, and skips GitHub release publishing.
 
 You do **not** need to create the tag ahead of time. If the tag does not exist yet, the workflow creates it at the dispatched commit when it creates the GitHub release.
 
@@ -45,6 +48,10 @@ The workflow:
 - uploads install/uninstall bootstrap scripts to the GitHub release so users do not need `raw.githubusercontent.com`
 
 If the release already exists, the workflow uploads the refreshed assets with `--clobber`.
+
+### Dry-run artifact download
+
+When `dry_run` is `true`, download the `cli-nuget` artifact from the workflow run page to inspect `Devolutions.MultiPwsh.Cli.<version>.nupkg`.
 
 ## 4. Verify release assets
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,7 @@ The workflow:
 - builds artifacts from the commit you dispatched the workflow from
 - creates the tag at that commit if needed
 - uploads archives and `checksums.txt` to the GitHub release
+- builds and uploads `Devolutions.MultiPwsh.Cli.<version>.nupkg` to the GitHub release
 - uploads install/uninstall bootstrap scripts to the GitHub release so users do not need `raw.githubusercontent.com`
 
 If the release already exists, the workflow uploads the refreshed assets with `--clobber`.
@@ -50,7 +51,25 @@ If the release already exists, the workflow uploads the refreshed assets with `-
 Confirm the release contains:
 
 - all platform zip archives
+- `Devolutions.MultiPwsh.Cli.<version>.nupkg`
 - `checksums.txt`
 - `install-multi-pwsh.ps1` and `install-multi-pwsh.sh`
 - `uninstall-multi-pwsh.ps1` and `uninstall-multi-pwsh.sh`
 - generated release notes or any required manual edits
+
+## 5. Package consumption in .NET apps
+
+Reference the package and build your project:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.9.0" />
+</ItemGroup>
+```
+
+The package contributes `multi-pwsh` payloads under `runtimes/<rid>/native/` and copies them to build/publish output.
+
+Optional output-name overrides:
+
+- `DevolutionsMultiPwshCliWindowsOutputName` (default: `multi-pwsh.exe`)
+- `DevolutionsMultiPwshCliUnixOutputName` (default: `multi-pwsh`)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -68,8 +68,3 @@ Reference the package and build your project:
 ```
 
 The package contributes `multi-pwsh` payloads under `runtimes/<rid>/native/` and copies them to build/publish output.
-
-Optional output-name overrides:
-
-- `DevolutionsMultiPwshCliWindowsOutputName` (default: `multi-pwsh.exe`)
-- `DevolutionsMultiPwshCliUnixOutputName` (default: `multi-pwsh`)

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.csproj
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Pack">
+  <PropertyGroup>
+    <Version>0.0.0</Version>
+    <Company>Devolutions Inc.</Company>
+    <Authors>Devolutions</Authors>
+    <PackageId>Devolutions.MultiPwsh.Cli</PackageId>
+    <PackageTags>multi-pwsh;powershell;cli;native</PackageTags>
+    <Description>Prebuilt multi-pwsh CLI executable for use from .NET projects.</Description>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <NoBuild>true</NoBuild>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackFrameworkReferences>false</PackFrameworkReferences>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Devolutions/multi-pwsh</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Devolutions/multi-pwsh.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\win-x64\multi-pwsh.exe" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\win-x64\multi-pwsh.exe')">
+      <PackagePath>runtimes\win-x64\native\multi-pwsh.exe</PackagePath>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\win-arm64\multi-pwsh.exe" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\win-arm64\multi-pwsh.exe')">
+      <PackagePath>runtimes\win-arm64\native\multi-pwsh.exe</PackagePath>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\linux-x64\multi-pwsh" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\linux-x64\multi-pwsh')">
+      <PackagePath>runtimes\linux-x64\native</PackagePath>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\linux-arm64\multi-pwsh" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\linux-arm64\multi-pwsh')">
+      <PackagePath>runtimes\linux-arm64\native</PackagePath>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\osx-x64\multi-pwsh" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\osx-x64\multi-pwsh')">
+      <PackagePath>runtimes\osx-x64\native</PackagePath>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\osx-arm64\multi-pwsh" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\osx-arm64\multi-pwsh')">
+      <PackagePath>runtimes\osx-arm64\native</PackagePath>
+    </Content>
+    <Content Include="Devolutions.MultiPwsh.Cli.targets" PackagePath="build\Devolutions.MultiPwsh.Cli.targets" Pack="true" />
+  </ItemGroup>
+</Project>

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.targets
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.targets
@@ -1,12 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <DevolutionsMultiPwshCliWindowsOutputName Condition="'$(DevolutionsMultiPwshCliWindowsOutputName)' == ''">multi-pwsh.exe</DevolutionsMultiPwshCliWindowsOutputName>
-    <DevolutionsMultiPwshCliUnixOutputName Condition="'$(DevolutionsMultiPwshCliUnixOutputName)' == ''">multi-pwsh</DevolutionsMultiPwshCliUnixOutputName>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'win-x64'">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\multi-pwsh.exe" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\multi-pwsh.exe')">
-      <Link>runtimes\win-x64\native\$(DevolutionsMultiPwshCliWindowsOutputName)</Link>
+      <Link>runtimes\win-x64\native\multi-pwsh.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <PublishState>Included</PublishState>
@@ -17,7 +12,7 @@
 
   <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'win-arm64'">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\multi-pwsh.exe" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\multi-pwsh.exe')">
-      <Link>runtimes\win-arm64\native\$(DevolutionsMultiPwshCliWindowsOutputName)</Link>
+      <Link>runtimes\win-arm64\native\multi-pwsh.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <PublishState>Included</PublishState>
@@ -28,7 +23,7 @@
 
   <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'linux-x64'">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\multi-pwsh')">
-      <Link>runtimes\linux-x64\native\$(DevolutionsMultiPwshCliUnixOutputName)</Link>
+      <Link>runtimes\linux-x64\native\multi-pwsh</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <PublishState>Included</PublishState>
@@ -39,7 +34,7 @@
 
   <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'linux-arm64'">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\native\multi-pwsh')">
-      <Link>runtimes\linux-arm64\native\$(DevolutionsMultiPwshCliUnixOutputName)</Link>
+      <Link>runtimes\linux-arm64\native\multi-pwsh</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <PublishState>Included</PublishState>
@@ -50,7 +45,7 @@
 
   <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'osx-x64'">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native\multi-pwsh')">
-      <Link>runtimes\osx-x64\native\$(DevolutionsMultiPwshCliUnixOutputName)</Link>
+      <Link>runtimes\osx-x64\native\multi-pwsh</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <PublishState>Included</PublishState>
@@ -61,7 +56,7 @@
 
   <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\native\multi-pwsh')">
-      <Link>runtimes\osx-arm64\native\$(DevolutionsMultiPwshCliUnixOutputName)</Link>
+      <Link>runtimes\osx-arm64\native\multi-pwsh</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <PublishState>Included</PublishState>

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.targets
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.targets
@@ -1,0 +1,72 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DevolutionsMultiPwshCliWindowsOutputName Condition="'$(DevolutionsMultiPwshCliWindowsOutputName)' == ''">multi-pwsh.exe</DevolutionsMultiPwshCliWindowsOutputName>
+    <DevolutionsMultiPwshCliUnixOutputName Condition="'$(DevolutionsMultiPwshCliUnixOutputName)' == ''">multi-pwsh</DevolutionsMultiPwshCliUnixOutputName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'win-x64'">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\multi-pwsh.exe" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\multi-pwsh.exe')">
+      <Link>runtimes\win-x64\native\$(DevolutionsMultiPwshCliWindowsOutputName)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <PublishState>Included</PublishState>
+      <Visible>false</Visible>
+      <Pack>false</Pack>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'win-arm64'">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\multi-pwsh.exe" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\multi-pwsh.exe')">
+      <Link>runtimes\win-arm64\native\$(DevolutionsMultiPwshCliWindowsOutputName)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <PublishState>Included</PublishState>
+      <Visible>false</Visible>
+      <Pack>false</Pack>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'linux-x64'">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\multi-pwsh')">
+      <Link>runtimes\linux-x64\native\$(DevolutionsMultiPwshCliUnixOutputName)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <PublishState>Included</PublishState>
+      <Visible>false</Visible>
+      <Pack>false</Pack>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'linux-arm64'">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\native\multi-pwsh')">
+      <Link>runtimes\linux-arm64\native\$(DevolutionsMultiPwshCliUnixOutputName)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <PublishState>Included</PublishState>
+      <Visible>false</Visible>
+      <Pack>false</Pack>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'osx-x64'">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native\multi-pwsh')">
+      <Link>runtimes\osx-x64\native\$(DevolutionsMultiPwshCliUnixOutputName)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <PublishState>Included</PublishState>
+      <Visible>false</Visible>
+      <Pack>false</Pack>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\native\multi-pwsh')">
+      <Link>runtimes\osx-arm64\native\$(DevolutionsMultiPwshCliUnixOutputName)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <PublishState>Included</PublishState>
+      <Visible>false</Visible>
+      <Pack>false</Pack>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/scripts/Build-CliNativeNuGetPackage.ps1
+++ b/scripts/Build-CliNativeNuGetPackage.ps1
@@ -1,0 +1,184 @@
+[CmdletBinding()]
+param(
+    [string]$Version,
+
+    [string]$Configuration = 'Release',
+
+    [string]$StagingRoot,
+
+    [string]$OutputRoot,
+
+    [string[]]$RuntimeIdentifiers = @('win-x64', 'win-arm64', 'linux-x64', 'linux-arm64', 'osx-x64', 'osx-arm64'),
+
+    [switch]$NoBuild,
+
+    [switch]$NoPack,
+
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+if ([string]::IsNullOrWhiteSpace($StagingRoot)) {
+    $StagingRoot = Join-Path $repoRoot 'artifacts\cli\multi-pwsh'
+}
+elseif (-not [System.IO.Path]::IsPathRooted($StagingRoot)) {
+    $StagingRoot = Join-Path $repoRoot $StagingRoot
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = Join-Path $repoRoot 'artifacts\cli-nuget'
+}
+elseif (-not [System.IO.Path]::IsPathRooted($OutputRoot)) {
+    $OutputRoot = Join-Path $repoRoot $OutputRoot
+}
+
+function Invoke-NativeCommand {
+    param(
+        [Parameter(Mandatory)][string]$FilePath,
+        [string[]]$ArgumentList
+    )
+
+    Write-Host ">> $FilePath $($ArgumentList -join ' ')"
+    & $FilePath @ArgumentList
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code $LASTEXITCODE`: $FilePath $($ArgumentList -join ' ')"
+    }
+}
+
+function Get-SourceVersion {
+    $multiManifest = Join-Path $repoRoot 'crates\multi-pwsh\Cargo.toml'
+    $hostManifest = Join-Path $repoRoot 'crates\pwsh-host\Cargo.toml'
+
+    $multiMatch = Select-String -Path $multiManifest -Pattern '^version = "([^"]+)"$' | Select-Object -First 1
+    $hostMatch = Select-String -Path $hostManifest -Pattern '^version = "([^"]+)"$' | Select-Object -First 1
+
+    if (($null -eq $multiMatch) -or ($null -eq $hostMatch)) {
+        throw 'Unable to detect crate versions from Cargo.toml.'
+    }
+
+    $multiVersion = $multiMatch.Matches[0].Groups[1].Value
+    $hostVersion = $hostMatch.Matches[0].Groups[1].Value
+
+    if ($multiVersion -ne $hostVersion) {
+        throw "Crate version mismatch detected: multi-pwsh=$multiVersion pwsh-host=$hostVersion"
+    }
+
+    $multiVersion
+}
+
+function Resolve-RustTarget {
+    param([Parameter(Mandatory)][string]$RuntimeIdentifier)
+
+    switch ($RuntimeIdentifier) {
+        'win-x64' { @{ CargoTarget = 'x86_64-pc-windows-msvc'; BinaryName = 'multi-pwsh.exe' } }
+        'win-arm64' { @{ CargoTarget = 'aarch64-pc-windows-msvc'; BinaryName = 'multi-pwsh.exe' } }
+        'linux-x64' { @{ CargoTarget = 'x86_64-unknown-linux-gnu'; BinaryName = 'multi-pwsh' } }
+        'linux-arm64' { @{ CargoTarget = 'aarch64-unknown-linux-gnu'; BinaryName = 'multi-pwsh' } }
+        'osx-x64' { @{ CargoTarget = 'x86_64-apple-darwin'; BinaryName = 'multi-pwsh' } }
+        'osx-arm64' { @{ CargoTarget = 'aarch64-apple-darwin'; BinaryName = 'multi-pwsh' } }
+        default { throw "Unsupported runtime identifier: $RuntimeIdentifier" }
+    }
+}
+
+function Assert-FileExists {
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not (Test-Path -Path $Path -PathType Leaf)) {
+        throw "Expected file was not found: $Path"
+    }
+}
+
+function Set-NupkgUnixExecutablePermissions {
+    param([Parameter(Mandatory)][string]$PackagePath)
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $archive = [System.IO.Compression.ZipFile]::Open($PackagePath, [System.IO.Compression.ZipArchiveMode]::Update)
+    try {
+        foreach ($entry in $archive.Entries) {
+            if ($entry.FullName -match '^runtimes/(linux|osx)-[^/]+/native/multi-pwsh$') {
+                $entry.ExternalAttributes = -2115174400 # 0o100755 << 16 as a signed Int32.
+            }
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = Get-SourceVersion
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    throw 'Package version is empty.'
+}
+
+if ($Clean) {
+    Remove-Item -Path $StagingRoot -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $OutputRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+New-Item -Path $StagingRoot -ItemType Directory -Force | Out-Null
+New-Item -Path $OutputRoot -ItemType Directory -Force | Out-Null
+
+$cargoManifest = Join-Path $repoRoot 'crates\multi-pwsh\Cargo.toml'
+
+foreach ($rid in $RuntimeIdentifiers) {
+    $target = Resolve-RustTarget -RuntimeIdentifier $rid
+    $stageDir = Join-Path $StagingRoot $rid
+    New-Item -Path $stageDir -ItemType Directory -Force | Out-Null
+
+    if (-not $NoBuild) {
+        $env:CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = 'aarch64-linux-gnu-gcc'
+        $previousRustFlags = $env:RUSTFLAGS
+        try {
+            if ($target['CargoTarget'] -like '*-windows-msvc') {
+                $env:RUSTFLAGS = '-C target-feature=+crt-static'
+            }
+
+            Invoke-NativeCommand -FilePath cargo -ArgumentList @(
+                'build',
+                '--locked',
+                '--release',
+                '--package',
+                'multi-pwsh',
+                '--bin',
+                'multi-pwsh',
+                '--manifest-path',
+                $cargoManifest,
+                '--target',
+                $target['CargoTarget']
+            )
+        }
+        finally {
+            $env:RUSTFLAGS = $previousRustFlags
+        }
+
+        $builtBinary = Join-Path $repoRoot "target\$($target['CargoTarget'])\release\$($target['BinaryName'])"
+        Assert-FileExists -Path $builtBinary
+        Copy-Item -Path $builtBinary -Destination (Join-Path $stageDir $target['BinaryName']) -Force
+    }
+
+    Assert-FileExists -Path (Join-Path $stageDir $target['BinaryName'])
+}
+
+if (-not $NoPack) {
+    $packageProject = Join-Path $repoRoot 'nuget\Devolutions.MultiPwsh.Cli\Devolutions.MultiPwsh.Cli.csproj'
+    Invoke-NativeCommand -FilePath dotnet -ArgumentList @(
+        'pack',
+        $packageProject,
+        '-c',
+        $Configuration,
+        '-o',
+        $OutputRoot,
+        "/p:Version=$Version",
+        '/p:ContinuousIntegrationBuild=true'
+    )
+
+    $packagePath = Join-Path $OutputRoot "Devolutions.MultiPwsh.Cli.$Version.nupkg"
+    Assert-FileExists -Path $packagePath
+    Set-NupkgUnixExecutablePermissions -PackagePath $packagePath
+}


### PR DESCRIPTION
## Summary
- Add `Devolutions.MultiPwsh.Cli` as a regular `PackageReference` NuGet package, not a DotnetTool package.
- Package native CLI payloads under `runtimes/<rid>/native` for Windows, Linux, and macOS RIDs.
- Add `build/Devolutions.MultiPwsh.Cli.targets` so consuming .NET projects copy the CLI payloads to build and publish output.
- Add `scripts/Build-CliNativeNuGetPackage.ps1` to build/stage RID binaries, pack the `.nupkg`, use static MSVC runtime for Windows, and preserve Unix executable bits in the package.
- Update CI with a NuGet PackageReference smoke test that verifies `runtimes/win-x64/native/multi-pwsh.exe` is copied to a consumer app's output.
- Update the release workflow to build per-RID artifacts, pack and upload `Devolutions.MultiPwsh.Cli.<version>.nupkg`, and support dry-run artifact downloads for inspection.
- Add Windows code signing to the release flow using Devolutions `psign` from an Ubuntu runner, with signing secrets selected via `publish-test` / `publish-prod` environments.
- Ensure the signed Windows executables are used both in GitHub release zip assets and inside the NuGet package under `runtimes/win-*/native`.
- Document release, dry-run, signing, and PackageReference consumption behavior in `RELEASE.md`.

## Package behavior
A consuming .NET project can add:

```xml
<ItemGroup>
  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.11.0" />
</ItemGroup>
```

The package contributes hidden non-packable content items and copies the CLI payloads into build/publish output under the runtime layout, for example:

```text
bin/Debug/net8.0/runtimes/win-x64/native/multi-pwsh.exe
```

## Signing behavior
- Windows release builds upload unsigned binaries only as intermediate workflow artifacts.
- The `sign-windows` job runs on `ubuntu-latest`, downloads Linux `psign-tool`, and signs `win-x64` / `win-arm64` `multi-pwsh.exe` with `psign-tool --mode portable`.
- Non-dry-run releases fail if signing secrets are unavailable.
- Dry runs sign when the selected environment exposes signing secrets; otherwise they emit a warning and keep Windows artifacts unsigned for inspection only.
- The same signed Windows binaries are staged into both release zips and the NuGet runtime payloads.

## Validation
- `actionlint` passed for `.github/workflows/release.yml`.
- YAML parse passed for `.github/workflows/release.yml`.
- `cargo fmt --all --check` passed.
- `cargo +stable clippy --workspace --all-targets` passed with pre-existing warnings only.
- Local `win-x64` package build passed via `scripts/Build-CliNativeNuGetPackage.ps1`.
- Throwaway .NET consumer smoke test passed and verified `bin/Debug/net8.0/runtimes/win-x64/native/multi-pwsh.exe` exists.
- Release dry run `27110335641` passed from commit `55123e9253967610efb2e1783f0397d0abc521f8` with `dry_run=true` and `github-env=test`.
- Downloaded dry-run artifacts `multi-pwsh-windows-x64.zip`, `multi-pwsh-windows-arm64.zip`, and `cli-nuget` / `Devolutions.MultiPwsh.Cli.0.11.0.nupkg`.
- `Get-AuthenticodeSignature` reported `Valid` for both Windows release zip executables and both NuGet payload executables at `runtimes/win-x64/native/multi-pwsh.exe` and `runtimes/win-arm64/native/multi-pwsh.exe`.
- The dry-run `.nupkg` contains all expected RID runtime entries: `linux-arm64`, `linux-x64`, `osx-arm64`, `osx-x64`, `win-arm64`, and `win-x64`.
