### PR TITLE
Add linux-arm release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,13 @@ jobs:
             multi_archive: multi-pwsh-linux-arm64.zip
             multi_binary: multi-pwsh
 
+          - name: linux-arm
+            os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            runtime_id: linux-arm
+            multi_archive: multi-pwsh-linux-arm.zip
+            multi_binary: multi-pwsh
+
           - name: windows-x64
             os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -238,6 +245,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
+      - name: Install Linux ARM linker
+        if: matrix.target == 'armv7-unknown-linux-gnueabihf'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-linux-gnueabihf
+
       - name: Configure static MSVC runtime
         if: contains(matrix.target, 'windows-msvc')
         shell: pwsh
@@ -248,6 +261,7 @@ jobs:
         shell: pwsh
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
         run: |
           cargo build --locked --release --package multi-pwsh --bin multi-pwsh --target "${{ matrix.target }}"
 
@@ -559,6 +573,7 @@ jobs:
             @{ Artifact = 'multi-pwsh-nuget-win-arm64'; Rid = 'win-arm64'; Binary = 'multi-pwsh.exe' },
             @{ Artifact = 'multi-pwsh-nuget-linux-x64'; Rid = 'linux-x64'; Binary = 'multi-pwsh' },
             @{ Artifact = 'multi-pwsh-nuget-linux-arm64'; Rid = 'linux-arm64'; Binary = 'multi-pwsh' },
+            @{ Artifact = 'multi-pwsh-nuget-linux-arm'; Rid = 'linux-arm'; Binary = 'multi-pwsh' },
             @{ Artifact = 'multi-pwsh-nuget-osx-x64'; Rid = 'osx-x64'; Binary = 'multi-pwsh' },
             @{ Artifact = 'multi-pwsh-nuget-osx-arm64'; Rid = 'osx-arm64'; Binary = 'multi-pwsh' }
           )

--- a/crates/multi-pwsh/src/main.rs
+++ b/crates/multi-pwsh/src/main.rs
@@ -1614,6 +1614,7 @@ fn multi_pwsh_asset_name(target_os: HostOs, target_arch: HostArch) -> Result<Str
     let arch = match (target_os, target_arch) {
         (_, HostArch::X64) => "x64",
         (HostOs::Windows | HostOs::Macos | HostOs::Linux, HostArch::Arm64) => "arm64",
+        (HostOs::Linux, HostArch::Arm32) => "arm",
         _ => {
             return Err(MultiPwshError::UnsupportedPlatform(format!(
                 "multi-pwsh does not publish an archive for {} {}",
@@ -4101,6 +4102,13 @@ mod tests {
         assert!(options.include_prerelease);
         assert!(options.arch.is_none());
         assert_eq!(options.checksum_source, ChecksumSource::ReleaseAsset);
+    }
+
+    #[test]
+    fn multi_pwsh_asset_name_supports_linux_arm32() {
+        let asset_name = multi_pwsh_asset_name(HostOs::Linux, HostArch::Arm32).unwrap();
+
+        assert_eq!(asset_name, "multi-pwsh-linux-arm.zip");
     }
 
     #[test]

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.AppHost.targets
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.AppHost.targets
@@ -4,7 +4,7 @@
       <MultiPwshAppHostPackageRoot Condition="'$(MultiPwshAppHostPackageRoot)' == ''">$(MSBuildThisFileDirectory)..\</MultiPwshAppHostPackageRoot>
       <MultiPwshAppHostRuntimeNativeRoot Condition="'$(MultiPwshAppHostRuntimeNativeRoot)' == ''">$(MultiPwshAppHostPackageRoot)runtimes\</MultiPwshAppHostRuntimeNativeRoot>
       <MultiPwshAppHostManifestPath Condition="'$(MultiPwshAppHostManifestPath)' == ''">$(MultiPwshAppHostPackageRoot)build\Devolutions.MultiPwsh.Cli.AppHostManifest.json</MultiPwshAppHostManifestPath>
-      <MultiPwshAppHostSupportedRuntimeIdentifiers Condition="'$(MultiPwshAppHostSupportedRuntimeIdentifiers)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</MultiPwshAppHostSupportedRuntimeIdentifiers>
+      <MultiPwshAppHostSupportedRuntimeIdentifiers Condition="'$(MultiPwshAppHostSupportedRuntimeIdentifiers)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64</MultiPwshAppHostSupportedRuntimeIdentifiers>
     </PropertyGroup>
 
     <ItemGroup>
@@ -12,7 +12,7 @@
         <NativeFileName>multi-pwsh.exe</NativeFileName>
         <AppHostFileName>pwsh.exe</AppHostFileName>
       </_MultiPwshAppHostAssetDefinition>
-      <_MultiPwshAppHostAssetDefinition Include="linux-x64;linux-arm64;osx-x64;osx-arm64">
+      <_MultiPwshAppHostAssetDefinition Include="linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64">
         <NativeFileName>multi-pwsh</NativeFileName>
         <AppHostFileName>pwsh</AppHostFileName>
       </_MultiPwshAppHostAssetDefinition>

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.csproj
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.csproj
@@ -35,6 +35,9 @@
     <Content Include="$(MultiPwshCliStagingRoot)\linux-arm64\multi-pwsh" Pack="true" Condition="Exists('$(MultiPwshCliStagingRoot)\linux-arm64\multi-pwsh')">
       <PackagePath>runtimes\linux-arm64\native</PackagePath>
     </Content>
+    <Content Include="$(MultiPwshCliStagingRoot)\linux-arm\multi-pwsh" Pack="true" Condition="Exists('$(MultiPwshCliStagingRoot)\linux-arm\multi-pwsh')">
+      <PackagePath>runtimes\linux-arm\native</PackagePath>
+    </Content>
     <Content Include="$(MultiPwshCliStagingRoot)\osx-x64\multi-pwsh" Pack="true" Condition="Exists('$(MultiPwshCliStagingRoot)\osx-x64\multi-pwsh')">
       <PackagePath>runtimes\osx-x64\native</PackagePath>
     </Content>

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.props
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.props
@@ -7,6 +7,6 @@
     <MultiPwshAppHostPackageRoot Condition="'$(MultiPwshAppHostPackageRoot)' == ''">$(MSBuildThisFileDirectory)..\</MultiPwshAppHostPackageRoot>
     <MultiPwshAppHostRuntimeNativeRoot Condition="'$(MultiPwshAppHostRuntimeNativeRoot)' == ''">$(MultiPwshAppHostPackageRoot)runtimes\</MultiPwshAppHostRuntimeNativeRoot>
     <MultiPwshAppHostManifestPath Condition="'$(MultiPwshAppHostManifestPath)' == ''">$(MultiPwshAppHostPackageRoot)build\Devolutions.MultiPwsh.Cli.AppHostManifest.json</MultiPwshAppHostManifestPath>
-    <MultiPwshAppHostSupportedRuntimeIdentifiers Condition="'$(MultiPwshAppHostSupportedRuntimeIdentifiers)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</MultiPwshAppHostSupportedRuntimeIdentifiers>
+    <MultiPwshAppHostSupportedRuntimeIdentifiers Condition="'$(MultiPwshAppHostSupportedRuntimeIdentifiers)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64</MultiPwshAppHostSupportedRuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.targets
+++ b/nuget/Devolutions.MultiPwsh.Cli/Devolutions.MultiPwsh.Cli.targets
@@ -47,6 +47,17 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(MultiPwshRuntimeNativeContentCopyEnabled)' == 'true' And ('$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'linux-arm')">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-arm\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-arm\native\multi-pwsh')">
+      <Link>runtimes\linux-arm\native\multi-pwsh</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <PublishState>Included</PublishState>
+      <Visible>false</Visible>
+      <Pack>false</Pack>
+    </Content>
+  </ItemGroup>
+
   <ItemGroup Condition="'$(MultiPwshRuntimeNativeContentCopyEnabled)' == 'true' And ('$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'osx-x64')">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native\multi-pwsh" Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native\multi-pwsh')">
       <Link>runtimes\osx-x64\native\multi-pwsh</Link>

--- a/scripts/Build-CliNativeNuGetPackage.ps1
+++ b/scripts/Build-CliNativeNuGetPackage.ps1
@@ -8,7 +8,7 @@ param(
 
     [string]$OutputRoot,
 
-    [string[]]$RuntimeIdentifiers = @('win-x64', 'win-arm64', 'linux-x64', 'linux-arm64', 'osx-x64', 'osx-arm64'),
+    [string[]]$RuntimeIdentifiers = @('win-x64', 'win-arm64', 'linux-x64', 'linux-arm64', 'linux-arm', 'osx-x64', 'osx-arm64'),
 
     [switch]$NoBuild,
 

--- a/scripts/Build-NativeNuGetPackages.ps1
+++ b/scripts/Build-NativeNuGetPackages.ps1
@@ -8,7 +8,7 @@ param(
 
     [string]$OutputRoot,
 
-    [string[]]$RuntimeIdentifiers = @('win-x64', 'win-arm64', 'linux-x64', 'linux-arm64', 'osx-x64', 'osx-arm64'),
+    [string[]]$RuntimeIdentifiers = @('win-x64', 'win-arm64', 'linux-x64', 'linux-arm64', 'linux-arm', 'osx-x64', 'osx-arm64'),
 
     [ValidateSet('Cli')]
     [string[]]$Packages = @('Cli'),
@@ -79,6 +79,7 @@ function Resolve-RustTarget {
         'win-arm64' { @{ CargoTarget = 'aarch64-pc-windows-msvc'; BinaryName = 'multi-pwsh.exe' } }
         'linux-x64' { @{ CargoTarget = 'x86_64-unknown-linux-gnu'; BinaryName = 'multi-pwsh' } }
         'linux-arm64' { @{ CargoTarget = 'aarch64-unknown-linux-gnu'; BinaryName = 'multi-pwsh' } }
+        'linux-arm' { @{ CargoTarget = 'armv7-unknown-linux-gnueabihf'; BinaryName = 'multi-pwsh' } }
         'osx-x64' { @{ CargoTarget = 'x86_64-apple-darwin'; BinaryName = 'multi-pwsh' } }
         'osx-arm64' { @{ CargoTarget = 'aarch64-apple-darwin'; BinaryName = 'multi-pwsh' } }
         default { throw "Unsupported runtime identifier: $RuntimeIdentifier" }
@@ -290,6 +291,7 @@ foreach ($rid in $RuntimeIdentifiers) {
 
     if (-not $NoBuild) {
         $env:CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = 'aarch64-linux-gnu-gcc'
+        $env:CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER = 'arm-linux-gnueabihf-gcc'
         $previousRustFlags = $env:RUSTFLAGS
         try {
             if ($target['CargoTarget'] -like '*-windows-msvc') {

--- a/tools/install-multi-pwsh.sh
+++ b/tools/install-multi-pwsh.sh
@@ -90,8 +90,9 @@ uname_m="$(uname -m)"
 case "${uname_m}" in
   x86_64 | amd64) arch="x64" ;;
   aarch64 | arm64) arch="arm64" ;;
+  armv7l | armv7* | armhf) arch="arm" ;;
   *)
-    echo "Unsupported architecture: ${uname_m}. Supported arch: x86_64/amd64, aarch64/arm64." >&2
+    echo "Unsupported architecture: ${uname_m}. Supported arch: x86_64/amd64, aarch64/arm64, armv7/armhf." >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
Add linux-arm as a first-class multi-pwsh release and NuGet runtime target. Wire the armv7 Linux Rust target into release builds, package manifests, AppHost targets, cache artifact selection, and the Unix bootstrap installer.