### PR TITLE
Expose flexible apphost package assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "flate2",
  "home",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",

--- a/README.md
+++ b/README.md
@@ -277,7 +277,31 @@ See [docs/host-and-venv.md](docs/host-and-venv.md) for host shims, local replace
 
 ## CLI NuGet package and AppHost mode
 
-`Devolutions.MultiPwsh.Cli` packages RID-specific `multi-pwsh` binaries for .NET projects. It also includes opt-in MSBuild targets for downstream packages that need to copy `multi-pwsh` as a replacement apphost. AppHost mode is inert by default.
+`Devolutions.MultiPwsh.Cli` packages RID-specific `multi-pwsh` binaries under `runtimes/<rid>/native/` for .NET projects. It also exposes neutral MSBuild metadata for downstream packages that need to consume the same binaries as PowerShell apphosts. The package supplies only the native launcher; downstream packages must place it beside their own `pwsh.dll` and `pwsh.runtimeconfig.json`.
+
+Package authors can consume the launchers privately and map them into their own package layout:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.13.0" PrivateAssets="all" />
+</ItemGroup>
+
+<PropertyGroup>
+  <MultiPwshRuntimeNativeContentCopyEnabled>false</MultiPwshRuntimeNativeContentCopyEnabled>
+</PropertyGroup>
+
+<Target Name="StagePowerShellAppHosts" DependsOnTargets="ResolveMultiPwshAppHostAssets">
+  <ItemGroup>
+    <PowerShellSdkAppHost Include="@(MultiPwshAppHostAsset)">
+      <PackagePath>tools/apphost/%(RuntimeIdentifier)/%(AppHostFileName)</PackagePath>
+    </PowerShellSdkAppHost>
+  </ItemGroup>
+</Target>
+```
+
+`@(MultiPwshAppHostAsset)` includes the source path as the item identity plus metadata such as `RuntimeIdentifier`, `NativeFileName`, `AppHostFileName`, `PackageRelativePath`, and `PackageId`. The package also sets `MultiPwshAppHostSupportedRuntimeIdentifiers` and `MultiPwshAppHostManifestPath`.
+
+For a simple single-RID project, AppHost mode can copy the selected binary directly to build and publish output. AppHost mode is inert by default.
 
 ```xml
 <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/latest/download/in
 irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.13.0`):
+Install a specific tag (example `v0.14.0`):
 
 ```bash
-curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.13.0/install-multi-pwsh.sh | bash -s -- v0.13.0
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.14.0/install-multi-pwsh.sh | bash -s -- v0.14.0
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.13.0/install-multi-pwsh.ps1))) -Version v0.13.0
+& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.14.0/install-multi-pwsh.ps1))) -Version v0.14.0
 ```
 
 Uninstall bootstrap scripts:
@@ -283,7 +283,7 @@ Package authors can consume the launchers privately and map them into their own 
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.13.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -305,7 +305,7 @@ For a simple single-RID project, AppHost mode can copy the selected binary direc
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.13.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/multi-pwsh"

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/docs/host-and-venv.md
+++ b/docs/host-and-venv.md
@@ -32,7 +32,7 @@ Typical downstream vendored-SDK usage:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.13.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.AppHost.targets
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.AppHost.targets
@@ -1,5 +1,36 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="ResolveMultiPwshAppHost" Condition="'$(MultiPwshAppHostEnabled)' == 'true'">
+  <Target Name="ResolveMultiPwshAppHostAssets">
+    <PropertyGroup>
+      <MultiPwshAppHostPackageRoot Condition="'$(MultiPwshAppHostPackageRoot)' == ''">$(MSBuildThisFileDirectory)..\</MultiPwshAppHostPackageRoot>
+      <MultiPwshAppHostRuntimeNativeRoot Condition="'$(MultiPwshAppHostRuntimeNativeRoot)' == ''">$(MultiPwshAppHostPackageRoot)runtimes\</MultiPwshAppHostRuntimeNativeRoot>
+      <MultiPwshAppHostManifestPath Condition="'$(MultiPwshAppHostManifestPath)' == ''">$(MultiPwshAppHostPackageRoot)build\Devolutions.MultiPwsh.Cli.AppHostManifest.json</MultiPwshAppHostManifestPath>
+      <MultiPwshAppHostSupportedRuntimeIdentifiers Condition="'$(MultiPwshAppHostSupportedRuntimeIdentifiers)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</MultiPwshAppHostSupportedRuntimeIdentifiers>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_MultiPwshAppHostAssetDefinition Include="win-x64;win-arm64">
+        <NativeFileName>multi-pwsh.exe</NativeFileName>
+        <AppHostFileName>pwsh.exe</AppHostFileName>
+      </_MultiPwshAppHostAssetDefinition>
+      <_MultiPwshAppHostAssetDefinition Include="linux-x64;linux-arm64;osx-x64;osx-arm64">
+        <NativeFileName>multi-pwsh</NativeFileName>
+        <AppHostFileName>pwsh</AppHostFileName>
+      </_MultiPwshAppHostAssetDefinition>
+
+      <MultiPwshAppHostAsset Include="$(MultiPwshAppHostRuntimeNativeRoot)%(_MultiPwshAppHostAssetDefinition.Identity)\native\%(_MultiPwshAppHostAssetDefinition.NativeFileName)"
+                              Condition="Exists('$(MultiPwshAppHostRuntimeNativeRoot)%(_MultiPwshAppHostAssetDefinition.Identity)\native\%(_MultiPwshAppHostAssetDefinition.NativeFileName)')">
+        <RuntimeIdentifier>%(_MultiPwshAppHostAssetDefinition.Identity)</RuntimeIdentifier>
+        <NativeFileName>%(_MultiPwshAppHostAssetDefinition.NativeFileName)</NativeFileName>
+        <AppHostFileName>%(_MultiPwshAppHostAssetDefinition.AppHostFileName)</AppHostFileName>
+        <PackageRelativePath>runtimes/%(_MultiPwshAppHostAssetDefinition.Identity)/native/%(_MultiPwshAppHostAssetDefinition.NativeFileName)</PackageRelativePath>
+        <PackageId>Devolutions.MultiPwsh.Cli</PackageId>
+      </MultiPwshAppHostAsset>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ResolveMultiPwshAppHost"
+          DependsOnTargets="ResolveMultiPwshAppHostAssets"
+          Condition="'$(MultiPwshAppHostEnabled)' == 'true'">
     <PropertyGroup>
       <_MultiPwshAppHostResolvedRuntimeIdentifier Condition="'$(MultiPwshAppHostRuntimeIdentifier)' != ''">$(MultiPwshAppHostRuntimeIdentifier)</_MultiPwshAppHostResolvedRuntimeIdentifier>
       <_MultiPwshAppHostResolvedRuntimeIdentifier Condition="'$(_MultiPwshAppHostResolvedRuntimeIdentifier)' == '' And '$(PowerShellSDKAppHostRuntimeIdentifier)' != ''">$(PowerShellSDKAppHostRuntimeIdentifier)</_MultiPwshAppHostResolvedRuntimeIdentifier>
@@ -18,14 +49,22 @@
       <_MultiPwshAppHostOutputBaseName Condition="'$(_MultiPwshAppHostOutputBaseName)' == ''">multi-pwsh</_MultiPwshAppHostOutputBaseName>
       <_MultiPwshAppHostOutputName Condition="'$(MultiPwshAppHostOutputName)' != ''">$(MultiPwshAppHostOutputName)</_MultiPwshAppHostOutputName>
       <_MultiPwshAppHostOutputName Condition="'$(_MultiPwshAppHostOutputName)' == ''">$(_MultiPwshAppHostOutputBaseName)$(_MultiPwshAppHostExeSuffix)</_MultiPwshAppHostOutputName>
-      <MultiPwshAppHostResolvedNativeBinary>$(MSBuildThisFileDirectory)..\runtimes\$(_MultiPwshAppHostResolvedRuntimeIdentifier)\native\$(_MultiPwshAppHostNativeFileName)</MultiPwshAppHostResolvedNativeBinary>
     </PropertyGroup>
 
-    <Error Condition="!Exists('$(MultiPwshAppHostResolvedNativeBinary)')"
-           Text="Devolutions.MultiPwsh.Cli does not contain a native binary for runtime identifier '$(_MultiPwshAppHostResolvedRuntimeIdentifier)' at '$(MultiPwshAppHostResolvedNativeBinary)'. Supported RIDs are win-x64, win-arm64, linux-x64, linux-arm64, osx-x64, and osx-arm64." />
+    <ItemGroup>
+      <_MultiPwshResolvedAppHostAsset Include="@(MultiPwshAppHostAsset)"
+                                      Condition="'%(MultiPwshAppHostAsset.RuntimeIdentifier)' == '$(_MultiPwshAppHostResolvedRuntimeIdentifier)'" />
+    </ItemGroup>
+
+    <Error Condition="'@(_MultiPwshResolvedAppHostAsset)' == ''"
+           Text="Devolutions.MultiPwsh.Cli does not contain a native binary for runtime identifier '$(_MultiPwshAppHostResolvedRuntimeIdentifier)'. Supported RIDs are $(MultiPwshAppHostSupportedRuntimeIdentifiers)." />
+
+    <PropertyGroup>
+      <MultiPwshAppHostResolvedNativeBinary>@(_MultiPwshResolvedAppHostAsset)</MultiPwshAppHostResolvedNativeBinary>
+    </PropertyGroup>
 
     <ItemGroup>
-      <MultiPwshAppHostNativeBinary Include="$(MultiPwshAppHostResolvedNativeBinary)">
+      <MultiPwshAppHostNativeBinary Include="@(_MultiPwshResolvedAppHostAsset)">
         <RuntimeIdentifier>$(_MultiPwshAppHostResolvedRuntimeIdentifier)</RuntimeIdentifier>
         <OutputName>$(_MultiPwshAppHostOutputName)</OutputName>
       </MultiPwshAppHostNativeBinary>

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.csproj
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.csproj
@@ -19,27 +19,29 @@
     <RepositoryType>git</RepositoryType>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <MultiPwshCliStagingRoot Condition="'$(MultiPwshCliStagingRoot)' == ''">$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh</MultiPwshCliStagingRoot>
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\win-x64\multi-pwsh.exe" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\win-x64\multi-pwsh.exe')">
+    <Content Include="$(MultiPwshCliStagingRoot)\win-x64\multi-pwsh.exe" Pack="true" Condition="Exists('$(MultiPwshCliStagingRoot)\win-x64\multi-pwsh.exe')">
       <PackagePath>runtimes\win-x64\native\multi-pwsh.exe</PackagePath>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\win-arm64\multi-pwsh.exe" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\win-arm64\multi-pwsh.exe')">
+    <Content Include="$(MultiPwshCliStagingRoot)\win-arm64\multi-pwsh.exe" Pack="true" Condition="Exists('$(MultiPwshCliStagingRoot)\win-arm64\multi-pwsh.exe')">
       <PackagePath>runtimes\win-arm64\native\multi-pwsh.exe</PackagePath>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\linux-x64\multi-pwsh" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\linux-x64\multi-pwsh')">
+    <Content Include="$(MultiPwshCliStagingRoot)\linux-x64\multi-pwsh" Pack="true" Condition="Exists('$(MultiPwshCliStagingRoot)\linux-x64\multi-pwsh')">
       <PackagePath>runtimes\linux-x64\native</PackagePath>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\linux-arm64\multi-pwsh" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\linux-arm64\multi-pwsh')">
+    <Content Include="$(MultiPwshCliStagingRoot)\linux-arm64\multi-pwsh" Pack="true" Condition="Exists('$(MultiPwshCliStagingRoot)\linux-arm64\multi-pwsh')">
       <PackagePath>runtimes\linux-arm64\native</PackagePath>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\osx-x64\multi-pwsh" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\osx-x64\multi-pwsh')">
+    <Content Include="$(MultiPwshCliStagingRoot)\osx-x64\multi-pwsh" Pack="true" Condition="Exists('$(MultiPwshCliStagingRoot)\osx-x64\multi-pwsh')">
       <PackagePath>runtimes\osx-x64\native</PackagePath>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\osx-arm64\multi-pwsh" Pack="true" Condition="Exists('$(MSBuildThisFileDirectory)..\..\artifacts\cli\multi-pwsh\osx-arm64\multi-pwsh')">
+    <Content Include="$(MultiPwshCliStagingRoot)\osx-arm64\multi-pwsh" Pack="true" Condition="Exists('$(MultiPwshCliStagingRoot)\osx-arm64\multi-pwsh')">
       <PackagePath>runtimes\osx-arm64\native</PackagePath>
     </Content>
+    <None Include="$(MultiPwshCliStagingRoot)\apphost-manifest.json" Pack="true" PackagePath="build\Devolutions.MultiPwsh.Cli.AppHostManifest.json" Condition="Exists('$(MultiPwshCliStagingRoot)\apphost-manifest.json')" />
     <Content Include="Devolutions.MultiPwsh.Cli.targets" PackagePath="build\Devolutions.MultiPwsh.Cli.targets" Pack="true" />
     <Content Include="Devolutions.MultiPwsh.Cli.props" PackagePath="buildTransitive\Devolutions.MultiPwsh.Cli.props" Pack="true" />
     <Content Include="Devolutions.MultiPwsh.Cli.AppHost.targets" PackagePath="buildTransitive\Devolutions.MultiPwsh.Cli.targets" Pack="true" />

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.props
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.props
@@ -3,5 +3,10 @@
     <MultiPwshAppHostEnabled Condition="'$(MultiPwshAppHostEnabled)' == ''">false</MultiPwshAppHostEnabled>
     <MultiPwshAppHostCopyToOutput Condition="'$(MultiPwshAppHostCopyToOutput)' == ''">true</MultiPwshAppHostCopyToOutput>
     <MultiPwshAppHostCopyToPublish Condition="'$(MultiPwshAppHostCopyToPublish)' == ''">true</MultiPwshAppHostCopyToPublish>
+    <MultiPwshRuntimeNativeContentCopyEnabled Condition="'$(MultiPwshRuntimeNativeContentCopyEnabled)' == ''">true</MultiPwshRuntimeNativeContentCopyEnabled>
+    <MultiPwshAppHostPackageRoot Condition="'$(MultiPwshAppHostPackageRoot)' == ''">$(MSBuildThisFileDirectory)..\</MultiPwshAppHostPackageRoot>
+    <MultiPwshAppHostRuntimeNativeRoot Condition="'$(MultiPwshAppHostRuntimeNativeRoot)' == ''">$(MultiPwshAppHostPackageRoot)runtimes\</MultiPwshAppHostRuntimeNativeRoot>
+    <MultiPwshAppHostManifestPath Condition="'$(MultiPwshAppHostManifestPath)' == ''">$(MultiPwshAppHostPackageRoot)build\Devolutions.MultiPwsh.Cli.AppHostManifest.json</MultiPwshAppHostManifestPath>
+    <MultiPwshAppHostSupportedRuntimeIdentifiers Condition="'$(MultiPwshAppHostSupportedRuntimeIdentifiers)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</MultiPwshAppHostSupportedRuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.targets
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.targets
@@ -1,5 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'win-x64'">
+  <PropertyGroup>
+    <MultiPwshRuntimeNativeContentCopyEnabled Condition="'$(MultiPwshRuntimeNativeContentCopyEnabled)' == ''">true</MultiPwshRuntimeNativeContentCopyEnabled>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(MultiPwshRuntimeNativeContentCopyEnabled)' == 'true' And ('$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'win-x64')">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\multi-pwsh.exe" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\multi-pwsh.exe')">
       <Link>runtimes\win-x64\native\multi-pwsh.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -10,7 +14,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'win-arm64'">
+  <ItemGroup Condition="'$(MultiPwshRuntimeNativeContentCopyEnabled)' == 'true' And ('$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'win-arm64')">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\multi-pwsh.exe" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\multi-pwsh.exe')">
       <Link>runtimes\win-arm64\native\multi-pwsh.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -21,7 +25,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'linux-x64'">
+  <ItemGroup Condition="'$(MultiPwshRuntimeNativeContentCopyEnabled)' == 'true' And ('$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'linux-x64')">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\multi-pwsh')">
       <Link>runtimes\linux-x64\native\multi-pwsh</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -32,7 +36,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'linux-arm64'">
+  <ItemGroup Condition="'$(MultiPwshRuntimeNativeContentCopyEnabled)' == 'true' And ('$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'linux-arm64')">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\native\multi-pwsh')">
       <Link>runtimes\linux-arm64\native\multi-pwsh</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -43,7 +47,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'osx-x64'">
+  <ItemGroup Condition="'$(MultiPwshRuntimeNativeContentCopyEnabled)' == 'true' And ('$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'osx-x64')">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native\multi-pwsh')">
       <Link>runtimes\osx-x64\native\multi-pwsh</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -54,7 +58,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
+  <ItemGroup Condition="'$(MultiPwshRuntimeNativeContentCopyEnabled)' == 'true' And ('$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'osx-arm64')">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\native\multi-pwsh')">
       <Link>runtimes\osx-arm64\native\multi-pwsh</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/nuget/Devolutions.MultiPwsh.Cli/README.md
+++ b/nuget/Devolutions.MultiPwsh.Cli/README.md
@@ -2,7 +2,29 @@
 
 `Devolutions.MultiPwsh.Cli` ships RID-specific `multi-pwsh` native binaries for .NET projects. It also includes opt-in AppHost MSBuild targets for projects that need to copy the same binary as a PowerShell replacement apphost.
 
-The normal CLI payload is copied under `runtimes/<rid>/native/` for build and publish outputs. AppHost mode is inert by default; set `MultiPwshAppHostEnabled=true` to copy the selected RID binary as `multi-pwsh`, `pwsh`, or another explicit file name.
+The normal CLI payload is copied under `runtimes/<rid>/native/` for build and publish outputs. Package authors can disable that content copy and consume neutral apphost metadata instead:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.13.0" PrivateAssets="all" />
+</ItemGroup>
+
+<PropertyGroup>
+  <MultiPwshRuntimeNativeContentCopyEnabled>false</MultiPwshRuntimeNativeContentCopyEnabled>
+</PropertyGroup>
+
+<Target Name="StagePowerShellAppHosts" DependsOnTargets="ResolveMultiPwshAppHostAssets">
+  <ItemGroup>
+    <PowerShellSdkAppHost Include="@(MultiPwshAppHostAsset)">
+      <PackagePath>tools/apphost/%(RuntimeIdentifier)/%(AppHostFileName)</PackagePath>
+    </PowerShellSdkAppHost>
+  </ItemGroup>
+</Target>
+```
+
+`@(MultiPwshAppHostAsset)` includes the source path as the item identity plus `RuntimeIdentifier`, `NativeFileName`, `AppHostFileName`, `PackageRelativePath`, and `PackageId` metadata. The package also provides `MultiPwshAppHostSupportedRuntimeIdentifiers` and `MultiPwshAppHostManifestPath`.
+
+AppHost mode is inert by default; set `MultiPwshAppHostEnabled=true` to copy the selected RID binary as `multi-pwsh`, `pwsh`, or another explicit file name.
 
 ```xml
 <ItemGroup>

--- a/nuget/Devolutions.MultiPwsh.Cli/README.md
+++ b/nuget/Devolutions.MultiPwsh.Cli/README.md
@@ -6,7 +6,7 @@ The normal CLI payload is copied under `runtimes/<rid>/native/` for build and pu
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.13.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -28,7 +28,7 @@ AppHost mode is inert by default; set `MultiPwshAppHostEnabled=true` to copy the
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.13.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/scripts/Build-NativeNuGetPackages.ps1
+++ b/scripts/Build-NativeNuGetPackages.ps1
@@ -85,6 +85,49 @@ function Resolve-RustTarget {
     }
 }
 
+function Resolve-AppHostFileName {
+    param([Parameter(Mandatory)][string]$RuntimeIdentifier)
+
+    if ($RuntimeIdentifier.StartsWith('win-', [System.StringComparison]::OrdinalIgnoreCase)) {
+        'pwsh.exe'
+    }
+    else {
+        'pwsh'
+    }
+}
+
+function New-AppHostManifest {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$PackageId,
+        [Parameter(Mandatory)][string]$PackageVersion,
+        [Parameter(Mandatory)][string[]]$RuntimeIdentifiers
+    )
+
+    $assets = foreach ($rid in $RuntimeIdentifiers) {
+        $target = Resolve-RustTarget -RuntimeIdentifier $rid
+        [ordered]@{
+            runtimeIdentifier = $rid
+            packageRelativePath = "runtimes/$rid/native/$($target['BinaryName'])"
+            nativeFileName = $target['BinaryName']
+            appHostFileName = Resolve-AppHostFileName -RuntimeIdentifier $rid
+        }
+    }
+
+    $manifest = [ordered]@{
+        packageId = $PackageId
+        packageVersion = $PackageVersion
+        supportedRuntimeIdentifiers = $RuntimeIdentifiers
+        requiredAdjacentPayloadFiles = @('pwsh.dll', 'pwsh.runtimeconfig.json')
+        notes = 'This package supplies only the native PowerShell apphost executable. Consumers must place it beside their own PowerShell managed payload.'
+        assets = @($assets)
+    }
+
+    $manifestDirectory = Split-Path -Path $Path -Parent
+    New-Item -Path $manifestDirectory -ItemType Directory -Force | Out-Null
+    $manifest | ConvertTo-Json -Depth 5 | Set-Content -Path $Path -Encoding utf8
+}
+
 function Resolve-PackageProject {
     param([Parameter(Mandatory)][string]$Package)
 
@@ -95,6 +138,7 @@ function Resolve-PackageProject {
                 Project = Join-Path $repoRoot 'nuget\Devolutions.MultiPwsh.Cli\Devolutions.MultiPwsh.Cli.csproj'
                 FixedEntries = @(
                     'build/Devolutions.MultiPwsh.Cli.targets',
+                    'build/Devolutions.MultiPwsh.Cli.AppHostManifest.json',
                     'buildTransitive/Devolutions.MultiPwsh.Cli.props',
                     'buildTransitive/Devolutions.MultiPwsh.Cli.targets',
                     'README.md'
@@ -135,6 +179,7 @@ function Assert-NupkgContents {
     param(
         [Parameter(Mandatory)][string]$PackagePath,
         [Parameter(Mandatory)][hashtable]$PackageInfo,
+        [Parameter(Mandatory)][string]$PackageVersion,
         [Parameter(Mandatory)][string[]]$ExpectedRuntimeIdentifiers
     )
 
@@ -160,6 +205,56 @@ function Assert-NupkgContents {
         foreach ($entry in $expectedEntries) {
             if (-not $actualEntries.ContainsKey($entry)) {
                 throw "Expected package entry '$entry' was not found in $PackagePath"
+            }
+        }
+
+        $manifestEntryName = 'build/Devolutions.MultiPwsh.Cli.AppHostManifest.json'
+        $manifestEntry = $archive.GetEntry($manifestEntryName)
+        if ($null -eq $manifestEntry) {
+            throw "Expected package manifest '$manifestEntryName' was not found in $PackagePath"
+        }
+
+        $reader = [System.IO.StreamReader]::new($manifestEntry.Open())
+        try {
+            $manifest = $reader.ReadToEnd() | ConvertFrom-Json
+        }
+        finally {
+            $reader.Dispose()
+        }
+
+        if ($manifest.packageId -ne $PackageInfo['Id']) {
+            throw "Package manifest packageId mismatch: expected '$($PackageInfo['Id'])', got '$($manifest.packageId)'"
+        }
+
+        if ($manifest.packageVersion -ne $PackageVersion) {
+            throw "Package manifest packageVersion mismatch: expected '$PackageVersion', got '$($manifest.packageVersion)'"
+        }
+
+        $manifestRids = @($manifest.supportedRuntimeIdentifiers)
+        $manifestAssets = @($manifest.assets)
+        foreach ($rid in $ExpectedRuntimeIdentifiers) {
+            if ($manifestRids -notcontains $rid) {
+                throw "Package manifest is missing supported RID '$rid'"
+            }
+
+            $target = Resolve-RustTarget -RuntimeIdentifier $rid
+            $asset = $manifestAssets | Where-Object { $_.runtimeIdentifier -eq $rid } | Select-Object -First 1
+            if ($null -eq $asset) {
+                throw "Package manifest is missing an asset for RID '$rid'"
+            }
+
+            $expectedPackageRelativePath = "runtimes/$rid/native/$($target['BinaryName'])"
+            if ($asset.packageRelativePath -ne $expectedPackageRelativePath) {
+                throw "Package manifest asset path mismatch for '$rid': expected '$expectedPackageRelativePath', got '$($asset.packageRelativePath)'"
+            }
+
+            if ($asset.nativeFileName -ne $target['BinaryName']) {
+                throw "Package manifest native file mismatch for '$rid': expected '$($target['BinaryName'])', got '$($asset.nativeFileName)'"
+            }
+
+            $expectedAppHostFileName = Resolve-AppHostFileName -RuntimeIdentifier $rid
+            if ($asset.appHostFileName -ne $expectedAppHostFileName) {
+                throw "Package manifest apphost file mismatch for '$rid': expected '$expectedAppHostFileName', got '$($asset.appHostFileName)'"
             }
         }
     }
@@ -228,6 +323,8 @@ foreach ($rid in $RuntimeIdentifiers) {
 if (-not $NoPack) {
     foreach ($package in $Packages) {
         $packageInfo = Resolve-PackageProject -Package $package
+        New-AppHostManifest -Path (Join-Path $StagingRoot 'apphost-manifest.json') -PackageId $packageInfo['Id'] -PackageVersion $Version -RuntimeIdentifiers $RuntimeIdentifiers
+
         Invoke-NativeCommand -FilePath dotnet -ArgumentList @(
             'pack',
             $packageInfo['Project'],
@@ -235,6 +332,7 @@ if (-not $NoPack) {
             $Configuration,
             '-o',
             $OutputRoot,
+            "/p:MultiPwshCliStagingRoot=$StagingRoot",
             "/p:Version=$Version",
             '/p:ContinuousIntegrationBuild=true'
         )
@@ -242,6 +340,6 @@ if (-not $NoPack) {
         $packagePath = Join-Path $OutputRoot "$($packageInfo['Id']).$Version.nupkg"
         Assert-FileExists -Path $packagePath
         Set-NupkgUnixExecutablePermissions -PackagePath $packagePath
-        Assert-NupkgContents -PackagePath $packagePath -PackageInfo $packageInfo -ExpectedRuntimeIdentifiers $RuntimeIdentifiers
+        Assert-NupkgContents -PackagePath $packagePath -PackageInfo $packageInfo -PackageVersion $Version -ExpectedRuntimeIdentifiers $RuntimeIdentifiers
     }
 }

--- a/tests/Invoke-AppHostNuGetPackageSmokeTest.ps1
+++ b/tests/Invoke-AppHostNuGetPackageSmokeTest.ps1
@@ -150,13 +150,23 @@ try {
     <SelfContained>false</SelfContained>
     <MultiPwshAppHostEnabled>true</MultiPwshAppHostEnabled>
     <MultiPwshAppHostOutputName>$outputName</MultiPwshAppHostOutputName>
+    <MultiPwshRuntimeNativeContentCopyEnabled>false</MultiPwshRuntimeNativeContentCopyEnabled>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="$packageId" Version="$PackageVersion" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="ValidateResolvedAppHostMetadata" AfterTargets="ResolveMultiPwshAppHost">
+  <Target Name="ValidateResolvedAppHostMetadata" DependsOnTargets="ResolveMultiPwshAppHostAssets" AfterTargets="ResolveMultiPwshAppHost">
+    <ItemGroup>
+      <_CurrentRidAppHostAsset Include="@(MultiPwshAppHostAsset)" Condition="'%(MultiPwshAppHostAsset.RuntimeIdentifier)' == '$RuntimeIdentifier'" />
+    </ItemGroup>
+
+    <Error Condition="'`$(MultiPwshAppHostSupportedRuntimeIdentifiers)' == ''" Text="MultiPwshAppHostSupportedRuntimeIdentifiers was not set." />
+    <Error Condition="'`$(MultiPwshAppHostManifestPath)' == '' Or !Exists('`$(MultiPwshAppHostManifestPath)')" Text="MultiPwshAppHostManifestPath was not set to an existing manifest." />
+    <Error Condition="'@(_CurrentRidAppHostAsset)' == ''" Text="MultiPwshAppHostAsset was not emitted for $RuntimeIdentifier." />
+    <Error Condition="'@(_CurrentRidAppHostAsset)' != '' And '%(_CurrentRidAppHostAsset.AppHostFileName)' != '$outputName'" Text="MultiPwshAppHostAsset AppHostFileName metadata was not '$outputName'." />
+    <Error Condition="'@(_CurrentRidAppHostAsset)' != '' And '%(_CurrentRidAppHostAsset.PackageRelativePath)' == ''" Text="MultiPwshAppHostAsset PackageRelativePath metadata was not set." />
     <Error Condition="'`$(MultiPwshAppHostResolvedNativeBinary)' == ''" Text="MultiPwshAppHostResolvedNativeBinary was not set." />
     <Error Condition="'@(MultiPwshAppHostNativeBinary)' == ''" Text="MultiPwshAppHostNativeBinary item was not set." />
   </Target>
@@ -184,6 +194,7 @@ try {
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>$RuntimeIdentifier</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
+    <MultiPwshRuntimeNativeContentCopyEnabled>false</MultiPwshRuntimeNativeContentCopyEnabled>
   </PropertyGroup>
 
   <ItemGroup>
@@ -201,6 +212,17 @@ try {
         if (Test-Path -Path $unexpectedPath -PathType Leaf) {
             throw "AppHost targets should be inert by default, but found unexpected output: $unexpectedPath"
         }
+    }
+
+    $runtimeNativeName = if ($RuntimeIdentifier.StartsWith('win-', [System.StringComparison]::OrdinalIgnoreCase)) {
+        'multi-pwsh.exe'
+    }
+    else {
+        'multi-pwsh'
+    }
+    $unexpectedRuntimeNativePath = Join-Path $inertOutputDir "runtimes\$RuntimeIdentifier\native\$runtimeNativeName"
+    if (Test-Path -Path $unexpectedRuntimeNativePath -PathType Leaf) {
+        throw "Runtime native content copy should be disabled, but found unexpected output: $unexpectedRuntimeNativePath"
     }
 
     Invoke-CheckedCommand -FilePath dotnet -ArgumentList @('restore', $projectPath, '--configfile', $nugetConfig)


### PR DESCRIPTION
## Summary
- add neutral MSBuild metadata for resolving packaged multi-pwsh apphost launchers by RID
- generate and validate an apphost manifest during native NuGet package creation
- document private build-time consumption and add an opt-out for normal runtime native content copying

## Validation
- `rustup toolchain install stable --profile minimal`
- `rustup default stable`
- `rustup component add rustfmt clippy --toolchain stable`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build .\dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj -p:PwshExePath="C:\Users\mamoreau\.copilot\session-state\e2f1f2c5-0659-44bc-8bc8-dacc2c220905\files\pwsh74\pwsh-7.4.17\pwsh.exe"`
- `dotnet test .\dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj --no-build -p:PwshExePath="C:\Users\mamoreau\.copilot\session-state\e2f1f2c5-0659-44bc-8bc8-dacc2c220905\files\pwsh74\pwsh-7.4.17\pwsh.exe"`
- `pwsh -NoLogo -NoProfile -File .\scripts\Build-NativeNuGetPackages.ps1 -RuntimeIdentifiers win-x64 -Clean`
- `pwsh -NoLogo -NoProfile -File .\tests\Invoke-AppHostNuGetPackageSmokeTest.ps1 -PackageSource .\artifacts\native-nuget -RuntimeIdentifier win-x64`