### PR TITLE
Fix macOS Intel release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -721,7 +721,7 @@ jobs:
             runtime_id: win-x64
           - os: ubuntu-latest
             runtime_id: linux-x64
-          - os: macos-13
+          - os: macos-15-intel
             runtime_id: osx-x64
           - os: macos-14
             runtime_id: osx-arm64


### PR DESCRIPTION
## Summary
- replace retired `macos-13` with `macos-15-intel` for the `osx-x64` SDK native asset smoke job
- retain `macos-14` for the `osx-arm64` job

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj -p:PwshExePath=...`
- `dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build -p:PwshExePath=...`