### PR TITLE
Align scoped install paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -39,7 +39,7 @@ jobs:
           rustup component add rustfmt clippy --toolchain stable
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2.8.2
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -81,7 +81,7 @@ jobs:
           rustup default stable
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2.8.2
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Install multi-pwsh from source
         shell: pwsh
@@ -111,7 +111,7 @@ jobs:
           echo "$multi_pwsh_bin" >> "$GITHUB_PATH"
 
       - name: Cache multi-pwsh downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/multi-pwsh-cache
           key: multi-pwsh-cache-${{ runner.os }}-${{ hashFiles('crates/multi-pwsh/Cargo.toml', '.github/workflows/ci.yml') }}
@@ -175,10 +175,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Install PowerShell 7.4 for binding discovery
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/Install-PowerShell74ForCi.ps1
+
       - name: Install Rust toolchain
         shell: pwsh
         run: |
@@ -62,6 +68,12 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Install PowerShell 7.4 for binding discovery
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/Install-PowerShell74ForCi.ps1
+
       - name: Install Rust toolchain
         shell: pwsh
         run: |
@@ -88,9 +100,7 @@ jobs:
         run: |
           $multiPwshHome = if ($env:MULTI_PWSH_HOME) { $env:MULTI_PWSH_HOME } else { Join-Path $HOME '.pwsh' }
           $multiPwshBin = if ($env:MULTI_PWSH_BIN_DIR) { $env:MULTI_PWSH_BIN_DIR } else { Join-Path $multiPwshHome 'bin' }
-          $userAliasBin = Join-Path $env:LOCALAPPDATA 'PowerShell\bin'
           $multiPwshBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          $userAliasBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Add multi-pwsh alias bin to PATH (Unix)
         if: matrix.os != 'windows-latest'
@@ -152,11 +162,11 @@ jobs:
 
       - name: Build .NET project
         shell: pwsh
-        run: dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj -p:PwshExePath="pwsh-7.4"
+        run: dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj -p:PwshExePath="$env:PwshExePath"
 
       - name: Run .NET tests
         shell: pwsh
-        run: dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build -p:PwshExePath="pwsh-7.4"
+        run: dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build -p:PwshExePath="$env:PwshExePath"
 
   nuget-cli:
     name: NuGet CLI package smoke (Windows)
@@ -171,6 +181,12 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
+
+      - name: Install PowerShell 7.4 for binding discovery
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/Install-PowerShell74ForCi.ps1
 
       - name: Install Rust toolchain
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,12 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Install PowerShell 7.4 for binding discovery
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/Install-PowerShell74ForCi.ps1
+
       - name: Install Rust toolchain
         shell: pwsh
         run: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -41,6 +41,12 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Install PowerShell 7.4 for binding discovery
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/Install-PowerShell74ForCi.ps1
+
       - name: Install Rust toolchain
         shell: pwsh
         run: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -54,10 +54,10 @@ jobs:
           rustup default stable
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2.8.2
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Cache multi-pwsh downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/multi-pwsh-cache
           key: multi-pwsh-scope-smoke-${{ runner.os }}-${{ hashFiles('crates/multi-pwsh/Cargo.toml', '.github/workflows/smoke-tests.yml', 'tests/Invoke-ScopedInstallSmokeTest.ps1') }}

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ That means:
 Platform behavior:
 
 - Windows uses the GitHub ZIP archives with MSI-like install roots and selected installer-style integrations that still make sense for archive installs.
+- `user` installs default to `~/.pwsh` on every platform, with aliases in `~/.pwsh/bin`.
+- Windows `machine` installs default to `%ProgramFiles%\PowerShell` with aliases in `%ProgramFiles%\PowerShell\bin`.
 - macOS `machine` installs use the official `.tar.gz` archives under `/usr/local/microsoft/powershell` with aliases published to `/usr/local/bin`.
 - Linux `machine` installs use the official `.tar.gz` archives under `/opt/microsoft/powershell` with aliases published to `/usr/local/bin`.
 - Unix `machine` installs expect you to provide elevation yourself; `multi-pwsh` does not invoke `sudo`.

--- a/crates/multi-pwsh/build.rs
+++ b/crates/multi-pwsh/build.rs
@@ -17,6 +17,18 @@ fn main() {
         .set("OriginalFilename", "multi-pwsh.exe")
         .set("FileVersion", &version)
         .set("ProductVersion", &version);
+    resource.set_manifest(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>"#,
+    );
 
     resource.compile().expect("failed to compile Windows resources");
 }

--- a/crates/multi-pwsh/src/layout.rs
+++ b/crates/multi-pwsh/src/layout.rs
@@ -243,10 +243,7 @@ fn collect_versions_from_dir(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
     use tempfile::TempDir;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn with_env_var<T>(key: &str, value: Option<&Path>, action: impl FnOnce() -> T) -> T {
         let previous = env::var_os(key);
@@ -273,7 +270,7 @@ mod tests {
         venv_dir: Option<&Path>,
         action: impl FnOnce() -> T,
     ) -> T {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
 
         with_env_var("MULTI_PWSH_HOME", home, || {
             with_env_var("MULTI_PWSH_BIN_DIR", bin_dir, || {

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -15,6 +15,8 @@ use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process;
+#[cfg(test)]
+use std::sync::Mutex;
 
 use semver::Version;
 
@@ -48,6 +50,9 @@ const MULTI_PWSH_OFFLINE_CACHE_ENV_VAR: &str = "MULTI_PWSH_OFFLINE_CACHE";
 const MULTI_PWSH_RELEASE_SOURCE_ENV_VAR: &str = "MULTI_PWSH_RELEASE_SOURCE";
 const VIRTUAL_ENVIRONMENT_FLAG: &str = "-virtualenvironment";
 const VIRTUAL_ENVIRONMENT_SHORT_FLAG: &str = "-venv";
+
+#[cfg(test)]
+static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
 const HELP_TOPICS: &[&str] = &[
     "install",
     "update",
@@ -296,6 +301,10 @@ impl Drop for ProcessEnvVarGuard {
             None => unsafe { env::remove_var(self.key) },
         }
     }
+}
+
+fn default_current_user_layout(os: HostOs) -> Result<InstallLayout> {
+    InstallLayout::new(os)
 }
 
 fn configure_virtual_environment_host_env(os: HostOs, venv_dir: &Path) -> Result<Vec<ProcessEnvVarGuard>> {
@@ -900,7 +909,7 @@ fn run_host_mode_with_layout(layout: InstallLayout, selector_input: &str, pwsh_a
 
 fn run_host_mode(selector_input: &str, pwsh_args: Vec<OsString>) -> Result<i32> {
     let os = HostOs::detect()?;
-    let layout = InstallLayout::new(os)?;
+    let layout = default_current_user_layout(os)?;
     run_host_mode_with_layout(layout, selector_input, pwsh_args)
 }
 
@@ -1591,10 +1600,15 @@ fn cache_multi_pwsh_artifact(
 
 fn run_cache_warm(selector_input: &str, options: CacheWarmOptions) -> Result<()> {
     let selector = parse_install_selector(selector_input)?;
+    let os = HostOs::detect().unwrap_or(HostOs::Windows);
     let output_root = options.output.unwrap_or_else(|| {
-        InstallLayout::new(HostOs::detect().unwrap_or(HostOs::Windows))
-            .map(|layout| layout.cache_dir())
-            .unwrap_or_else(|_| PathBuf::from("."))
+        env::var_os("MULTI_PWSH_CACHE_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                default_current_user_layout(os)
+                    .map(|layout| layout.cache_dir())
+                    .unwrap_or_else(|_| PathBuf::from("."))
+            })
     });
     fs::create_dir_all(&output_root)?;
 
@@ -1823,7 +1837,7 @@ fn run_alias(args: &[String]) -> Result<()> {
     }
 
     let os = HostOs::detect()?;
-    let layout = InstallLayout::new(os)?;
+    let layout = default_current_user_layout(os)?;
     layout.ensure_base_dirs()?;
 
     match args[0].as_str() {
@@ -3206,7 +3220,7 @@ fn run_doctor(args: &[String]) -> Result<()> {
     }
 
     let os = HostOs::detect()?;
-    let layout = InstallLayout::new(os)?;
+    let layout = default_current_user_layout(os)?;
     layout.ensure_base_dirs()?;
 
     refresh_special_aliases(&layout, os)?;
@@ -3430,13 +3444,10 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
     use tempfile::TempDir;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
     fn with_env_var<T>(key: &str, value: Option<&str>, action: impl FnOnce() -> T) -> T {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
         let previous = env::var_os(key);
 
         match value {
@@ -3452,6 +3463,81 @@ mod tests {
         }
 
         result
+    }
+
+    fn with_env_vars<T>(values: &[(&str, Option<&Path>)], action: impl FnOnce() -> T) -> T {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
+        let previous: Vec<_> = values.iter().map(|(key, _)| (*key, env::var_os(key))).collect();
+
+        for (key, value) in values {
+            match value {
+                Some(value) => unsafe { env::set_var(*key, value) },
+                None => unsafe { env::remove_var(*key) },
+            }
+        }
+
+        let result = action();
+
+        for (key, value) in previous {
+            match value {
+                Some(value) => unsafe { env::set_var(key, value) },
+                None => unsafe { env::remove_var(key) },
+            }
+        }
+
+        result
+    }
+
+    #[test]
+    fn default_current_user_layout_uses_user_home_layout_on_windows() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().join("multi-pwsh-home");
+        let venvs_dir = temp_dir.path().join("custom-venvs");
+
+        with_env_vars(
+            &[
+                ("MULTI_PWSH_HOME", Some(home.as_path())),
+                ("MULTI_PWSH_BIN_DIR", None),
+                ("MULTI_PWSH_CACHE_DIR", None),
+                ("MULTI_PWSH_VENV_DIR", Some(venvs_dir.as_path())),
+            ],
+            || {
+                let layout = default_current_user_layout(HostOs::Windows).unwrap();
+
+                assert_eq!(layout.home(), home.as_path());
+                assert_eq!(layout.bin_dir(), home.join("bin"));
+                assert_eq!(layout.cache_dir(), home.join("cache"));
+                assert_eq!(layout.venvs_dir(), venvs_dir);
+                assert_eq!(layout.versions_dir(), home.join("multi"));
+            },
+        );
+    }
+
+    #[test]
+    fn default_current_user_layout_honors_explicit_overrides_on_windows() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().join("multi-pwsh-home");
+        let bin_dir = temp_dir.path().join("bin-root");
+        let cache_dir = temp_dir.path().join("cache-root");
+        let venv_dir = temp_dir.path().join("venv-root");
+
+        with_env_vars(
+            &[
+                ("MULTI_PWSH_HOME", Some(home.as_path())),
+                ("MULTI_PWSH_BIN_DIR", Some(bin_dir.as_path())),
+                ("MULTI_PWSH_CACHE_DIR", Some(cache_dir.as_path())),
+                ("MULTI_PWSH_VENV_DIR", Some(venv_dir.as_path())),
+            ],
+            || {
+                let layout = default_current_user_layout(HostOs::Windows).unwrap();
+
+                assert_eq!(layout.home(), home.as_path());
+                assert_eq!(layout.bin_dir(), bin_dir);
+                assert_eq!(layout.cache_dir(), cache_dir);
+                assert_eq!(layout.venvs_dir(), venv_dir);
+                assert_eq!(layout.versions_dir(), home.join("multi"));
+            },
+        );
     }
 
     #[test]
@@ -4167,7 +4253,7 @@ mod tests {
 
     #[test]
     fn configure_virtual_environment_host_env_sets_and_restores_windows_startup_hook_variables() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
         let temp_dir = tempfile::tempdir().unwrap();
         let forced_path = temp_dir.path().join("venv");
         fs::create_dir_all(&forced_path).unwrap();
@@ -4208,7 +4294,7 @@ mod tests {
 
     #[test]
     fn configure_virtual_environment_host_env_sets_and_restores_unix_startup_hook_variables() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
         let temp_dir = tempfile::tempdir().unwrap();
         let forced_path = temp_dir.path().join("venv");
         fs::create_dir_all(&forced_path).unwrap();

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -464,7 +464,7 @@ fn is_option_like(arg: &OsStr) -> bool {
 fn parse_mcp_command_values(value: &OsStr) -> Vec<String> {
     value
         .to_string_lossy()
-        .split(|character| matches!(character, ',' | ';'))
+        .split([',', ';'])
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)

--- a/crates/multi-pwsh/src/mcp.rs
+++ b/crates/multi-pwsh/src/mcp.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{LockResult, Mutex, MutexGuard};
 
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, Implementation, JsonObject, ListToolsResult, PaginatedRequestParams,
@@ -123,11 +123,25 @@ struct ServerState {
 
 #[derive(Clone)]
 struct SharedPowerShell {
-    inner: Arc<Mutex<pwsh_host::PowerShell>>,
+    inner: Arc<PowerShellLock>,
 }
 
-unsafe impl Send for SharedPowerShell {}
-unsafe impl Sync for SharedPowerShell {}
+struct PowerShellLock(Mutex<pwsh_host::PowerShell>);
+
+// SAFETY: run_mcp_server drives the MCP host on a current-thread runtime, and
+// the mutex serializes all access across cloned handlers.
+unsafe impl Send for PowerShellLock {}
+unsafe impl Sync for PowerShellLock {}
+
+impl PowerShellLock {
+    fn new(powershell: pwsh_host::PowerShell) -> Self {
+        Self(Mutex::new(powershell))
+    }
+
+    fn lock(&self) -> LockResult<MutexGuard<'_, pwsh_host::PowerShell>> {
+        self.0.lock()
+    }
+}
 
 #[derive(Clone, Debug)]
 struct ExposedTool {
@@ -230,7 +244,7 @@ impl HostMcpServer {
 impl SharedPowerShell {
     fn new(pwsh_dir: &Path) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(Self {
-            inner: Arc::new(Mutex::new(pwsh_host::PowerShell::new_for_pwsh_dir(pwsh_dir)?)),
+            inner: Arc::new(PowerShellLock::new(pwsh_host::PowerShell::new_for_pwsh_dir(pwsh_dir)?)),
         })
     }
 

--- a/crates/multi-pwsh/src/package.rs
+++ b/crates/multi-pwsh/src/package.rs
@@ -260,31 +260,17 @@ pub fn package_layout(
     install_root: Option<PathBuf>,
 ) -> Result<InstallLayout> {
     match (os, scope, install_root) {
-        (HostOs::Windows, PackageScope::CurrentUser, None) => {
-            let root = default_install_root(os, PackageScope::CurrentUser, arch)?;
-            // Use the default layout's venvs_dir so that `multi-pwsh venv` commands and
-            // package install alias shims resolve venvs from the same directory.
-            let default_venvs_dir = InstallLayout::new(os)
-                .map(|l| l.venvs_dir())
-                .unwrap_or_else(|_| root.join("venv"));
-            InstallLayout::from_parts(
-                os,
-                root.clone(),
-                root.join("bin"),
-                root.join("cache"),
-                default_venvs_dir,
-                root,
-            )
+        (HostOs::Windows | HostOs::Macos | HostOs::Linux, PackageScope::CurrentUser, Some(root)) => {
+            InstallLayout::from_root(os, root)
         }
-        (HostOs::Windows, scope, install_root) => {
+        (HostOs::Windows | HostOs::Macos | HostOs::Linux, PackageScope::CurrentUser, None) => InstallLayout::new(os),
+        (HostOs::Windows, PackageScope::AllUsers, install_root) => {
             let root = match install_root {
                 Some(root) => root,
-                None => default_install_root(os, scope, arch)?,
+                None => default_install_root(os, PackageScope::AllUsers, arch)?,
             };
             InstallLayout::from_root_with_versions_dir(os, root.clone(), root)
         }
-        (HostOs::Macos | HostOs::Linux, PackageScope::CurrentUser, Some(root)) => InstallLayout::from_root(os, root),
-        (HostOs::Macos | HostOs::Linux, PackageScope::CurrentUser, None) => InstallLayout::new(os),
         (HostOs::Macos | HostOs::Linux, PackageScope::AllUsers, install_root) => {
             let root = match install_root {
                 Some(root) => root,
@@ -298,14 +284,13 @@ pub fn package_layout(
 
 pub fn default_install_root(os: HostOs, scope: PackageScope, arch: HostArch) -> Result<PathBuf> {
     match (os, scope) {
-        (HostOs::Windows, PackageScope::CurrentUser) => {
-            let base = env::var_os("LOCALAPPDATA").map(PathBuf::from).ok_or_else(|| {
+        (HostOs::Windows | HostOs::Macos | HostOs::Linux, PackageScope::CurrentUser) => Ok(home_dir()
+            .ok_or_else(|| {
                 MultiPwshError::InvalidArguments(
-                    "LOCALAPPDATA is not defined; unable to determine current-user package install root".to_string(),
+                    "home directory is not defined; unable to determine current-user package install root".to_string(),
                 )
-            })?;
-            Ok(base.join("PowerShell"))
-        }
+            })?
+            .join(".pwsh")),
         (HostOs::Windows, PackageScope::AllUsers) => {
             let key = if arch == HostArch::X86 {
                 "ProgramFiles(x86)"
@@ -324,13 +309,6 @@ pub fn default_install_root(os: HostOs, scope: PackageScope, arch: HostArch) -> 
                 })?;
             Ok(base.join("PowerShell"))
         }
-        (HostOs::Macos, PackageScope::CurrentUser) | (HostOs::Linux, PackageScope::CurrentUser) => Ok(home_dir()
-            .ok_or_else(|| {
-                MultiPwshError::InvalidArguments(
-                    "HOME is not defined; unable to determine current-user package install root".to_string(),
-                )
-            })?
-            .join(".pwsh")),
         (HostOs::Macos, PackageScope::AllUsers) => Ok(PathBuf::from("/usr/local/microsoft/powershell")),
         (HostOs::Linux, PackageScope::AllUsers) => Ok(PathBuf::from("/opt/microsoft/powershell")),
     }
@@ -902,10 +880,7 @@ fn remove_file_context_menu(scope: PackageScope) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
     use tempfile::TempDir;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn with_env_var<T>(key: &str, value: Option<&Path>, action: impl FnOnce() -> T) -> T {
         let previous = env::var_os(key);
@@ -1050,21 +1025,148 @@ mod tests {
     }
 
     #[test]
-    fn package_layout_windows_user_default_uses_default_venv_root() {
-        let _guard = ENV_LOCK.lock().unwrap();
+    fn package_layout_windows_user_default_uses_default_user_layout() {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().join("pwsh-home");
+        let venvs_dir = temp_dir.path().join("custom-venvs");
+
+        with_env_var("MULTI_PWSH_HOME", Some(&home), || {
+            with_env_var("MULTI_PWSH_BIN_DIR", None, || {
+                with_env_var("MULTI_PWSH_CACHE_DIR", None, || {
+                    with_env_var("MULTI_PWSH_VENV_DIR", Some(&venvs_dir), || {
+                        let layout =
+                            package_layout(HostOs::Windows, HostArch::X64, PackageScope::CurrentUser, None).unwrap();
+
+                        assert_eq!(layout.home(), home.as_path());
+                        assert_eq!(layout.bin_dir(), home.join("bin"));
+                        assert_eq!(layout.cache_dir(), home.join("cache"));
+                        assert_eq!(layout.versions_dir(), home.join("multi"));
+                        assert_eq!(layout.venvs_dir(), venvs_dir);
+                    })
+                })
+            })
+        });
+    }
+
+    #[test]
+    fn package_layout_windows_user_explicit_root_uses_user_layout_shape() {
+        let root = PathBuf::from(r"C:\Users\Me\.pwsh");
+        let layout = package_layout(
+            HostOs::Windows,
+            HostArch::X64,
+            PackageScope::CurrentUser,
+            Some(root.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(layout.home(), root.as_path());
+        assert_eq!(layout.bin_dir(), root.join("bin"));
+        assert_eq!(layout.cache_dir(), root.join("cache"));
+        assert_eq!(layout.versions_dir(), root.join("multi"));
+        assert_eq!(
+            layout.version_install_dir(&Version::parse("7.4.13").unwrap()),
+            root.join("multi").join("7.4.13")
+        );
+    }
+
+    #[test]
+    fn package_layout_windows_user_default_honors_explicit_overrides() {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().join("pwsh-home");
+        let bin_dir = temp_dir.path().join("custom-bin");
+        let cache_dir = temp_dir.path().join("custom-cache");
+        let venv_dir = temp_dir.path().join("custom-venv");
+
+        with_env_var("MULTI_PWSH_HOME", Some(&home), || {
+            with_env_var("MULTI_PWSH_BIN_DIR", Some(&bin_dir), || {
+                with_env_var("MULTI_PWSH_CACHE_DIR", Some(&cache_dir), || {
+                    with_env_var("MULTI_PWSH_VENV_DIR", Some(&venv_dir), || {
+                        let layout =
+                            package_layout(HostOs::Windows, HostArch::X64, PackageScope::CurrentUser, None).unwrap();
+
+                        assert_eq!(layout.home(), home.as_path());
+                        assert_eq!(layout.bin_dir(), bin_dir);
+                        assert_eq!(layout.cache_dir(), cache_dir);
+                        assert_eq!(layout.versions_dir(), home.join("multi"));
+                        assert_eq!(layout.venvs_dir(), venv_dir);
+                    })
+                })
+            })
+        });
+    }
+
+    #[test]
+    fn package_layout_windows_user_default_ignores_local_app_data() {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
         let temp_dir = TempDir::new().unwrap();
         let local_app_data = temp_dir.path().join("local-app-data");
-        let default_home = temp_dir.path().join("pwsh-home");
+        let home = temp_dir.path().join("pwsh-home");
 
         with_env_var("LOCALAPPDATA", Some(&local_app_data), || {
-            with_env_var("MULTI_PWSH_HOME", Some(&default_home), || {
-                let layout = package_layout(HostOs::Windows, HostArch::X64, PackageScope::CurrentUser, None).unwrap();
+            with_env_var("MULTI_PWSH_HOME", Some(&home), || {
+                with_env_var("MULTI_PWSH_BIN_DIR", None, || {
+                    with_env_var("MULTI_PWSH_CACHE_DIR", None, || {
+                        with_env_var("MULTI_PWSH_VENV_DIR", None, || {
+                            let layout =
+                                package_layout(HostOs::Windows, HostArch::X64, PackageScope::CurrentUser, None)
+                                    .unwrap();
 
-                let expected_install_root = local_app_data.join("PowerShell");
-                assert_eq!(layout.home(), expected_install_root.as_path());
-                assert_eq!(layout.bin_dir(), expected_install_root.join("bin"));
-                assert_eq!(layout.versions_dir(), expected_install_root);
-                assert_eq!(layout.venvs_dir(), default_home.join("venv"));
+                            assert_eq!(layout.home(), home.as_path());
+                            assert_eq!(layout.bin_dir(), home.join("bin"));
+                            assert_eq!(layout.cache_dir(), home.join("cache"));
+                            assert_eq!(layout.versions_dir(), home.join("multi"));
+                        })
+                    })
+                })
+            })
+        });
+    }
+
+    #[test]
+    fn package_layout_windows_user_default_preserves_explicit_home_override() {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().join("pwsh-home");
+
+        with_env_var("MULTI_PWSH_HOME", Some(&home), || {
+            with_env_var("MULTI_PWSH_BIN_DIR", None, || {
+                with_env_var("MULTI_PWSH_CACHE_DIR", None, || {
+                    with_env_var("MULTI_PWSH_VENV_DIR", None, || {
+                        let layout =
+                            package_layout(HostOs::Windows, HostArch::X64, PackageScope::CurrentUser, None).unwrap();
+
+                        assert_eq!(layout.home(), home.as_path());
+                        assert_eq!(layout.bin_dir(), home.join("bin"));
+                        assert_eq!(layout.cache_dir(), home.join("cache"));
+                        assert_eq!(layout.venvs_dir(), home.join("venv"));
+                        assert_eq!(layout.versions_dir(), home.join("multi"));
+                    })
+                })
+            })
+        });
+    }
+
+    #[test]
+    fn package_layout_windows_user_default_uses_explicit_bin_and_cache_overrides() {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().join("pwsh-home");
+        let bin_dir = temp_dir.path().join("custom-bin");
+        let cache_dir = temp_dir.path().join("custom-cache");
+
+        with_env_var("MULTI_PWSH_HOME", Some(&home), || {
+            with_env_var("MULTI_PWSH_BIN_DIR", Some(&bin_dir), || {
+                with_env_var("MULTI_PWSH_CACHE_DIR", Some(&cache_dir), || {
+                    let layout =
+                        package_layout(HostOs::Windows, HostArch::X64, PackageScope::CurrentUser, None).unwrap();
+
+                    assert_eq!(layout.home(), home.as_path());
+                    assert_eq!(layout.bin_dir(), bin_dir);
+                    assert_eq!(layout.cache_dir(), cache_dir);
+                    assert_eq!(layout.versions_dir(), home.join("multi"));
+                })
             })
         });
     }

--- a/crates/multi-pwsh/src/package.rs
+++ b/crates/multi-pwsh/src/package.rs
@@ -1052,6 +1052,7 @@ mod tests {
     #[test]
     fn package_layout_windows_user_explicit_root_uses_user_layout_shape() {
         let root = PathBuf::from(r"C:\Users\Me\.pwsh");
+        let expected = InstallLayout::from_root(HostOs::Windows, root.clone()).unwrap();
         let layout = package_layout(
             HostOs::Windows,
             HostArch::X64,
@@ -1061,12 +1062,12 @@ mod tests {
         .unwrap();
 
         assert_eq!(layout.home(), root.as_path());
-        assert_eq!(layout.bin_dir(), root.join("bin"));
-        assert_eq!(layout.cache_dir(), root.join("cache"));
-        assert_eq!(layout.versions_dir(), root.join("multi"));
+        assert_eq!(layout.bin_dir(), expected.bin_dir());
+        assert_eq!(layout.cache_dir(), expected.cache_dir());
+        assert_eq!(layout.versions_dir(), expected.versions_dir());
         assert_eq!(
             layout.version_install_dir(&Version::parse("7.4.13").unwrap()),
-            root.join("multi").join("7.4.13")
+            expected.version_install_dir(&Version::parse("7.4.13").unwrap())
         );
     }
 

--- a/crates/pwsh-host/src/loader.rs
+++ b/crates/pwsh-host/src/loader.rs
@@ -4,7 +4,6 @@ use crate::error::Error;
 use crate::host_detect::pwsh_host_detect;
 use crate::host_exit_code::HostExitCode;
 use crate::host_exit_code::KnownHostExitCode;
-use crate::hostfxr::load_hostfxr;
 use crate::hostfxr::load_hostfxr_from_pwsh_dir;
 use crate::pdcstr;
 use crate::pdcstring::PdCString;

--- a/docs/host-and-venv.md
+++ b/docs/host-and-venv.md
@@ -7,7 +7,7 @@
 - `-VirtualEnvironment <name>` and `-venv <name>` are consumed by `multi-pwsh` before handing control to PowerShell and set `PSModulePath` to the selected venv module root for that launch.
 - `PSMODULE_VENV_PATH` can also be used as an explicit path-based venv selector for hosted launches. If it is already set in the environment, `multi-pwsh host` treats it as an intentional venv opt-in.
 - Alias lifecycle maintains native host shims as hard links to `multi-pwsh` during install, update, and `doctor --repair-aliases`.
-- On Windows, alias command paths are `pwsh-*.exe` host shims in `MULTI_PWSH_BIN_DIR` (default: `~/.pwsh/bin`).
+- On Windows, alias command paths are `pwsh-*.exe` host shims in the active install scope's `bin` directory. The default user scope uses `~/.pwsh/bin`, matching Linux/macOS.
 - On Linux/macOS, alias command paths (`pwsh-*`) are hard links to `multi-pwsh`.
 - `multi-pwsh doctor --repair-aliases` performs a shim health check and re-links broken hard links automatically.
 - Copying or renaming `multi-pwsh.exe` to an alias-like name such as `pwsh-7.4.exe` also enters implicit host mode.

--- a/scripts/Install-PowerShell74ForCi.ps1
+++ b/scripts/Install-PowerShell74ForCi.ps1
@@ -1,0 +1,155 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-GitHubHeaders {
+    $headers = @{
+        "User-Agent" = "multi-pwsh-ci"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+        $headers["Authorization"] = "Bearer $env:GITHUB_TOKEN"
+    }
+
+    $headers
+}
+
+function Get-PowerShell74Release {
+    $headers = Get-GitHubHeaders
+    $releases = Invoke-RestMethod `
+        -Headers $headers `
+        -Uri "https://api.github.com/repos/PowerShell/PowerShell/releases?per_page=100"
+
+    $release = $releases |
+        Where-Object { -not $_.prerelease -and $_.tag_name -match "^v7\.4\.\d+$" } |
+        Sort-Object { [version]$_.tag_name.TrimStart("v") } -Descending |
+        Select-Object -First 1
+
+    if ($null -eq $release) {
+        throw "Unable to find a PowerShell 7.4.x release."
+    }
+
+    $release
+}
+
+function Get-AssetName {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+    $archName = switch ($arch) {
+        "Arm64" { "arm64" }
+        "X64" { "x64" }
+        default { throw "Unsupported process architecture for PowerShell CI bootstrap: $arch" }
+    }
+
+    if ($IsWindows) {
+        "PowerShell-$Version-win-$archName.zip"
+    }
+    elseif ($IsMacOS) {
+        "powershell-$Version-osx-$archName.tar.gz"
+    }
+    else {
+        "powershell-$Version-linux-$archName.tar.gz"
+    }
+}
+
+function New-PwshShim {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PwshExe,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TempRoot
+    )
+
+    $shimDir = Join-Path $TempRoot "pwsh-7.4-shims"
+    New-Item -Path $shimDir -ItemType Directory -Force | Out-Null
+
+    $minorShimName = if ($IsWindows) { "pwsh-7.4.cmd" } else { "pwsh-7.4" }
+    $patchShimName = if ($IsWindows) { "pwsh-$Version.cmd" } else { "pwsh-$Version" }
+
+    foreach ($shimName in @($minorShimName, $patchShimName)) {
+        $shimPath = Join-Path $shimDir $shimName
+
+        if ($IsWindows) {
+            $escapedExe = $PwshExe.Replace("%", "%%")
+            "@echo off`r`n`"$escapedExe`" %*`r`n" | Set-Content -Path $shimPath -Encoding ascii -NoNewline
+        }
+        else {
+            @"
+#!/usr/bin/env sh
+exec "$PwshExe" "$@"
+"@ | Set-Content -Path $shimPath -Encoding utf8NoBOM -NoNewline
+            chmod +x $shimPath
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_PATH)) {
+        $shimDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    }
+
+    $env:PATH = "$shimDir$([IO.Path]::PathSeparator)$env:PATH"
+}
+
+$tempRoot = if (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+    $env:RUNNER_TEMP
+}
+else {
+    [IO.Path]::GetTempPath()
+}
+
+$release = Get-PowerShell74Release
+$version = $release.tag_name.TrimStart("v")
+$assetName = Get-AssetName -Version $version
+$asset = $release.assets | Where-Object { $_.name -eq $assetName } | Select-Object -First 1
+
+if ($null -eq $asset) {
+    throw "Unable to find PowerShell asset '$assetName' in release $($release.tag_name)."
+}
+
+$installDir = Join-Path $tempRoot "pwsh-$version"
+$archivePath = Join-Path $tempRoot $assetName
+
+if (Test-Path -Path $installDir) {
+    Remove-Item -Path $installDir -Recurse -Force
+}
+
+New-Item -Path $installDir -ItemType Directory -Force | Out-Null
+
+Write-Host "Downloading $assetName..."
+Invoke-WebRequest -Uri $asset.browser_download_url -Headers (Get-GitHubHeaders) -OutFile $archivePath
+
+if ($assetName.EndsWith(".zip", [StringComparison]::OrdinalIgnoreCase)) {
+    Expand-Archive -Path $archivePath -DestinationPath $installDir -Force
+}
+else {
+    tar -xzf $archivePath -C $installDir
+}
+
+$pwshExeName = if ($IsWindows) { "pwsh.exe" } else { "pwsh" }
+$pwshExe = Join-Path $installDir $pwshExeName
+
+if (-not (Test-Path -Path $pwshExe -PathType Leaf)) {
+    throw "PowerShell executable was not found after extraction: $pwshExe"
+}
+
+if (-not $IsWindows) {
+    chmod +x $pwshExe
+}
+
+New-PwshShim -PwshExe $pwshExe -Version $version -TempRoot $tempRoot
+
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_ENV)) {
+    "PwshExePath=$pwshExe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+}
+
+Write-Host "Installed PowerShell $version for binding discovery: $pwshExe"
+& $pwshExe -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'

--- a/tests/Invoke-ScopedInstallSmokeTest.ps1
+++ b/tests/Invoke-ScopedInstallSmokeTest.ps1
@@ -94,12 +94,7 @@ function Invoke-PwshAlias {
 }
 
 function Get-UserScopeRoot {
-    if ($IsWindows) {
-        Join-Path $env:LOCALAPPDATA "PowerShell"
-    }
-    else {
-        Join-Path $HOME ".pwsh"
-    }
+    Join-Path $HOME ".pwsh"
 }
 
 function Get-UserScopeBin {


### PR DESCRIPTION
## Summary
- keep user-scope installs on the cross-platform `~/.pwsh` layout
- keep Windows machine-scope installs under `%ProgramFiles%\PowerShell`
- document scoped install roots and add an explicit Windows `asInvoker` manifest for the CLI binary
- share the environment-test lock across modules so env-sensitive tests are stable under parallel runs

## Validation
- `rustup toolchain install stable --profile minimal`
- `rustup default stable`
- `rustup component add rustfmt clippy --toolchain stable`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj -p:PwshExePath="C:\Users\mamoreau\AppData\Local\PowerShell\7.4.17\pwsh.exe"`
- `dotnet test dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj --no-build -p:PwshExePath="C:\Users\mamoreau\AppData\Local\PowerShell\7.4.17\pwsh.exe"`