### PR TITLE
chore: bump version to 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "flate2",
  "home",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-sdk-ffi"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "pwsh-host",
  "winresource",

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/latest/download/in
 irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.14.2`):
+Install a specific tag (example `v0.15.0`):
 
 ```bash
-curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.14.2/install-multi-pwsh.sh | bash -s -- v0.14.2
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.15.0/install-multi-pwsh.sh | bash -s -- v0.15.0
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.14.2/install-multi-pwsh.ps1))) -Version v0.14.2
+& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.15.0/install-multi-pwsh.ps1))) -Version v0.15.0
 ```
 
 Uninstall bootstrap scripts:
@@ -289,7 +289,7 @@ Package authors can consume the launchers privately and map them into their own 
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.2" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.15.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -311,7 +311,7 @@ For a simple single-RID project, AppHost mode can copy the selected binary direc
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.2" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.15.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/multi-pwsh"

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/crates/pwsh-sdk-ffi/Cargo.toml
+++ b/crates/pwsh-sdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-sdk-ffi"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 publish = false

--- a/docs/host-and-venv.md
+++ b/docs/host-and-venv.md
@@ -33,7 +33,7 @@ Typical downstream vendored-SDK usage:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.2" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.15.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Devolutions.MultiPwsh.Sdk</AssemblyName>
     <PackageId>Devolutions.MultiPwsh.Sdk</PackageId>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.14.2</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.15.0</PackageVersion>
     <Authors>Devolutions</Authors>
     <Description>Experimental dynamically selected PowerShell payload facade for the in-process NativeAOT Devolutions Rust FFI.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/nuget/Devolutions.MultiPwsh.Cli/README.md
+++ b/nuget/Devolutions.MultiPwsh.Cli/README.md
@@ -6,7 +6,7 @@ The normal CLI payload is copied under `runtimes/<rid>/native/` for build and pu
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.2" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.15.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -28,7 +28,7 @@ AppHost mode is inert by default; set `MultiPwshAppHostEnabled=true` to copy the
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.14.2" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.15.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/scripts/Bump-CrateVersions.ps1
+++ b/scripts/Bump-CrateVersions.ps1
@@ -13,6 +13,7 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $cratesRoot = Join-Path $repoRoot 'crates'
 $readmePath = Join-Path $repoRoot 'README.md'
+$sdkProjectPath = Join-Path $repoRoot 'dotnet\sdk-ffi\Devolutions.MultiPwsh.Sdk.csproj'
 $packageExamplePaths = @(
     $readmePath,
     (Join-Path $repoRoot 'docs\host-and-venv.md'),
@@ -34,6 +35,7 @@ if (-not $cargoFiles) {
 $encoding = New-Object System.Text.UTF8Encoding($false)
 $updated = @()
 $readmeUpdated = $false
+$sdkProjectUpdated = $false
 $packageExamplesUpdated = @()
 
 foreach ($cargoFile in $cargoFiles) {
@@ -113,6 +115,28 @@ if (Test-Path -Path $readmePath -PathType Leaf) {
     }
 }
 
+if (Test-Path -Path $sdkProjectPath -PathType Leaf) {
+    $sdkProjectContent = [System.IO.File]::ReadAllText($sdkProjectPath)
+    $newSdkProjectContent = [System.Text.RegularExpressions.Regex]::Replace(
+        $sdkProjectContent,
+        '(?<prefix><PackageVersion\b[^>]*>)(?<current>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?<suffix></PackageVersion>)',
+        [System.Text.RegularExpressions.MatchEvaluator] {
+            param($sdkProjectMatch)
+            $sdkProjectMatch.Groups['prefix'].Value + $Version + $sdkProjectMatch.Groups['suffix'].Value
+        },
+        [System.Text.RegularExpressions.RegexOptions]::None,
+        [System.TimeSpan]::FromSeconds(5)
+    )
+
+    if ($newSdkProjectContent -ne $sdkProjectContent) {
+        if (-not $DryRun) {
+            [System.IO.File]::WriteAllText($sdkProjectPath, $newSdkProjectContent, $encoding)
+        }
+
+        $sdkProjectUpdated = $true
+    }
+}
+
 foreach ($packageExamplePath in $packageExamplePaths) {
     if (-not (Test-Path -Path $packageExamplePath -PathType Leaf)) {
         continue
@@ -139,7 +163,7 @@ foreach ($packageExamplePath in $packageExamplePaths) {
     }
 }
 
-if ($updated.Count -eq 0 -and -not $readmeUpdated -and $packageExamplesUpdated.Count -eq 0) {
+if ($updated.Count -eq 0 -and -not $readmeUpdated -and -not $sdkProjectUpdated -and $packageExamplesUpdated.Count -eq 0) {
     Write-Host "All crate package versions are already $Version"
     if (Test-Path -Path $readmePath -PathType Leaf) {
         Write-Host "No README release example tag needed updating"
@@ -157,6 +181,10 @@ if ($updated.Count -gt 0) {
 
 if ($readmeUpdated) {
     Write-Host "Updated README release example tag in: $readmePath"
+}
+
+if ($sdkProjectUpdated) {
+    Write-Host "Updated SDK package version in: $sdkProjectPath"
 }
 
 if ($packageExamplesUpdated.Count -gt 0) {


### PR DESCRIPTION
## Summary
- bump Rust crate and SDK package versions to 0.15.0
- update release and NuGet package-reference documentation
- include the SDK package in the version-bump helper

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj`
- `dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build`