### PR TITLE
Bump version to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "flate2",
  "home",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/multi-pwsh"

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"


### PR DESCRIPTION
## Summary
- Bump `multi-pwsh` crate version to `0.12.1`
- Bump `pwsh-host` crate version to `0.12.1`
- Update `Cargo.lock` package entries

## Validation
- `cargo metadata --locked --format-version 1 --no-deps --quiet`
- `cargo +stable fmt --all --check`
- `cargo +stable clippy --workspace --all-targets` failed locally in `Discover-Bindings.ps1` with `Access is denied` during the managed binding build, even when `PwshExePath` was set to `C:\Users\mamoreau\.pwsh\bin\pwsh-7.4.exe`.
- `dotnet build dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj` passed once with the same explicit `PwshExePath`.