### PR TITLE
chore: bump version to 0.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "flate2",
  "home",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/latest/download/in
 irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.14.1`):
+Install a specific tag (example `v0.14.2`):
 
 ```bash
-curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.14.1/install-multi-pwsh.sh | bash -s -- v0.14.1
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.14.2/install-multi-pwsh.sh | bash -s -- v0.14.2
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.14.1/install-multi-pwsh.ps1))) -Version v0.14.1
+& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.14.2/install-multi-pwsh.ps1))) -Version v0.14.2
 ```
 
 Uninstall bootstrap scripts:
@@ -288,7 +288,7 @@ Package authors can consume the launchers privately and map them into their own 
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.1" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.2" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -310,7 +310,7 @@ For a simple single-RID project, AppHost mode can copy the selected binary direc
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.1" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.2" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/multi-pwsh"

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/docs/host-and-venv.md
+++ b/docs/host-and-venv.md
@@ -33,7 +33,7 @@ Typical downstream vendored-SDK usage:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.1" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.2" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/nuget/Devolutions.MultiPwsh.Cli/README.md
+++ b/nuget/Devolutions.MultiPwsh.Cli/README.md
@@ -6,7 +6,7 @@ The normal CLI payload is copied under `runtimes/<rid>/native/` for build and pu
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.1" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.2" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -28,7 +28,7 @@ AppHost mode is inert by default; set `MultiPwshAppHostEnabled=true` to copy the
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.1" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.2" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>


### PR DESCRIPTION
Bump crate versions and documentation references from 0.14.1 to 0.14.2.

Updated files:
- `crates/multi-pwsh/Cargo.toml`
- `crates/pwsh-host/Cargo.toml`
- `Cargo.lock`
- `README.md`
- `nuget/Devolutions.MultiPwsh.Cli/README.md`
- `docs/host-and-venv.md`