### PR TITLE
Fix installer ArchivePath variable collision (#45)

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -70,6 +70,10 @@ jobs:
           $cargoBin = Join-Path $cargoHome 'bin'
           $cargoBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Run bootstrap installer tests
+        shell: pwsh
+        run: ./tests/Invoke-BootstrapInstallerTest.ps1
+
       - name: Run smoke tests
         shell: pwsh
         env:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,13 @@
 # Testing
 
+## Bootstrap installer tests
+
+Run the mocked Windows bootstrap installer harness:
+
+```powershell
+pwsh -NoLogo -NoProfile -NonInteractive -File .\tests\Invoke-BootstrapInstallerTest.ps1
+```
+
 ## Scoped install smoke tests
 
 Run the cross-platform scoped install smoke harness:

--- a/tests/Invoke-BootstrapInstallerTest.ps1
+++ b/tests/Invoke-BootstrapInstallerTest.ps1
@@ -1,0 +1,102 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    Write-Host 'Skipping Windows bootstrap installer test on non-Windows runner.'
+    return
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)]
+        [bool]$Condition,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$installerPath = Join-Path $repoRoot 'tools\install-multi-pwsh.ps1'
+if (-not (Test-Path -LiteralPath $installerPath -PathType Leaf)) {
+    throw "Installer script was not found at $installerPath"
+}
+
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("multi-pwsh-bootstrap-test-" + [System.Guid]::NewGuid().ToString('N'))
+$oldMultiPwshHome = $env:MULTI_PWSH_HOME
+$oldMultiPwshBinDir = $env:MULTI_PWSH_BIN_DIR
+$oldUserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+
+try {
+    New-Item -Path $testRoot -ItemType Directory -Force | Out-Null
+
+    $env:MULTI_PWSH_HOME = Join-Path $testRoot 'home'
+    $env:MULTI_PWSH_BIN_DIR = Join-Path $testRoot 'bin'
+
+    $script:MockArchivePath = $null
+    $script:MockPayloadRoot = Join-Path $testRoot 'payload'
+
+    function Invoke-WebRequest {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$Uri,
+
+            [Parameter(Mandatory = $true)]
+            [string]$OutFile,
+
+            [switch]$UseBasicParsing
+        )
+
+        $outDir = Split-Path -Parent $OutFile
+        New-Item -Path $outDir -ItemType Directory -Force | Out-Null
+
+        if ($OutFile.EndsWith('.zip', [System.StringComparison]::OrdinalIgnoreCase)) {
+            Remove-Item -LiteralPath $script:MockPayloadRoot -Recurse -Force -ErrorAction SilentlyContinue
+            New-Item -Path $script:MockPayloadRoot -ItemType Directory -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $script:MockPayloadRoot 'multi-pwsh.exe') -Value 'mock multi-pwsh' -Encoding ascii
+            Compress-Archive -Path (Join-Path $script:MockPayloadRoot 'multi-pwsh.exe') -DestinationPath $OutFile -Force
+            $script:MockArchivePath = $OutFile
+            return
+        }
+
+        Assert-True -Condition ($null -ne $script:MockArchivePath) -Message 'Checksum was requested before the archive was created.'
+        $assetName = Split-Path -Leaf $script:MockArchivePath
+        $hash = (Get-FileHash -LiteralPath $script:MockArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        Set-Content -LiteralPath $OutFile -Value "$hash  $assetName" -Encoding ascii
+    }
+
+    Get-Content -LiteralPath $installerPath -Raw | Invoke-Expression
+
+    $targetExe = Join-Path $env:MULTI_PWSH_BIN_DIR 'multi-pwsh.exe'
+    Assert-True -Condition (Test-Path -LiteralPath $targetExe -PathType Leaf) -Message "Expected installer to create $targetExe"
+}
+finally {
+    [Environment]::SetEnvironmentVariable('Path', $oldUserPath, 'User')
+
+    if ($null -eq $oldMultiPwshHome) {
+        Remove-Item Env:\MULTI_PWSH_HOME -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:MULTI_PWSH_HOME = $oldMultiPwshHome
+    }
+
+    if ($null -eq $oldMultiPwshBinDir) {
+        Remove-Item Env:\MULTI_PWSH_BIN_DIR -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:MULTI_PWSH_BIN_DIR = $oldMultiPwshBinDir
+    }
+
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}
+
+Write-Host 'Bootstrap installer test completed successfully.'

--- a/tools/install-multi-pwsh.ps1
+++ b/tools/install-multi-pwsh.ps1
@@ -181,7 +181,7 @@ $binDir = Get-MultiPwshBinDir
 $targetExe = Join-Path $binDir 'multi-pwsh.exe'
 
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("multi-pwsh-install-" + [System.Guid]::NewGuid().ToString('N'))
-$archivePath = if ([string]::IsNullOrWhiteSpace($ArchivePath)) { Join-Path $tempRoot $assetName } else { $ArchivePath }
+$resolvedArchivePath = if ([string]::IsNullOrWhiteSpace($ArchivePath)) { Join-Path $tempRoot $assetName } else { $ArchivePath }
 $localChecksumPath = if ([string]::IsNullOrWhiteSpace($ChecksumPath)) { Join-Path $tempRoot 'checksums.txt' } else { $ChecksumPath }
 $extractDir = Join-Path $tempRoot 'extract'
 
@@ -193,8 +193,8 @@ try {
         $sourceArchive = Join-Path $versionDirectory $assetName
         $sourceChecksum = if ([string]::IsNullOrWhiteSpace($ChecksumPath)) { Join-Path $versionDirectory 'checksums.txt' } else { $ChecksumPath }
         Write-Host "Using offline $assetName from $sourceArchive"
-        if (-not [string]::Equals([System.IO.Path]::GetFullPath($sourceArchive), [System.IO.Path]::GetFullPath($archivePath), [System.StringComparison]::OrdinalIgnoreCase)) {
-            Copy-Item -LiteralPath $sourceArchive -Destination $archivePath -Force
+        if (-not [string]::Equals([System.IO.Path]::GetFullPath($sourceArchive), [System.IO.Path]::GetFullPath($resolvedArchivePath), [System.StringComparison]::OrdinalIgnoreCase)) {
+            Copy-Item -LiteralPath $sourceArchive -Destination $resolvedArchivePath -Force
         }
         if (-not [string]::Equals([System.IO.Path]::GetFullPath($sourceChecksum), [System.IO.Path]::GetFullPath($localChecksumPath), [System.StringComparison]::OrdinalIgnoreCase)) {
             Copy-Item -LiteralPath $sourceChecksum -Destination $localChecksumPath -Force
@@ -205,7 +205,7 @@ try {
 
         $invokeParams = @{
             Uri = $downloadUrl
-            OutFile = $archivePath
+            OutFile = $resolvedArchivePath
         }
 
         $checksumInvokeParams = @{
@@ -225,9 +225,9 @@ try {
         throw '-ChecksumPath is required when -ArchivePath is used without -OfflineCache'
     }
 
-    Assert-ArchiveChecksum -ArchivePath $archivePath -ChecksumPath $localChecksumPath -AssetName $assetName
+    Assert-ArchiveChecksum -ArchivePath $resolvedArchivePath -ChecksumPath $localChecksumPath -AssetName $assetName
 
-    Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+    Expand-Archive -Path $resolvedArchivePath -DestinationPath $extractDir -Force
 
     $sourceExe = Join-Path $extractDir 'multi-pwsh.exe'
     if (-not (Test-Path -Path $sourceExe -PathType Leaf)) {


### PR DESCRIPTION
## Summary

Fixes #45.

The `irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.ps1 | iex` bootstrap was failing with:

```
-ChecksumPath is required when -ArchivePath is used without -OfflineCache
```

even though no `-ArchivePath` was supplied.

## Root cause

PowerShell variable names are case-insensitive. In `tools/install-multi-pwsh.ps1` the script computed a working path with:

```powershell
$archivePath = if ([string]::IsNullOrWhiteSpace($ArchivePath)) { ... } else { $ArchivePath }
```

That assignment also overwrote the `$ArchivePath` **parameter** with the non-empty resolved temp path. The subsequent branch logic then saw `$ArchivePath` as set, skipped the download branch, and fell into the `elseif` that throws the misleading checksum error.

## Fix

- Rename the local resolved variable to `$resolvedArchivePath` so the user-supplied `$ArchivePath` parameter is preserved across the branch checks. The `-OfflineCache`, plain download, and `-ArchivePath` + `-ChecksumPath` paths all keep their original semantics.

## Tests

- Added `tests/Invoke-BootstrapInstallerTest.ps1`, which mocks `Invoke-WebRequest` to produce a deterministic archive and checksums file, runs the real installer against a throwaway `MULTI_PWSH_HOME`/`MULTI_PWSH_BIN_DIR`, and asserts that `multi-pwsh.exe` was installed without supplying `-ArchivePath`/`-ChecksumPath` — i.e. the exact path that was broken in #45.
- Wired the new test into `.github/workflows/smoke-tests.yml` and documented it in `docs/testing.md`. The test self-skips on non-Windows runners since it targets the Windows `.ps1` bootstrapper.

## Verification

- `pwsh -File .\tests\Invoke-BootstrapInstallerTest.ps1` → passes.
- Manually ran the patched script against a temp install home using the same `Get-Content … | Invoke-Expression` pattern as `irm | iex` → installs successfully.
- Confirmed the published `v0.12.0` `install-multi-pwsh.ps1` reproduces the original error in the same harness.
- `cargo fmt --all --check` → clean.

`cargo build --all-targets` / `dotnet build` / `cargo clippy` were not completed locally: the existing `DiscoverBindings` MSBuild target (run via `pwsh-7.4`) hangs in this environment. No Rust or C# code is changed in this PR, so CI will exercise those gates.
