### PR TITLE
Add generic live object contract packs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Run multi-pwsh venv integration tests
         shell: pwsh
-        run: cargo test -p multi-pwsh --test cli_args venv
+        run: cargo test -p multi-pwsh --test cli_args venv -- --test-threads=1
 
       - name: Build .NET project
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
         run: |
           dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj -c Release -p:PwshExePath="$env:PwshExePath"
           $env:PWSH_FFI_PAYLOAD = Split-Path -Parent $env:PwshExePath
-          cargo test -p pwsh-sdk-ffi -- --ignored
+          cargo test -p pwsh-sdk-ffi -- --ignored --test-threads=1
 
       - name: Run PATH-resolved NativeAOT SDK sample
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         run: cargo build --all-targets
 
       - name: Run Rust tests
-        run: cargo test --all-targets
+        run: cargo test --all-targets -- --test-threads=1
 
       - name: Run multi-pwsh venv integration tests
         shell: pwsh

--- a/crates/pwsh-host/src/bindings.rs
+++ b/crates/pwsh-host/src/bindings.rs
@@ -12,8 +12,8 @@ pub(crate) use self::bindings_generated::Bindings;
 use self::bindings_generated::PowerShellHandle;
 pub(crate) use self::ffi::FfiBindings;
 pub use self::ffi::{
-    FfiBindingError, FfiInvocationResult, FfiPowerShell, FfiPowerShellSession, FfiSessionEvent, FfiSessionSnapshot,
-    FfiSnapshotValue,
+    FfiBindingError, FfiInvocationResult, FfiLiveObjectContractDescriptor, FfiPowerShell, FfiPowerShellSession,
+    FfiSessionEvent, FfiSessionSnapshot, FfiSnapshotValue,
 };
 use crate::loader::HostedRuntime;
 

--- a/crates/pwsh-host/src/bindings/ffi.rs
+++ b/crates/pwsh-host/src/bindings/ffi.rs
@@ -20,6 +20,9 @@ const FFI_FEATURE_SNAPSHOT_PROJECTIONS: u64 = 1 << 13;
 const FFI_FEATURE_SESSION_CONFIGURATION: u64 = 1 << 14;
 const FFI_FEATURE_SESSION_VARIABLES: u64 = 1 << 15;
 const FFI_FEATURE_CAPABILITY_RPC: u64 = 1 << 16;
+const FFI_FEATURE_LIVE_OBJECT_PROBE: u64 = 1 << 17;
+const FFI_FEATURE_LIVE_SESSION_OBJECT_PROBE: u64 = 1 << 18;
+const FFI_FEATURE_LIVE_OBJECT_CONTRACTS: u64 = 1 << 19;
 const STATUS_SUCCESS: i32 = 0;
 const STATUS_BUFFER_TOO_SMALL: i32 = 1;
 
@@ -32,6 +35,18 @@ struct FfiCallResult {
     diagnostic_capacity: i32,
     diagnostic_required_length: i32,
     diagnostic_written_length: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FfiLiveObjectContractDescriptor {
+    pub size: u32,
+    pub directions: u32,
+    pub interface_id_low: u64,
+    pub interface_id_high: u64,
+    pub major_version: u16,
+    pub minor_version: u16,
+    pub reserved: u32,
 }
 
 #[repr(C)]
@@ -82,6 +97,14 @@ struct FfiApiV2 {
     session_remove_variable_fn: *const libc::c_void,
     session_get_variable_snapshot_fn: *const libc::c_void,
     power_shell_set_capability_context_fn: *const libc::c_void,
+    live_object_probe_create_fn: *const libc::c_void,
+    live_object_probe_release_fn: *const libc::c_void,
+    live_object_probe_unregister_fn: *const libc::c_void,
+    power_shell_add_argument_live_object_fn: *const libc::c_void,
+    power_shell_session_set_live_object_variable_fn: *const libc::c_void,
+    live_object_contract_pack_register_fn: *const libc::c_void,
+    power_shell_session_set_live_object_contract_variable_fn: *const libc::c_void,
+    live_object_contract_pack_register_many_fn: *const libc::c_void,
 }
 
 type FnBindingsGetFfiApiV2 = unsafe extern "system" fn() -> *const FfiApiV2;
@@ -177,6 +200,19 @@ type FnFfiPowerShellSessionGetEventInfo =
     unsafe extern "system" fn(PowerShellHandle, i32, *mut i64, *mut u32, *mut u32, *mut FfiCallResult) -> i32;
 type FnFfiPowerShellSessionSetVariable =
     unsafe extern "system" fn(PowerShellHandle, *const u8, i32, u32, *const u8, i32, *mut FfiCallResult) -> i32;
+type FnFfiPowerShellSessionSetLiveObjectVariable =
+    unsafe extern "system" fn(PowerShellHandle, *const u8, i32, *mut libc::c_void, *mut FfiCallResult) -> i32;
+type FnFfiLiveObjectContractPackRegister = unsafe extern "system" fn(*mut libc::c_void, *mut FfiCallResult) -> i32;
+type FnFfiLiveObjectContractPackRegisterMany =
+    unsafe extern "system" fn(*const *mut libc::c_void, u32, *mut FfiCallResult) -> i32;
+type FnFfiPowerShellSessionSetLiveObjectContractVariable = unsafe extern "system" fn(
+    PowerShellHandle,
+    *const u8,
+    i32,
+    *const FfiLiveObjectContractDescriptor,
+    *mut libc::c_void,
+    *mut FfiCallResult,
+) -> i32;
 type FnFfiPowerShellSessionRemoveVariable =
     unsafe extern "system" fn(PowerShellHandle, *const u8, i32, *mut u32, *mut FfiCallResult) -> i32;
 type FnFfiPowerShellSessionGetVariableSnapshot = unsafe extern "system" fn(
@@ -216,6 +252,11 @@ type FnFfiInvocationResultCopyStreamRecordValue = unsafe extern "system" fn(
     *mut i32,
     *mut FfiCallResult,
 ) -> i32;
+type FnFfiLiveObjectProbeCreate = unsafe extern "system" fn(i64, *mut *mut libc::c_void, *mut FfiCallResult) -> i32;
+type FnFfiLiveObjectProbeRelease = unsafe extern "system" fn(*mut libc::c_void, *mut FfiCallResult) -> i32;
+type FnFfiLiveObjectProbeUnregister = unsafe extern "system" fn(*mut libc::c_void, *mut FfiCallResult) -> i32;
+type FnFfiPowerShellAddLiveObject =
+    unsafe extern "system" fn(PowerShellHandle, *mut libc::c_void, *mut FfiCallResult) -> i32;
 
 #[derive(Clone, Copy)]
 pub(crate) struct FfiBindings {
@@ -261,6 +302,14 @@ pub(crate) struct FfiBindings {
     session_remove_variable_fn: FnFfiPowerShellSessionRemoveVariable,
     session_get_variable_snapshot_fn: FnFfiPowerShellSessionGetVariableSnapshot,
     power_shell_set_capability_context_fn: FnFfiPowerShellSetCapabilityContext,
+    live_object_probe_create_fn: FnFfiLiveObjectProbeCreate,
+    live_object_probe_release_fn: FnFfiLiveObjectProbeRelease,
+    live_object_probe_unregister_fn: FnFfiLiveObjectProbeUnregister,
+    power_shell_add_argument_live_object_fn: FnFfiPowerShellAddLiveObject,
+    power_shell_session_set_live_object_variable_fn: FnFfiPowerShellSessionSetLiveObjectVariable,
+    live_object_contract_pack_register_fn: FnFfiLiveObjectContractPackRegister,
+    power_shell_session_set_live_object_contract_variable_fn: FnFfiPowerShellSessionSetLiveObjectContractVariable,
+    live_object_contract_pack_register_many_fn: FnFfiLiveObjectContractPackRegisterMany,
 }
 
 #[derive(Debug)]
@@ -331,14 +380,20 @@ impl FfiBindings {
                     | FFI_FEATURE_SNAPSHOT_PROJECTIONS
                     | FFI_FEATURE_SESSION_CONFIGURATION
                     | FFI_FEATURE_SESSION_VARIABLES
-                    | FFI_FEATURE_CAPABILITY_RPC)
+                    | FFI_FEATURE_CAPABILITY_RPC
+                    | FFI_FEATURE_LIVE_OBJECT_PROBE
+                    | FFI_FEATURE_LIVE_SESSION_OBJECT_PROBE
+                    | FFI_FEATURE_LIVE_OBJECT_CONTRACTS)
                 != (FFI_FEATURE_ASYNC_OPERATION_PRIMITIVES
                     | FFI_FEATURE_SESSION_PRIMITIVES
                     | FFI_FEATURE_SESSION_POLLING
                     | FFI_FEATURE_SNAPSHOT_PROJECTIONS
                     | FFI_FEATURE_SESSION_CONFIGURATION
                     | FFI_FEATURE_SESSION_VARIABLES
-                    | FFI_FEATURE_CAPABILITY_RPC)
+                    | FFI_FEATURE_CAPABILITY_RPC
+                    | FFI_FEATURE_LIVE_OBJECT_PROBE
+                    | FFI_FEATURE_LIVE_SESSION_OBJECT_PROBE
+                    | FFI_FEATURE_LIVE_OBJECT_CONTRACTS)
         {
             return Err(Error::IO(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -389,6 +444,14 @@ impl FfiBindings {
             api.session_remove_variable_fn,
             api.session_get_variable_snapshot_fn,
             api.power_shell_set_capability_context_fn,
+            api.live_object_probe_create_fn,
+            api.live_object_probe_release_fn,
+            api.live_object_probe_unregister_fn,
+            api.power_shell_add_argument_live_object_fn,
+            api.power_shell_session_set_live_object_variable_fn,
+            api.live_object_contract_pack_register_fn,
+            api.power_shell_session_set_live_object_contract_variable_fn,
+            api.live_object_contract_pack_register_many_fn,
         ];
         if fields.iter().any(|field| field.is_null()) {
             return Err(Error::IO(std::io::Error::new(
@@ -548,7 +611,135 @@ impl FfiBindings {
                     api.power_shell_set_capability_context_fn,
                 )
             },
+            live_object_probe_create_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveObjectProbeCreate>(api.live_object_probe_create_fn)
+            },
+            live_object_probe_release_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveObjectProbeRelease>(api.live_object_probe_release_fn)
+            },
+            live_object_probe_unregister_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveObjectProbeUnregister>(
+                    api.live_object_probe_unregister_fn,
+                )
+            },
+            power_shell_add_argument_live_object_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiPowerShellAddLiveObject>(
+                    api.power_shell_add_argument_live_object_fn,
+                )
+            },
+            power_shell_session_set_live_object_variable_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiPowerShellSessionSetLiveObjectVariable>(
+                    api.power_shell_session_set_live_object_variable_fn,
+                )
+            },
+            live_object_contract_pack_register_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveObjectContractPackRegister>(
+                    api.live_object_contract_pack_register_fn,
+                )
+            },
+            power_shell_session_set_live_object_contract_variable_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiPowerShellSessionSetLiveObjectContractVariable>(
+                    api.power_shell_session_set_live_object_contract_variable_fn,
+                )
+            },
+            live_object_contract_pack_register_many_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveObjectContractPackRegisterMany>(
+                    api.live_object_contract_pack_register_many_fn,
+                )
+            },
         })
+    }
+
+    pub(crate) fn create_live_object_probe(&self, initial_count: i64) -> Result<*mut libc::c_void, FfiBindingError> {
+        let mut com_object = std::ptr::null_mut();
+        let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+        let mut call_result = new_call_result(&mut diagnostic);
+        let status = unsafe { (self.live_object_probe_create_fn)(initial_count, &mut com_object, &mut call_result) };
+        check_status(status, &call_result, &diagnostic)?;
+        if com_object.is_null() {
+            return Err(FfiBindingError::from_status(
+                -6,
+                "managed live object probe creation returned a null pointer".to_owned(),
+            ));
+        }
+
+        Ok(com_object)
+    }
+
+    pub(crate) fn release_live_object_probe(&self, com_object: *mut libc::c_void) -> Result<(), FfiBindingError> {
+        if com_object.is_null() {
+            return Err(FfiBindingError::from_status(
+                -1,
+                "live object probe pointer is null".to_owned(),
+            ));
+        }
+
+        let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+        let mut call_result = new_call_result(&mut diagnostic);
+        let status = unsafe { (self.live_object_probe_release_fn)(com_object, &mut call_result) };
+        check_status(status, &call_result, &diagnostic)
+    }
+
+    pub(crate) fn unregister_live_object_probe(&self, com_object: *mut libc::c_void) -> Result<(), FfiBindingError> {
+        if com_object.is_null() {
+            return Err(FfiBindingError::from_status(
+                -1,
+                "live object probe pointer is null".to_owned(),
+            ));
+        }
+
+        let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+        let mut call_result = new_call_result(&mut diagnostic);
+        let status = unsafe { (self.live_object_probe_unregister_fn)(com_object, &mut call_result) };
+        check_status(status, &call_result, &diagnostic)
+    }
+
+    /// # Safety
+    ///
+    /// `pack_api` must be a valid `NativeLiveObjectContractPackApi` pointer
+    /// produced by an assembly loaded into the active payload runtime.
+    pub(crate) unsafe fn register_live_object_contract_pack(
+        &self,
+        pack_api: *mut libc::c_void,
+    ) -> Result<(), FfiBindingError> {
+        if pack_api.is_null() {
+            return Err(FfiBindingError::from_status(
+                -1,
+                "live object contract pack API pointer is null".to_owned(),
+            ));
+        }
+
+        let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+        let mut call_result = new_call_result(&mut diagnostic);
+        let status = unsafe { (self.live_object_contract_pack_register_fn)(pack_api, &mut call_result) };
+        check_status(status, &call_result, &diagnostic)
+    }
+
+    /// # Safety
+    ///
+    /// Every pointer in `pack_apis` must identify a valid
+    /// `NativeLiveObjectContractPackApi` from the active payload runtime.
+    pub(crate) unsafe fn register_live_object_contract_packs(
+        &self,
+        pack_apis: &[*mut libc::c_void],
+    ) -> Result<(), FfiBindingError> {
+        if pack_apis.is_empty() || pack_apis.len() > 16 || pack_apis.iter().any(|api| api.is_null()) {
+            return Err(FfiBindingError::from_status(
+                -1,
+                "live object contract pack inputs are invalid".to_owned(),
+            ));
+        }
+
+        let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+        let mut call_result = new_call_result(&mut diagnostic);
+        let status = unsafe {
+            (self.live_object_contract_pack_register_many_fn)(
+                pack_apis.as_ptr(),
+                pack_apis.len() as u32,
+                &mut call_result,
+            )
+        };
+        check_status(status, &call_result, &diagnostic)
     }
 }
 
@@ -635,6 +826,23 @@ impl FfiPowerShell {
     pub fn add_argument_value(&self, kind: u32, payload: &[u8]) -> Result<(), FfiBindingError> {
         self.with_value(kind, payload, |handle, kind, bytes, length, result| unsafe {
             (self.bindings.add_argument_value_fn)(handle, kind, bytes, length, result)
+        })
+    }
+
+    /// # Safety
+    ///
+    /// `com_object` must be a valid IUnknown pointer for the built-in probe
+    /// contract and must remain valid for the managed projection call.
+    pub unsafe fn add_argument_live_object(&self, com_object: *mut libc::c_void) -> Result<(), FfiBindingError> {
+        if com_object.is_null() {
+            return Err(FfiBindingError::from_status(
+                -1,
+                "live object probe pointer is null".to_owned(),
+            ));
+        }
+
+        self.call(|handle, result| unsafe {
+            (self.bindings.power_shell_add_argument_live_object_fn)(handle, com_object, result)
         })
     }
 
@@ -1090,6 +1298,76 @@ impl FfiPowerShellSession {
                 kind,
                 payload.as_ptr(),
                 payload_length,
+                &mut call_result,
+            )
+        };
+        check_status(status, &call_result, &diagnostic)
+    }
+
+    /// # Safety
+    ///
+    /// `com_object` must be a valid IUnknown pointer for the built-in probe
+    /// contract and must remain valid for the managed projection call.
+    pub unsafe fn set_live_object_variable(
+        &self,
+        name: &str,
+        com_object: *mut libc::c_void,
+    ) -> Result<(), FfiBindingError> {
+        if com_object.is_null() {
+            return Err(FfiBindingError::from_status(
+                -1,
+                "live session object probe pointer is null".to_owned(),
+            ));
+        }
+
+        let handle = self
+            .handle
+            .ok_or_else(|| FfiBindingError::from_status(-4, "PowerShell session has been released".to_owned()))?;
+        let name_length = checked_utf8_length(name)?;
+        let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+        let mut call_result = new_call_result(&mut diagnostic);
+        let status = unsafe {
+            (self.bindings.power_shell_session_set_live_object_variable_fn)(
+                handle,
+                name.as_ptr(),
+                name_length,
+                com_object,
+                &mut call_result,
+            )
+        };
+        check_status(status, &call_result, &diagnostic)
+    }
+
+    /// # Safety
+    ///
+    /// `com_object` must be a valid IUnknown pointer that implements
+    /// `contract` and must remain valid for the managed projection call.
+    pub unsafe fn set_live_object_contract_variable(
+        &self,
+        name: &str,
+        contract: &FfiLiveObjectContractDescriptor,
+        com_object: *mut libc::c_void,
+    ) -> Result<(), FfiBindingError> {
+        if com_object.is_null() {
+            return Err(FfiBindingError::from_status(
+                -1,
+                "live object pointer is null".to_owned(),
+            ));
+        }
+
+        let handle = self
+            .handle
+            .ok_or_else(|| FfiBindingError::from_status(-4, "PowerShell session has been released".to_owned()))?;
+        let name_length = checked_utf8_length(name)?;
+        let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+        let mut call_result = new_call_result(&mut diagnostic);
+        let status = unsafe {
+            (self.bindings.power_shell_session_set_live_object_contract_variable_fn)(
+                handle,
+                name.as_ptr(),
+                name_length,
+                contract,
+                com_object,
                 &mut call_result,
             )
         };

--- a/crates/pwsh-host/src/lib.rs
+++ b/crates/pwsh-host/src/lib.rs
@@ -25,11 +25,11 @@ extern crate quick_error;
 mod pdcstring;
 
 pub use bindings::{
-    FfiBindingError, FfiInvocationResult, FfiPowerShell, FfiPowerShellSession, FfiSessionEvent, FfiSessionSnapshot,
-    FfiSnapshotValue, PowerShell,
+    FfiBindingError, FfiInvocationResult, FfiLiveObjectContractDescriptor, FfiPowerShell, FfiPowerShellSession,
+    FfiSessionEvent, FfiSessionSnapshot, FfiSnapshotValue, PowerShell,
 };
 pub use host_detect::find_pwsh_dir;
-pub use loader::{get_assembly_delegate_loader_for_pwsh_dir, HostedRuntime};
+pub use loader::{get_assembly_delegate_loader_for_pwsh_dir, HostedRuntime, LiveObjectContractPack};
 pub use named_pipe_command::{preprocess_named_pipe_command_args, NamedPipeCommandError};
 pub use pwsh_cli::{run_pwsh_command_line, run_pwsh_command_line_for_pwsh_dir, run_pwsh_command_line_for_pwsh_exe};
 pub use startup_hook::{MODULE_PATH_STRATEGY, STARTUP_HOOK_MODULE_VENV_PATH_ENV_VAR, STARTUP_HOOK_STRATEGY_ENV_VAR};

--- a/crates/pwsh-host/src/loader.rs
+++ b/crates/pwsh-host/src/loader.rs
@@ -1,6 +1,8 @@
+use std::convert::TryFrom;
+use std::ffi::c_void;
 use std::path::{Path, PathBuf};
 
-use crate::bindings::{Bindings, FfiBindings};
+use crate::bindings::{Bindings, FfiBindingError, FfiBindings};
 use crate::context::HostfxrContext;
 use crate::delegate_loader::AssemblyDelegateLoader;
 use crate::error::Error;
@@ -15,6 +17,12 @@ use crate::pwsh_cli::configure_startup_hooks_for_context;
 pub const BINDINGS_DLL: &[u8] =
     include_bytes!("../../../dotnet/bindings/bin/Release/net8.0/Devolutions.PowerShell.SDK.Bindings.dll");
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LiveObjectContractPack {
+    pub payload_adapter_assembly_path: PathBuf,
+    pub payload_adapter_type_name: String,
+}
+
 pub struct HostedRuntime {
     bindings: Bindings,
     ffi_bindings: FfiBindings,
@@ -25,11 +33,18 @@ pub struct HostedRuntime {
 
 impl HostedRuntime {
     pub fn new_for_pwsh_dir(pwsh_dir: impl AsRef<Path>) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::new_for_pwsh_dir_with_contract_packs(pwsh_dir, &[])
+    }
+
+    pub fn new_for_pwsh_dir_with_contract_packs(
+        pwsh_dir: impl AsRef<Path>,
+        contract_packs: &[LiveObjectContractPack],
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let pwsh_dir = validate_pwsh_payload(pwsh_dir.as_ref())?;
         let hostfxr = load_hostfxr_from_pwsh_dir(&pwsh_dir)?;
         let (host_context, bindings, ffi_bindings) =
             match hostfxr.initialize_for_dotnet_command_line(pwsh_dir.join("pwsh.dll")) {
-                Ok(context) => load_bindings_from_context(&hostfxr, context, &pwsh_dir)?,
+                Ok(context) => load_bindings_from_context(&hostfxr, context, &pwsh_dir, contract_packs)?,
                 Err(error) => {
                     let should_fallback = matches!(
                         error.downcast_ref::<Error>(),
@@ -44,7 +59,7 @@ impl HostedRuntime {
 
                     let runtime_config = PdCString::from_os_str(pwsh_dir.join("pwsh.runtimeconfig.json"))?;
                     let context = hostfxr.initialize_for_runtime_config_path(&runtime_config)?;
-                    load_bindings_from_context(&hostfxr, context, &pwsh_dir)?
+                    load_bindings_from_context(&hostfxr, context, &pwsh_dir, contract_packs)?
                 }
             };
 
@@ -63,6 +78,18 @@ impl HostedRuntime {
 
     pub(crate) fn ffi_bindings(&self) -> FfiBindings {
         self.ffi_bindings
+    }
+
+    pub fn create_live_object_probe(&self, initial_count: i64) -> Result<*mut c_void, FfiBindingError> {
+        self.ffi_bindings.create_live_object_probe(initial_count)
+    }
+
+    pub fn release_live_object_probe(&self, com_object: *mut c_void) -> Result<(), FfiBindingError> {
+        self.ffi_bindings.release_live_object_probe(com_object)
+    }
+
+    pub fn unregister_live_object_probe(&self, com_object: *mut c_void) -> Result<(), FfiBindingError> {
+        self.ffi_bindings.unregister_live_object_probe(com_object)
     }
 
     pub fn pwsh_dir(&self) -> &Path {
@@ -108,6 +135,17 @@ pub fn get_assembly_delegate_loader_for_pwsh_dir(
 }
 
 fn load_bindings(fn_loader: &AssemblyDelegateLoader<PdCString>) -> Result<(), Box<dyn std::error::Error>> {
+    load_assembly_from_native_memory(fn_loader, BINDINGS_DLL)
+}
+
+fn load_assembly_from_native_memory(
+    fn_loader: &AssemblyDelegateLoader<PdCString>,
+    assembly: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    if assembly.is_empty() || assembly.len() > u32::MAX as usize {
+        return Err("managed assembly payload is invalid".into());
+    }
+
     let load_assembly_from_native_memory = fn_loader.get_function_pointer_for_unmanaged_callers_only_method(
         pdcstr!("System.Management.Automation.PowerShellUnsafeAssemblyLoad, System.Management.Automation"),
         pdcstr!("LoadAssemblyFromNativeMemory"),
@@ -115,15 +153,47 @@ fn load_bindings(fn_loader: &AssemblyDelegateLoader<PdCString>) -> Result<(), Bo
 
     let load_assembly_from_native_memory: extern "system" fn(bytes: *const libc::c_uchar, size: libc::c_uint) -> i32 =
         unsafe { std::mem::transmute(load_assembly_from_native_memory) };
-    let result = (load_assembly_from_native_memory)(BINDINGS_DLL.as_ptr(), BINDINGS_DLL.len() as u32);
+    let result = (load_assembly_from_native_memory)(assembly.as_ptr(), assembly.len() as u32);
     HostExitCode::from(result).into_result()?;
     Ok(())
+}
+
+fn load_live_object_contract_pack(
+    fn_loader: &AssemblyDelegateLoader<PdCString>,
+    pack: &LiveObjectContractPack,
+) -> Result<*mut c_void, Box<dyn std::error::Error>> {
+    let assembly = std::fs::read(&pack.payload_adapter_assembly_path)?;
+    load_assembly_from_native_memory(fn_loader, &assembly)?;
+
+    let type_name = PdCString::try_from(pack.payload_adapter_type_name.as_str())?;
+    let get_pack_api = fn_loader
+        .get_function_pointer_for_unmanaged_callers_only_method(type_name, pdcstr!("GetLiveObjectContractPackV1"))?;
+    let get_pack_api: unsafe extern "system" fn() -> *mut c_void = unsafe { std::mem::transmute(get_pack_api) };
+    Ok(unsafe { get_pack_api() })
+}
+
+fn load_live_object_contract_packs(
+    fn_loader: &AssemblyDelegateLoader<PdCString>,
+    ffi_bindings: &FfiBindings,
+    contract_packs: &[LiveObjectContractPack],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut pack_apis = Vec::with_capacity(contract_packs.len());
+    for pack in contract_packs {
+        pack_apis.push(load_live_object_contract_pack(fn_loader, pack)?);
+    }
+    if pack_apis.is_empty() {
+        return Ok(());
+    }
+
+    unsafe { ffi_bindings.register_live_object_contract_packs(&pack_apis) }
+        .map_err(|error| Box::new(error) as Box<dyn std::error::Error>)
 }
 
 fn load_bindings_from_context<I>(
     hostfxr: &Hostfxr,
     context: HostfxrContext<'_, I>,
     pwsh_dir: &Path,
+    contract_packs: &[LiveObjectContractPack],
 ) -> Result<(crate::context::HostfxrHandle, Bindings, FfiBindings), Box<dyn std::error::Error>> {
     let host_context = context.handle();
     let result = (|| {
@@ -133,6 +203,7 @@ fn load_bindings_from_context<I>(
             Bindings::new_with_loader(&fn_loader).map_err(|error| Box::new(error) as Box<dyn std::error::Error>)?;
         let ffi_bindings =
             FfiBindings::new_with_loader(&fn_loader).map_err(|error| Box::new(error) as Box<dyn std::error::Error>)?;
+        load_live_object_contract_packs(&fn_loader, &ffi_bindings, contract_packs)?;
         Ok::<_, Box<dyn std::error::Error>>((bindings, ffi_bindings))
     })();
     if result.is_err() {

--- a/crates/pwsh-sdk-ffi/src/lib.rs
+++ b/crates/pwsh-sdk-ffi/src/lib.rs
@@ -8,13 +8,15 @@ use std::mem;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::slice;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+#[cfg(test)]
+use std::sync::MutexGuard;
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use pwsh_host::{
-    find_pwsh_dir, FfiBindingError, FfiInvocationResult, FfiPowerShell, FfiPowerShellSession, FfiSessionEvent,
-    FfiSessionSnapshot, FfiSnapshotValue, HostedRuntime,
+    find_pwsh_dir, FfiBindingError, FfiInvocationResult, FfiLiveObjectContractDescriptor, FfiPowerShell,
+    FfiPowerShellSession, FfiSessionEvent, FfiSessionSnapshot, FfiSnapshotValue, HostedRuntime, LiveObjectContractPack,
 };
 
 const ABI_VERSION: u32 = 2;
@@ -34,6 +36,9 @@ const FEATURE_SNAPSHOT_PROJECTIONS: u64 = 1 << 13;
 const FEATURE_SESSION_CONFIGURATION: u64 = 1 << 14;
 const FEATURE_SESSION_VARIABLES: u64 = 1 << 15;
 const FEATURE_CAPABILITY_RPC: u64 = 1 << 16;
+const FEATURE_LIVE_OBJECT_PROBE: u64 = 1 << 17;
+const FEATURE_LIVE_SESSION_OBJECT_PROBE: u64 = 1 << 18;
+const FEATURE_LIVE_OBJECT_CONTRACTS: u64 = 1 << 19;
 const CALL_RESULT_DIAGNOSTIC_TRUNCATED: u32 = 1;
 #[cfg(test)]
 const RESULT_RECORD_SCALAR_VALUE_PRESENT: u32 = 1 << 1;
@@ -58,6 +63,8 @@ const MAX_CAPABILITIES: usize = 16;
 const MAX_CAPABILITY_NAME_BYTES: usize = 64;
 const MAX_CAPABILITY_DEADLINE_MILLISECONDS: u32 = 30_000;
 const MAX_CAPABILITY_PERMISSIONS: u32 = 0x0f;
+const MAX_LIVE_OBJECT_CONTRACT_PACKS: usize = 16;
+const MAX_LIVE_OBJECT_CONTRACT_PACK_TYPE_NAME_BYTES: usize = 512;
 
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -211,9 +218,19 @@ pub struct SessionPoolOptions {
     _reserved: u32,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct LiveObjectContractPackInput {
+    size: u32,
+    flags: u32,
+    payload_adapter_assembly_path: Utf8Span,
+    payload_adapter_type_name: Utf8Span,
+}
+
 struct State {
     runtime: Option<Arc<HostedRuntime>>,
     activation_source_root: Option<PathBuf>,
+    live_object_contract_packs: Vec<LiveObjectContractPack>,
     sessions: HashMap<u64, Arc<Session>>,
     runspace_sessions: HashMap<u64, Arc<RunspaceSession>>,
     results: HashMap<u64, Arc<InvocationResult>>,
@@ -515,6 +532,7 @@ impl Default for State {
         Self {
             runtime: None,
             activation_source_root: None,
+            live_object_contract_packs: Vec::new(),
             sessions: HashMap::new(),
             runspace_sessions: HashMap::new(),
             results: HashMap::new(),
@@ -535,13 +553,85 @@ unsafe impl Send for State {}
 
 static STATE: OnceLock<Mutex<State>> = OnceLock::new();
 static SESSION_OPERATION_LOCK: Mutex<()> = Mutex::new(());
+static ACTIVE_PIPELINE_COUNT: AtomicU32 = AtomicU32::new(0);
+#[cfg(test)]
+static TEST_PIPELINE_SCOPE_LOCK: Mutex<()> = Mutex::new(());
 static NEXT_CAPABILITY_INVOCATION_ID: AtomicU64 = AtomicU64::new(1);
 thread_local! {
     static CAPABILITY_CALLBACK_DEPTH: Cell<u32> = const { Cell::new(0) };
+    static PIPELINE_EXECUTION_DEPTH: Cell<u32> = const { Cell::new(0) };
 }
 
 fn state() -> &'static Mutex<State> {
     STATE.get_or_init(|| Mutex::new(State::default()))
+}
+
+struct InvocationExecutionScope {
+    #[cfg(test)]
+    _test_scope_lock: Option<MutexGuard<'static, ()>>,
+}
+
+impl InvocationExecutionScope {
+    fn enter() -> Self {
+        #[cfg(test)]
+        let test_scope_lock = if pipeline_execution_depth() == 0 {
+            Some(
+                TEST_PIPELINE_SCOPE_LOCK
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            )
+        } else {
+            None
+        };
+        PIPELINE_EXECUTION_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        ACTIVE_PIPELINE_COUNT.fetch_add(1, Ordering::AcqRel);
+        Self {
+            #[cfg(test)]
+            _test_scope_lock: test_scope_lock,
+        }
+    }
+}
+
+impl Drop for InvocationExecutionScope {
+    fn drop(&mut self) {
+        ACTIVE_PIPELINE_COUNT.fetch_sub(1, Ordering::AcqRel);
+        PIPELINE_EXECUTION_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
+}
+
+fn pipeline_execution_depth() -> u32 {
+    PIPELINE_EXECUTION_DEPTH.with(Cell::get)
+}
+
+fn active_pipeline_count() -> u32 {
+    ACTIVE_PIPELINE_COUNT.load(Ordering::Acquire)
+}
+
+fn reject_active_pipeline_ffi_call() -> Result<(), (Status, String)> {
+    if pipeline_execution_depth() != 0 {
+        return Err((
+            Status::Backpressure,
+            "PowerShell FFI calls are not permitted from code invoked by an active PowerShell pipeline.".to_owned(),
+        ));
+    }
+    if active_pipeline_count() != 0 {
+        return Err((
+            Status::Backpressure,
+            "PowerShell FFI calls are not permitted while any PowerShell pipeline is running.".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn reject_active_pipeline_session_mutation() -> Result<(), (Status, String)> {
+    if active_pipeline_count() != 0 {
+        return Err((
+            Status::Backpressure,
+            "PowerShell session variables cannot be read or changed while any PowerShell pipeline is running."
+                .to_owned(),
+        ));
+    }
+    Ok(())
 }
 
 unsafe fn utf8_input<'a>(ptr: *const u8, len: usize) -> Result<&'a str, Status> {
@@ -589,6 +679,102 @@ unsafe fn data_value_input<'a>(value: *const DataValue) -> Result<(u32, &'a [u8]
     };
     validate_value_payload(value.kind, payload, 0)?;
     Ok((value.kind, payload))
+}
+
+unsafe fn live_object_contract_input<'a>(
+    value: *const FfiLiveObjectContractDescriptor,
+) -> Result<&'a FfiLiveObjectContractDescriptor, (Status, String)> {
+    if value.is_null() {
+        return Err((
+            Status::InvalidArgument,
+            "live object contract descriptor is null".to_owned(),
+        ));
+    }
+
+    let value = &*value;
+    if value.size < mem::size_of::<FfiLiveObjectContractDescriptor>() as u32
+        || value.directions == 0
+        || value.directions & !0x03 != 0
+        || value.interface_id_low == 0 && value.interface_id_high == 0
+        || value.major_version == 0
+        || value.reserved != 0
+    {
+        return Err((
+            Status::InvalidArgument,
+            "live object contract descriptor is invalid".to_owned(),
+        ));
+    }
+
+    Ok(value)
+}
+
+unsafe fn live_object_contract_pack_inputs(
+    values: *const LiveObjectContractPackInput,
+    count: usize,
+) -> Result<Vec<LiveObjectContractPack>, (Status, String)> {
+    if count == 0 || count > MAX_LIVE_OBJECT_CONTRACT_PACKS || values.is_null() {
+        return Err((
+            Status::InvalidArgument,
+            "live object contract pack input is invalid".to_owned(),
+        ));
+    }
+
+    let values = slice::from_raw_parts(values, count);
+    let mut packs = Vec::with_capacity(count);
+    for value in values {
+        if value.size < mem::size_of::<LiveObjectContractPackInput>() as u32 || value.flags != 0 {
+            return Err((
+                Status::InvalidArgument,
+                "live object contract pack header is invalid".to_owned(),
+            ));
+        }
+
+        let assembly_path = utf8_span(value.payload_adapter_assembly_path).map_err(|_| {
+            (
+                Status::InvalidArgument,
+                "live object contract pack assembly path must be UTF-8 without NUL".to_owned(),
+            )
+        })?;
+        let adapter_type_name = utf8_span(value.payload_adapter_type_name).map_err(|_| {
+            (
+                Status::InvalidArgument,
+                "live object contract pack adapter type must be UTF-8 without NUL".to_owned(),
+            )
+        })?;
+        if adapter_type_name.is_empty() || adapter_type_name.len() > MAX_LIVE_OBJECT_CONTRACT_PACK_TYPE_NAME_BYTES {
+            return Err((
+                Status::InvalidArgument,
+                "live object contract pack adapter type is invalid".to_owned(),
+            ));
+        }
+
+        let assembly_path = PathBuf::from(assembly_path);
+        if !assembly_path.is_absolute() {
+            return Err((
+                Status::InvalidArgument,
+                "live object contract pack assembly path must be absolute".to_owned(),
+            ));
+        }
+        let assembly_path = fs::canonicalize(&assembly_path).map_err(|error| {
+            (
+                Status::InvalidArgument,
+                format!("live object contract pack assembly cannot be resolved: {}", error),
+            )
+        })?;
+        if !assembly_path.is_file() {
+            return Err((
+                Status::InvalidArgument,
+                "live object contract pack assembly path must name a file".to_owned(),
+            ));
+        }
+
+        packs.push(LiveObjectContractPack {
+            payload_adapter_assembly_path: assembly_path,
+            payload_adapter_type_name: adapter_type_name.to_owned(),
+        });
+    }
+
+    Ok(packs)
 }
 
 fn validate_value_payload(kind: u32, payload: &[u8], depth: u8) -> Result<(), (Status, String)> {
@@ -1160,12 +1346,16 @@ fn invoke_with_capability(
             return Err(error);
         }
 
-        let result = session.power_shell.invoke_to_result();
+        let result = {
+            let _execution_scope = InvocationExecutionScope::enter();
+            session.power_shell.invoke_to_result()
+        };
         let clear = unsafe { session.power_shell.set_capability_context(0, 0, std::ptr::null()) };
         set_active_capability(session, None);
         capability.registration.end_invocation(capability.invocation_id);
         result.and_then(|result| clear.map(|_| result))
     } else {
+        let _execution_scope = InvocationExecutionScope::enter();
         session.power_shell.invoke_to_result()
     }
 }
@@ -1415,6 +1605,34 @@ unsafe fn v2_call<F>(result: *mut CallResult, operation: F) -> i32
 where
     F: FnOnce() -> Result<Status, (Status, String)>,
 {
+    v2_call_with_active_pipeline_policy(result, false, operation)
+}
+
+unsafe fn v2_call_allow_active_pipeline<F>(result: *mut CallResult, operation: F) -> i32
+where
+    F: FnOnce() -> Result<Status, (Status, String)>,
+{
+    v2_call_with_active_pipeline_policy(result, true, operation)
+}
+
+unsafe fn v2_call_with_active_pipeline_policy<F>(
+    result: *mut CallResult,
+    allow_active_pipeline: bool,
+    operation: F,
+) -> i32
+where
+    F: FnOnce() -> Result<Status, (Status, String)>,
+{
+    #[cfg(test)]
+    let _test_call_lock = if pipeline_execution_depth() == 0 {
+        Some(
+            TEST_PIPELINE_SCOPE_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        )
+    } else {
+        None
+    };
     let result = match prepare_call_result(result) {
         Ok(result) => result,
         Err(status) => return status.value(),
@@ -1424,6 +1642,17 @@ where
             result,
             Status::Backpressure,
             "PowerShell FFI calls are not permitted from a capability callback.",
+        );
+    }
+    if !allow_active_pipeline {
+        if let Err((status, diagnostic)) = reject_active_pipeline_ffi_call() {
+            return complete_call_result(result, status, &diagnostic);
+        }
+    } else if pipeline_execution_depth() != 0 {
+        return complete_call_result(
+            result,
+            Status::Backpressure,
+            "PowerShell FFI calls are not permitted from code invoked by an active PowerShell pipeline.",
         );
     }
 
@@ -2036,6 +2265,13 @@ where
 
 #[allow(clippy::arc_with_non_send_sync)]
 fn initialize_direct_payload(payload_path: &str) -> Result<Status, (Status, String)> {
+    initialize_direct_payload_with_contract_packs(payload_path, Vec::new())
+}
+
+fn initialize_direct_payload_with_contract_packs(
+    payload_path: &str,
+    contract_packs: Vec<LiveObjectContractPack>,
+) -> Result<Status, (Status, String)> {
     let payload_path = fs::canonicalize(payload_path).map_err(|error| {
         (
             Status::InvalidArgument,
@@ -2048,10 +2284,16 @@ fn initialize_direct_payload(payload_path: &str) -> Result<Status, (Status, Stri
             "PowerShell payload path must be an existing directory".to_owned(),
         ));
     }
-    initialize_runtime(payload_path)
+    initialize_runtime(payload_path, contract_packs)
 }
 
 fn initialize_from_path() -> Result<Status, (Status, String)> {
+    initialize_from_path_with_contract_packs(Vec::new())
+}
+
+fn initialize_from_path_with_contract_packs(
+    contract_packs: Vec<LiveObjectContractPack>,
+) -> Result<Status, (Status, String)> {
     let payload_path = find_pwsh_dir().ok_or_else(|| {
         (
             Status::HostFailure,
@@ -2064,18 +2306,23 @@ fn initialize_from_path() -> Result<Status, (Status, String)> {
             "the PowerShell payload selected from PATH is not valid UTF-8".to_owned(),
         )
     })?;
-    initialize_direct_payload(payload_path)
+    initialize_direct_payload_with_contract_packs(payload_path, contract_packs)
 }
 
 #[allow(clippy::arc_with_non_send_sync)]
-fn initialize_runtime(payload_path: PathBuf) -> Result<Status, (Status, String)> {
+fn initialize_runtime(
+    payload_path: PathBuf,
+    contract_packs: Vec<LiveObjectContractPack>,
+) -> Result<Status, (Status, String)> {
     let mut state = match state().lock() {
         Ok(state) => state,
         Err(poisoned) => poisoned.into_inner(),
     };
 
     if let Some(runtime) = &state.runtime {
-        return if state.activation_source_root.as_ref() == Some(&payload_path) {
+        return if state.activation_source_root.as_ref() == Some(&payload_path)
+            && state.live_object_contract_packs == contract_packs
+        {
             Ok(Status::Success)
         } else {
             let selected_path = state
@@ -2085,18 +2332,18 @@ fn initialize_runtime(payload_path: PathBuf) -> Result<Status, (Status, String)>
             Err((
                 Status::IncompatiblePayload,
                 format!(
-                    "PowerShell runtime is already initialized for {}; cannot select {}",
+                    "PowerShell runtime is already initialized for {}; cannot select a different payload or contract-pack set",
                     selected_path.display(),
-                    payload_path.display()
                 ),
             ))
         };
     }
 
-    let runtime =
-        HostedRuntime::new_for_pwsh_dir(&payload_path).map_err(|error| (Status::HostFailure, error.to_string()))?;
+    let runtime = HostedRuntime::new_for_pwsh_dir_with_contract_packs(&payload_path, &contract_packs)
+        .map_err(|error| (Status::HostFailure, error.to_string()))?;
     state.runtime = Some(Arc::new(runtime));
     state.activation_source_root = Some(payload_path);
+    state.live_object_contract_packs = contract_packs;
     Ok(Status::Success)
 }
 
@@ -2738,6 +2985,7 @@ fn with_runspace_session_mutation<F>(handle: u64, operation: F) -> Result<Status
 where
     F: FnOnce(&FfiPowerShellSession) -> Result<Status, (Status, String)>,
 {
+    reject_active_pipeline_session_mutation()?;
     let session = {
         let state = match state().lock() {
             Ok(state) => state,
@@ -2749,6 +2997,7 @@ where
             .cloned()
             .ok_or_else(|| (Status::InvalidHandle, "PowerShell session handle is invalid".to_owned()))?
     };
+    reject_active_pipeline_session_mutation()?;
     if runspace_session_has_active_operation(&session) {
         return Err((
             Status::Backpressure,
@@ -2759,6 +3008,7 @@ where
     let _operation_lock = SESSION_OPERATION_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    reject_active_pipeline_session_mutation()?;
     if runspace_session_has_active_operation(&session) {
         return Err((
             Status::Backpressure,
@@ -2866,6 +3116,71 @@ fn feature_flags() -> u64 {
         | FEATURE_SESSION_CONFIGURATION
         | FEATURE_SESSION_VARIABLES
         | FEATURE_CAPABILITY_RPC
+        | FEATURE_LIVE_OBJECT_PROBE
+        | FEATURE_LIVE_SESSION_OBJECT_PROBE
+        | FEATURE_LIVE_OBJECT_CONTRACTS
+}
+
+fn create_live_object_probe(initial_count: i64) -> Result<*mut std::ffi::c_void, (Status, String)> {
+    let _operation_lock = SESSION_OPERATION_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let runtime = {
+        let state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.runtime.as_ref().cloned().ok_or_else(|| {
+            (
+                Status::NotInitialized,
+                "PowerShell runtime has not been initialized".to_owned(),
+            )
+        })?
+    };
+    runtime.create_live_object_probe(initial_count).map_err(managed_failure)
+}
+
+fn release_live_object_probe(com_object: *mut std::ffi::c_void) -> Result<Status, (Status, String)> {
+    if com_object.is_null() {
+        return Err((Status::InvalidArgument, "live object probe pointer is null".to_owned()));
+    }
+
+    let _operation_lock = SESSION_OPERATION_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let runtime = {
+        let state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.runtime.as_ref().cloned().ok_or_else(|| {
+            (
+                Status::NotInitialized,
+                "PowerShell runtime has not been initialized".to_owned(),
+            )
+        })?
+    };
+    runtime
+        .release_live_object_probe(com_object)
+        .map(|_| Status::Success)
+        .map_err(managed_failure)
+}
+
+fn unregister_live_object_probe(com_object: *mut std::ffi::c_void) -> Result<Status, (Status, String)> {
+    if com_object.is_null() {
+        return Err((Status::InvalidArgument, "live object probe pointer is null".to_owned()));
+    }
+
+    let _operation_lock = SESSION_OPERATION_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let runtime = {
+        let state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.runtime.as_ref().cloned().ok_or_else(|| {
+            (
+                Status::NotInitialized,
+                "PowerShell runtime has not been initialized".to_owned(),
+            )
+        })?
+    };
+    runtime
+        .unregister_live_object_probe(com_object)
+        .map(|_| Status::Success)
+        .map_err(managed_failure)
 }
 
 #[no_mangle]
@@ -2895,8 +3210,39 @@ pub unsafe extern "C" fn multi_pwsh_initialize_utf8(payload_path: Utf8Span, resu
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_initialize_with_contract_packs_utf8(
+    payload_path: Utf8Span,
+    contract_packs: *const LiveObjectContractPackInput,
+    contract_pack_count: usize,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || {
+        let payload_path = utf8_span(payload_path).map_err(|_| {
+            (
+                Status::InvalidArgument,
+                "payload path must be UTF-8 without NUL".to_owned(),
+            )
+        })?;
+        let contract_packs = live_object_contract_pack_inputs(contract_packs, contract_pack_count)?;
+        initialize_direct_payload_with_contract_packs(payload_path, contract_packs)
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn multi_pwsh_initialize_from_path(result: *mut CallResult) -> i32 {
     v2_call(result, initialize_from_path)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_initialize_from_path_with_contract_packs(
+    contract_packs: *const LiveObjectContractPackInput,
+    contract_pack_count: usize,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || {
+        let contract_packs = live_object_contract_pack_inputs(contract_packs, contract_pack_count)?;
+        initialize_from_path_with_contract_packs(contract_packs)
+    })
 }
 
 #[no_mangle]
@@ -2934,8 +3280,43 @@ pub unsafe extern "C" fn multi_pwsh_create(handle: *mut u64, result: *mut CallRe
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_live_object_probe_create(
+    initial_count: i64,
+    com_object: *mut *mut std::ffi::c_void,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || {
+        if com_object.is_null() {
+            return Err((
+                Status::InvalidArgument,
+                "live object probe output pointer is null".to_owned(),
+            ));
+        }
+
+        *com_object = create_live_object_probe(initial_count)?;
+        Ok(Status::Success)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_live_object_probe_release(
+    com_object: *mut std::ffi::c_void,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || release_live_object_probe(com_object))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_live_object_probe_unregister(
+    com_object: *mut std::ffi::c_void,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || unregister_live_object_probe(com_object))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn multi_pwsh_release(handle: u64, result: *mut CallResult) -> i32 {
-    v2_call(result, || release_session_result(handle))
+    v2_call_allow_active_pipeline(result, || release_session_result(handle))
 }
 
 #[no_mangle]
@@ -3035,6 +3416,26 @@ pub unsafe extern "C" fn multi_pwsh_add_argument_value(
         with_session_result(handle, true, |session| {
             session
                 .add_argument_value(kind, payload)
+                .map(|_| Status::Success)
+                .map_err(managed_failure)
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_add_argument_live_object(
+    handle: u64,
+    com_object: *mut std::ffi::c_void,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || {
+        if com_object.is_null() {
+            return Err((Status::InvalidArgument, "live object probe pointer is null".to_owned()));
+        }
+
+        with_session_result(handle, true, |session| unsafe {
+            session
+                .add_argument_live_object(com_object)
                 .map(|_| Status::Success)
                 .map_err(managed_failure)
         })
@@ -3284,7 +3685,7 @@ pub unsafe extern "C" fn multi_pwsh_copy_invocation_error_field_utf8(
 
 #[no_mangle]
 pub unsafe extern "C" fn multi_pwsh_stop(handle: u64, result: *mut CallResult) -> i32 {
-    v2_call(result, || stop_session_operation(handle))
+    v2_call_allow_active_pipeline(result, || stop_session_operation(handle))
 }
 
 #[no_mangle]
@@ -3336,7 +3737,7 @@ pub unsafe extern "C" fn multi_pwsh_invoke(handle: u64, result_handle: *mut u64,
 
 #[no_mangle]
 pub unsafe extern "C" fn multi_pwsh_result_release(handle: u64, result: *mut CallResult) -> i32 {
-    v2_call(result, || release_result(handle))
+    v2_call_allow_active_pipeline(result, || release_result(handle))
 }
 
 #[no_mangle]
@@ -3346,7 +3747,7 @@ pub unsafe extern "C" fn multi_pwsh_result_get_info(
     sequence_count: *mut u32,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         if flags.is_null() || sequence_count.is_null() {
             return Err((
                 Status::InvalidArgument,
@@ -3376,7 +3777,7 @@ pub unsafe extern "C" fn multi_pwsh_result_get_metadata(
     had_errors: *mut u32,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         if state.is_null() || invocation_id.is_null() || had_errors.is_null() {
             return Err((
                 Status::InvalidArgument,
@@ -3402,7 +3803,7 @@ pub unsafe extern "C" fn multi_pwsh_result_get_stream_info(
     flags: *mut u32,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         if record_count.is_null() || flags.is_null() {
             return Err((
                 Status::InvalidArgument,
@@ -3439,7 +3840,7 @@ pub unsafe extern "C" fn multi_pwsh_result_get_stream_record_info(
     flags: *mut u32,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         if sequence.is_null() || flags.is_null() {
             return Err((
                 Status::InvalidArgument,
@@ -3486,7 +3887,7 @@ pub unsafe extern "C" fn multi_pwsh_result_copy_stream_record_field_utf8(
     required_len: *mut usize,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         let stream = i32::try_from(stream).map_err(|_| {
             (
                 Status::InvalidArgument,
@@ -3530,7 +3931,7 @@ pub unsafe extern "C" fn multi_pwsh_result_get_stream_totals(
     dropped_record_count: *mut u64,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         if total_record_count.is_null() || dropped_record_count.is_null() {
             return Err((
                 Status::InvalidArgument,
@@ -3564,7 +3965,7 @@ pub unsafe extern "C" fn multi_pwsh_result_get_stream_record_projection_info(
     projection_flags: *mut u32,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         if property_entry_count.is_null()
             || dropped_property_entry_count.is_null()
             || type_name_count.is_null()
@@ -3726,12 +4127,12 @@ pub unsafe extern "C" fn multi_pwsh_invoke_async(
 
 #[no_mangle]
 pub unsafe extern "C" fn multi_pwsh_operation_release(handle: u64, result: *mut CallResult) -> i32 {
-    v2_call(result, || release_operation(handle))
+    v2_call_allow_active_pipeline(result, || release_operation(handle))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn multi_pwsh_operation_stop(handle: u64, result: *mut CallResult) -> i32 {
-    v2_call(result, || stop_operation(handle))
+    v2_call_allow_active_pipeline(result, || stop_operation(handle))
 }
 
 #[no_mangle]
@@ -3741,7 +4142,7 @@ pub unsafe extern "C" fn multi_pwsh_operation_poll(
     terminal_status: *mut i32,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || poll_operation(handle, operation_state, terminal_status))
+    v2_call_allow_active_pipeline(result, || poll_operation(handle, operation_state, terminal_status))
 }
 
 #[no_mangle]
@@ -3752,7 +4153,7 @@ pub unsafe extern "C" fn multi_pwsh_operation_wait(
     terminal_status: *mut i32,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         wait_operation(handle, timeout_milliseconds, operation_state, terminal_status)
     })
 }
@@ -3763,7 +4164,7 @@ pub unsafe extern "C" fn multi_pwsh_operation_get_result(
     result_handle: *mut u64,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         if result_handle.is_null() {
             return Err((
                 Status::InvalidArgument,
@@ -3795,7 +4196,7 @@ pub unsafe extern "C" fn multi_pwsh_session_create(
 
 #[no_mangle]
 pub unsafe extern "C" fn multi_pwsh_session_release(session_handle: u64, result: *mut CallResult) -> i32 {
-    v2_call(result, || release_runspace_session(session_handle))
+    v2_call_allow_active_pipeline(result, || release_runspace_session(session_handle))
 }
 
 #[no_mangle]
@@ -3822,7 +4223,7 @@ pub unsafe extern "C" fn multi_pwsh_session_get_snapshot(
     snapshot: *mut SessionSnapshot,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         with_runspace_session(session_handle, |session| {
             let snapshot_value = session.snapshot().map_err(managed_failure)?;
             write_session_snapshot(snapshot, snapshot_value)
@@ -3839,7 +4240,7 @@ pub unsafe extern "C" fn multi_pwsh_session_get_event_info(
     flags: *mut u32,
     result: *mut CallResult,
 ) -> i32 {
-    v2_call(result, || {
+    v2_call_allow_active_pipeline(result, || {
         if sequence.is_null() || event_state.is_null() || flags.is_null() {
             return Err((
                 Status::InvalidArgument,
@@ -3883,6 +4284,79 @@ pub unsafe extern "C" fn multi_pwsh_session_set_variable(
         let (kind, payload) = data_value_input(value)?;
         with_runspace_session_mutation(session_handle, |session| {
             session.set_variable(name, kind, payload).map_err(managed_failure)?;
+            Ok(Status::Success)
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_session_set_live_object_variable(
+    session_handle: u64,
+    name: Utf8Span,
+    com_object: *mut std::ffi::c_void,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || {
+        if com_object.is_null() {
+            return Err((
+                Status::InvalidArgument,
+                "live session object probe pointer is null".to_owned(),
+            ));
+        }
+        let name = utf8_span(name).map_err(|_| {
+            (
+                Status::InvalidArgument,
+                "PowerShell session variable name must be UTF-8 without NUL".to_owned(),
+            )
+        })?;
+        if !valid_session_name(name) {
+            return Err((
+                Status::InvalidArgument,
+                "PowerShell session variable name must be a bounded ASCII identifier".to_owned(),
+            ));
+        }
+        with_runspace_session_mutation(session_handle, |session| {
+            unsafe {
+                session
+                    .set_live_object_variable(name, com_object)
+                    .map_err(managed_failure)?;
+            }
+            Ok(Status::Success)
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_session_set_live_object_contract_variable(
+    session_handle: u64,
+    name: Utf8Span,
+    contract: *const FfiLiveObjectContractDescriptor,
+    com_object: *mut std::ffi::c_void,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || {
+        if com_object.is_null() {
+            return Err((Status::InvalidArgument, "live object pointer is null".to_owned()));
+        }
+        let name = utf8_span(name).map_err(|_| {
+            (
+                Status::InvalidArgument,
+                "PowerShell session variable name must be UTF-8 without NUL".to_owned(),
+            )
+        })?;
+        if !valid_session_name(name) {
+            return Err((
+                Status::InvalidArgument,
+                "PowerShell session variable name must be a bounded ASCII identifier".to_owned(),
+            ));
+        }
+        let contract = live_object_contract_input(contract)?;
+        with_runspace_session_mutation(session_handle, |session| {
+            unsafe {
+                session
+                    .set_live_object_contract_variable(name, contract, com_object)
+                    .map_err(managed_failure)?;
+            }
             Ok(Status::Success)
         })
     })
@@ -4181,6 +4655,112 @@ mod tests {
     }
 
     #[test]
+    fn invocation_execution_scope_tracks_nesting_and_unwind_cleanup() {
+        assert_eq!(pipeline_execution_depth(), 0);
+
+        {
+            let _outer = InvocationExecutionScope::enter();
+            assert_eq!(pipeline_execution_depth(), 1);
+            assert_eq!(active_pipeline_count(), 1);
+
+            {
+                let _inner = InvocationExecutionScope::enter();
+                assert_eq!(pipeline_execution_depth(), 2);
+                assert_eq!(active_pipeline_count(), 2);
+            }
+
+            assert_eq!(pipeline_execution_depth(), 1);
+            assert_eq!(active_pipeline_count(), 1);
+        }
+
+        assert_eq!(pipeline_execution_depth(), 0);
+        assert_eq!(active_pipeline_count(), 0);
+
+        let unwind = catch_unwind(AssertUnwindSafe(|| {
+            let _scope = InvocationExecutionScope::enter();
+            assert_eq!(pipeline_execution_depth(), 1);
+            panic!("test pipeline unwind");
+        }));
+        assert!(unwind.is_err());
+        assert_eq!(pipeline_execution_depth(), 0);
+        assert_eq!(active_pipeline_count(), 0);
+    }
+
+    #[test]
+    fn execution_scope_rejects_nested_ffi_calls_before_runtime_access() {
+        let _scope = InvocationExecutionScope::enter();
+        let mut diagnostic = [0_u8; 128];
+        let mut result = CallResult {
+            size: mem::size_of::<CallResult>() as u32,
+            status: 0,
+            flags: 0,
+            _reserved: 0,
+            diagnostic: diagnostic.as_mut_ptr(),
+            diagnostic_capacity: diagnostic.len(),
+            diagnostic_required: 0,
+            diagnostic_written: 0,
+        };
+        let mut handle = 0;
+
+        assert_eq!(
+            unsafe { multi_pwsh_create(&mut handle, &mut result) },
+            Status::Backpressure.value()
+        );
+        assert_eq!(result.status, Status::Backpressure.value());
+        assert_eq!(handle, 0);
+        assert_eq!(
+            std::str::from_utf8(&diagnostic[..result.diagnostic_written]).unwrap(),
+            "PowerShell FFI calls are not permitted from code invoked by an active PowerShell pipeline."
+        );
+    }
+
+    #[test]
+    fn execution_scope_rejects_cross_thread_ffi_calls_before_runtime_access() {
+        let _scope = InvocationExecutionScope::enter();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                let error = reject_active_pipeline_ffi_call().unwrap_err();
+                assert_eq!(error.0, Status::Backpressure);
+                assert_eq!(
+                    error.1,
+                    "PowerShell FFI calls are not permitted while any PowerShell pipeline is running."
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn explicitly_permitted_v2_call_remains_allowed_without_execution_scope() {
+        let mut result = CallResult {
+            size: mem::size_of::<CallResult>() as u32,
+            status: 0,
+            flags: 0,
+            _reserved: 0,
+            diagnostic: std::ptr::null_mut(),
+            diagnostic_capacity: 0,
+            diagnostic_required: 0,
+            diagnostic_written: 0,
+        };
+
+        assert_eq!(
+            unsafe { v2_call_allow_active_pipeline(&mut result, || Ok(Status::Success)) },
+            Status::Success.value()
+        );
+    }
+
+    #[test]
+    fn active_pipeline_rejects_session_mutation_before_operation_locking() {
+        let _scope = InvocationExecutionScope::enter();
+        let error = reject_active_pipeline_session_mutation().unwrap_err();
+
+        assert_eq!(error.0, Status::Backpressure);
+        assert_eq!(
+            error.1,
+            "PowerShell session variables cannot be read or changed while any PowerShell pipeline is running."
+        );
+    }
+
+    #[test]
     fn abi_helpers_and_sized_calls_enforce_the_contract_without_a_payload() {
         const REQUIRED_FEATURES: u64 = FEATURE_STRUCTURED_INVOCATION_ERRORS
             | FEATURE_PER_CALL_DIAGNOSTICS
@@ -4197,7 +4777,10 @@ mod tests {
             | FEATURE_SNAPSHOT_PROJECTIONS
             | FEATURE_SESSION_CONFIGURATION
             | FEATURE_SESSION_VARIABLES
-            | FEATURE_CAPABILITY_RPC;
+            | FEATURE_CAPABILITY_RPC
+            | FEATURE_LIVE_OBJECT_PROBE
+            | FEATURE_LIVE_SESSION_OBJECT_PROBE
+            | FEATURE_LIVE_OBJECT_CONTRACTS;
 
         assert_eq!(ABI_VERSION, 2);
         assert_eq!(feature_flags(), REQUIRED_FEATURES);
@@ -6058,7 +6641,7 @@ mod tests {
     fn calls_contain_native_panics() {
         let mut call_result = v2_call_result_without_diagnostic();
         assert_eq!(
-            unsafe { v2_call(&mut call_result, || panic!("test panic containment")) },
+            unsafe { v2_call_allow_active_pipeline(&mut call_result, || panic!("test panic containment")) },
             Status::Panic.value()
         );
         assert_eq!(call_result.status, Status::Panic.value());

--- a/crates/pwsh-sdk-ffi/src/lib.rs
+++ b/crates/pwsh-sdk-ffi/src/lib.rs
@@ -561,6 +561,10 @@ thread_local! {
     static CAPABILITY_CALLBACK_DEPTH: Cell<u32> = const { Cell::new(0) };
     static PIPELINE_EXECUTION_DEPTH: Cell<u32> = const { Cell::new(0) };
 }
+#[cfg(test)]
+thread_local! {
+    static TEST_FFI_CALL_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
 
 fn state() -> &'static Mutex<State> {
     STATE.get_or_init(|| Mutex::new(State::default()))
@@ -571,10 +575,34 @@ struct InvocationExecutionScope {
     _test_scope_lock: Option<MutexGuard<'static, ()>>,
 }
 
+#[cfg(test)]
+struct TestFfiCallScope {
+    _lock: MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl TestFfiCallScope {
+    fn enter() -> Self {
+        TEST_FFI_CALL_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self {
+            _lock: TEST_PIPELINE_SCOPE_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestFfiCallScope {
+    fn drop(&mut self) {
+        TEST_FFI_CALL_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
+}
+
 impl InvocationExecutionScope {
     fn enter() -> Self {
         #[cfg(test)]
-        let test_scope_lock = if pipeline_execution_depth() == 0 {
+        let test_scope_lock = if pipeline_execution_depth() == 0 && TEST_FFI_CALL_DEPTH.with(Cell::get) == 0 {
             Some(
                 TEST_PIPELINE_SCOPE_LOCK
                     .lock()
@@ -1623,16 +1651,6 @@ unsafe fn v2_call_with_active_pipeline_policy<F>(
 where
     F: FnOnce() -> Result<Status, (Status, String)>,
 {
-    #[cfg(test)]
-    let _test_call_lock = if pipeline_execution_depth() == 0 {
-        Some(
-            TEST_PIPELINE_SCOPE_LOCK
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner()),
-        )
-    } else {
-        None
-    };
     let result = match prepare_call_result(result) {
         Ok(result) => result,
         Err(status) => return status.value(),
@@ -1655,6 +1673,12 @@ where
             "PowerShell FFI calls are not permitted from code invoked by an active PowerShell pipeline.",
         );
     }
+    #[cfg(test)]
+    let _test_call_lock = if !allow_active_pipeline && pipeline_execution_depth() == 0 {
+        Some(TestFfiCallScope::enter())
+    } else {
+        None
+    };
 
     match catch_unwind(AssertUnwindSafe(operation)) {
         Ok(Ok(status)) => complete_call_result(result, status, ""),

--- a/docs/in-process-ffi.md
+++ b/docs/in-process-ffi.md
@@ -19,6 +19,112 @@ hosted CoreCLR is a supported general .NET topology. The runtime host rejects
 incompatible initialization. Do not rely on dynamic runtime switching, multiple
 PowerShell runtime versions, or runtime unloading in the same process.
 
+### Experimental live-object probe
+
+`PowerShellRuntime.CreateLiveObjectProbe` is a deliberately narrow,
+non-production `IUnknown` experiment. It creates a payload-local
+`PSCustomObject` with one numeric `Count` property and projects only
+`GetCount` and `Increment` through a source-generated, fixed-GUID COM
+interface. It is portable userland `ComWrappers` use: it does not use Windows
+COM activation, registry metadata, BSTR/automation marshalling, or classic
+runtime COM interop.
+
+The `net10.0` facade receives an opaque interface pointer, creates a unique
+generated RCW, and immediately releases the producer's transit reference. The
+RCW owns its reference until `PowerShellLiveObjectProbe.Dispose`, which calls
+`ComObject.FinalRelease` after unregistering the payload identity entry; using
+the wrapper afterward throws
+`ObjectDisposedException`. `PowerShell.AddArgument(PowerShellLiveObjectProbe)`
+returns the original pointer to the payload binding, which accepts only
+pointers it created and restores the original payload object rather than
+accepting arbitrary foreign `IUnknown` values.
+
+This is currently validated only by the Windows x64 NativeAOT sample with an
+explicit PowerShell 7.4 payload. It must be used only after the creating
+invocation has completed and never from a capability callback or while a
+pipeline is active. The existing process-global operation lock does not make
+arbitrary direct proxy calls, reentrancy, runspace affinity, arbitrary member
+invocation, or cross-platform payload activation supported. The probe is not a
+general mechanism for exposing `PSObject`, SMA objects, delegates, hosts,
+credentials, reflection, or ordinary managed object references to the
+consumer runtime.
+
+### Experimental reverse session-object probe
+
+`PowerShellSessionObjectProbe` proves the inverse direction. A .NET 10-owned
+broker exports an `IUnknown` transfer reference to
+`PowerShellSession.SetLiveObjectVariable`; the payload creates a unique
+generated RCW, wraps it in a small PowerShell-visible payload proxy, and
+places that proxy in the session's `SessionStateProxy`. PowerShell can invoke
+only the proxy's fixed `Count` and `Increment` members, whose bodies call the
+generated interface and run in the .NET 10 broker.
+
+The payload retains each projected RCW by variable name and calls
+`ComObject.FinalRelease` when its value is replaced through either session
+setter, removed with `RemoveVariable`, or the session owner is released. The
+.NET 10 facade releases its transfer reference immediately after a successful
+or failed assignment, but the managed probe itself must outlive its
+session-variable binding. Remove the variable before disposing the probe.
+
+This is a narrow Windows x64 / PowerShell 7.4 acceptance experiment, not
+support for arbitrary .NET 10 objects in PowerShell session state. PowerShell
+scripts can remove, overwrite, or alias the variable independently. The
+payload reconciles its tracked bindings when each pipeline ends: it releases a
+proxy once no session variable references it and retains it while an alias
+still exists. The session mutation lock still rejects changes during an active
+pipeline, and the proxy must not call back into the FFI API.
+
+### Preview contract packs
+
+`PowerShellLiveObjectContract` and `PowerShellLiveObject<TContract>` provide
+the preview path for application-owned, consumer-to-session live objects.
+Applications compile one source-generated `IUnknown` interface into their
+`net10.0` consumer and their trusted `net8.0` payload adapter. The contract
+contains a non-empty interface GUID, major/minor version, and direction flags;
+methods must use preserved HRESULT returns and explicitly ABI-safe values.
+
+The consumer activates with
+`PowerShellRuntime.Activate(contractPacks)` or
+`PowerShellRuntime.Activate(payloadDirectory, contractPacks)`. Each
+`PowerShellLiveObjectContractPack` names an absolute payload-adapter assembly
+and its assembly-qualified static export type. During activation, the host
+loads the adapter into the selected payload runtime and invokes its
+`GetLiveObjectContractPackV1` unmanaged export. That export supplies a bounded
+contract descriptor list plus create/release callbacks for PowerShell-visible
+payload proxies. The payload registry rejects unknown, duplicate,
+direction-incompatible, or metadata-incompatible contracts before it projects
+an `IUnknown`.
+
+The `dotnet/live-object-test-pack` project is an acceptance fixture, not a
+shipping application contract. It proves that a separately compiled net8
+adapter can project a .NET 10 broker into a `PowerShellSession`, expose
+ordinary `Count` and `Increment` script members, retain its live state across
+invocations, and preserve a session-variable alias.
+
+Contract packs are deliberately explicit and trusted application code. They
+cannot expose raw pointers through PowerShell or turn arbitrary CLR objects
+into contracts. The current external-pack registry supports only the proven
+consumer-to-session direction. Payload-to-consumer object contracts,
+cross-session identity, compatibility relaxation, source generation, and
+application-specific schemas remain future work.
+
+### Live-object execution policy
+
+Direct calls from a PowerShell-visible payload proxy to a consumer broker are
+allowed only when the broker records bounded consumer-owned intent. Such a
+call must not invoke the native FFI, start another pipeline, access payload
+session state, call capability RPC, or mutate UI/runspace-affine state.
+
+The native bridge tracks active pipeline execution process-wide. General FFI
+calls fail with `Backpressure` while any pipeline is active, including calls
+forwarded to another thread by a broker; calls from a capability callback also
+fail before they acquire runtime or operation locks. Cancellation, operation
+polling/waiting, session snapshots/events, and immutable-result reads remain
+available while a pipeline runs. Session-variable reads and mutations fail
+with `Backpressure` before lock acquisition. These rules prevent deadlock;
+they do not make a live PowerShell object or runspace callable from a broker.
+A session-affine dispatcher is required before supporting that category.
+
 ## Lifecycle and ABI
 
 - The direct activation exports are process-global and accept one canonical

--- a/dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj
+++ b/dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj
@@ -12,6 +12,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(DiscoveredBindingsWrappersPath)" Visible="false" />
+    <Compile Include="..\interop\PowerShellLiveObjectProbeContract.cs"
+             Link="PowerShellLiveObjectProbeContract.cs" />
+    <Compile Include="..\interop\PowerShellLiveObjectContract.cs"
+             Link="PowerShellLiveObjectContract.cs" />
+    <Compile Include="..\interop\PowerShellLiveObjectTestContract.cs"
+             Link="PowerShellLiveObjectTestContract.cs" />
   </ItemGroup>
   <Target Name="ResolvePwshExePath" Condition="'$(PwshExePath)' == ''">
     <PropertyGroup>

--- a/dotnet/bindings/FfiBindings.cs
+++ b/dotnet/bindings/FfiBindings.cs
@@ -2,16 +2,19 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using System.Threading;
 using System.Text;
 using System.Management.Automation;
 using System.Management.Automation.Host;
 using System.Management.Automation.Runspaces;
+using Devolutions.PowerShell.Ffi.LiveObjects;
 
 namespace NativeHost
 {
@@ -54,6 +57,9 @@ namespace NativeHost
         private const ulong FfiFeatureSessionConfiguration = 1UL << 14;
         private const ulong FfiFeatureSessionVariables = 1UL << 15;
         private const ulong FfiFeatureCapabilityRpc = 1UL << 16;
+        private const ulong FfiFeatureLiveObjectProbe = 1UL << 17;
+        private const ulong FfiFeatureLiveSessionObjectProbe = 1UL << 18;
+        private const ulong FfiFeatureLiveObjectContracts = 1UL << 19;
         private const int FfiMaxSessionEvents = 32;
 
         [StructLayout(LayoutKind.Sequential)]
@@ -143,6 +149,14 @@ namespace NativeHost
             public IntPtr PowerShellSession_RemoveVariable;
             public IntPtr PowerShellSession_GetVariableSnapshot;
             public IntPtr PowerShell_SetCapabilityContext;
+            public IntPtr LiveObjectProbe_Create;
+            public IntPtr LiveObjectProbe_Release;
+            public IntPtr LiveObjectProbe_Unregister;
+            public IntPtr PowerShell_AddArgumentLiveObject;
+            public IntPtr PowerShellSession_SetLiveObjectVariable;
+            public IntPtr LiveObjectContractPack_Register;
+            public IntPtr PowerShellSession_SetLiveObjectContractVariable;
+            public IntPtr LiveObjectContractPack_RegisterMany;
         }
 
         private static string[] NormalizeDirectories(string[] directories, string description)
@@ -217,6 +231,17 @@ namespace NativeHost
             new ConcurrentDictionary<IntPtr, InvocationResult>();
         private static readonly ConcurrentDictionary<IntPtr, FfiInputBuffer> FfiInputBuffers =
             new ConcurrentDictionary<IntPtr, FfiInputBuffer>();
+        private static readonly ConcurrentDictionary<IntPtr, FfiLiveObjectProbeEntry> FfiLiveObjectProbes =
+            new ConcurrentDictionary<IntPtr, FfiLiveObjectProbeEntry>();
+        private static readonly StrategyBasedComWrappers FfiLiveObjectComWrappers = new();
+        private static readonly PowerShellLiveObjectContract FfiLiveObjectProbeContract = new(
+            typeof(IPowerShellLiveObjectProbe).GUID,
+            majorVersion: 1,
+            minorVersion: 0,
+            PowerShellLiveObjectDirection.ConsumerToSession);
+        private static readonly FfiLiveObjectContractPackRegistry FfiLiveObjectContracts = new(
+            FfiLiveObjectProbeContract,
+            static pointer => new FfiManagedLiveObjectLease(FfiLiveSessionObjectProbeProxy.Create(pointer)));
         private static long FfiNextInvocationId;
         private static IntPtr FfiApiV2Ptr = IntPtr.Zero;
 
@@ -251,7 +276,8 @@ namespace NativeHost
                 AbiVersion = FfiBindingsAbiVersion,
                 FeatureFlags = (1UL << 4) | (1UL << 5) | (1UL << 6) | FfiFeatureAsyncOperationPrimitives |
                     FfiFeatureSessionPrimitives | FfiFeatureSessionPolling | FfiFeatureSnapshotProjections |
-                    FfiFeatureSessionConfiguration | FfiFeatureSessionVariables | FfiFeatureCapabilityRpc,
+                    FfiFeatureSessionConfiguration | FfiFeatureSessionVariables | FfiFeatureCapabilityRpc |
+                    FfiFeatureLiveObjectProbe | FfiFeatureLiveSessionObjectProbe | FfiFeatureLiveObjectContracts,
                 PowerShell_Create = (IntPtr)(delegate* unmanaged<IntPtr*, FfiCallResult*, int>)&FfiPowerShell_Create,
                 PowerShell_Release = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiPowerShell_Release,
                 PowerShell_AddArgumentUtf8 = (IntPtr)(delegate* unmanaged<IntPtr, byte*, int, FfiCallResult*, int>)&FfiPowerShell_AddArgumentUtf8,
@@ -294,6 +320,14 @@ namespace NativeHost
                 PowerShellSession_RemoveVariable = (IntPtr)(delegate* unmanaged<IntPtr, byte*, int, uint*, FfiCallResult*, int>)&FfiPowerShellSession_RemoveVariable,
                 PowerShellSession_GetVariableSnapshot = (IntPtr)(delegate* unmanaged<IntPtr, byte*, int, uint*, uint*, byte*, int, int*, FfiCallResult*, int>)&FfiPowerShellSession_GetVariableSnapshot,
                 PowerShell_SetCapabilityContext = (IntPtr)(delegate* unmanaged<IntPtr, ulong, ulong, IntPtr, FfiCallResult*, int>)&FfiPowerShell_SetCapabilityContext,
+                LiveObjectProbe_Create = (IntPtr)(delegate* unmanaged<long, IntPtr*, FfiCallResult*, int>)&FfiLiveObjectProbe_Create,
+                LiveObjectProbe_Release = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiLiveObjectProbe_Release,
+                LiveObjectProbe_Unregister = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiLiveObjectProbe_Unregister,
+                PowerShell_AddArgumentLiveObject = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, FfiCallResult*, int>)&FfiPowerShell_AddArgumentLiveObject,
+                PowerShellSession_SetLiveObjectVariable = (IntPtr)(delegate* unmanaged<IntPtr, byte*, int, IntPtr, FfiCallResult*, int>)&FfiPowerShellSession_SetLiveObjectVariable,
+                LiveObjectContractPack_Register = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiLiveObjectContractPack_Register,
+                PowerShellSession_SetLiveObjectContractVariable = (IntPtr)(delegate* unmanaged<IntPtr, byte*, int, NativeLiveObjectContractDescriptor*, IntPtr, FfiCallResult*, int>)&FfiPowerShellSession_SetLiveObjectContractVariable,
+                LiveObjectContractPack_RegisterMany = (IntPtr)(delegate* unmanaged<IntPtr*, uint, FfiCallResult*, int>)&FfiLiveObjectContractPack_RegisterMany,
             };
         }
 
@@ -608,6 +642,76 @@ namespace NativeHost
         }
 
         [UnmanagedCallersOnly]
+        public static unsafe int FfiPowerShellSession_SetLiveObjectVariable(
+            IntPtr ptrSessionHandle,
+            byte* name,
+            int nameLength,
+            IntPtr ptrComObject,
+            FfiCallResult* result)
+        {
+            if (ptrComObject == IntPtr.Zero)
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Live session object probe pointer is null.");
+            }
+
+            int status = ReadUtf8(name, nameLength, result, out string nameText);
+            if (status != FfiStatusSuccess)
+            {
+                return status;
+            }
+
+            return Execute(result, () => GetPowerShellSession(ptrSessionHandle).SetLiveObjectVariable(nameText, ptrComObject));
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiLiveObjectContractPack_Register(
+            IntPtr ptrPackApi,
+            FfiCallResult* result)
+        {
+            return Execute(result, () => FfiLiveObjectContracts.Register(ptrPackApi));
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiLiveObjectContractPack_RegisterMany(
+            IntPtr* ptrPackApis,
+            uint packCount,
+            FfiCallResult* result)
+        {
+            return Execute(result, () => FfiLiveObjectContracts.RegisterMany(ptrPackApis, packCount));
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiPowerShellSession_SetLiveObjectContractVariable(
+            IntPtr ptrSessionHandle,
+            byte* name,
+            int nameLength,
+            NativeLiveObjectContractDescriptor* contract,
+            IntPtr ptrComObject,
+            FfiCallResult* result)
+        {
+            if (contract == null || ptrComObject == IntPtr.Zero)
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Live object contract transfer is invalid.");
+            }
+
+            int status = ReadUtf8(name, nameLength, result, out string nameText);
+            if (status != FfiStatusSuccess)
+            {
+                return status;
+            }
+
+            return Execute(result, () =>
+            {
+                PowerShellLiveObjectContract descriptor =
+                    PowerShellLiveObjectContract.FromNative(*contract);
+                GetPowerShellSession(ptrSessionHandle).SetLiveObjectVariable(
+                    nameText,
+                    descriptor,
+                    ptrComObject);
+            });
+        }
+
+        [UnmanagedCallersOnly]
         public static unsafe int FfiPowerShellSession_RemoveVariable(
             IntPtr ptrSessionHandle,
             byte* name,
@@ -870,6 +974,75 @@ namespace NativeHost
                 PowerShell ps = GetPowerShell(ptrHandle);
                 FfiInvocationResults.TryRemove(ptrHandle, out _);
                 ps.AddArgument(value);
+            });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiPowerShell_AddArgumentLiveObject(
+            IntPtr ptrHandle,
+            IntPtr ptrComObject,
+            FfiCallResult* result)
+        {
+            return Execute(result, () =>
+            {
+                PowerShell ps = GetPowerShell(ptrHandle);
+                FfiInvocationResults.TryRemove(ptrHandle, out _);
+                ps.AddArgument(GetLiveObjectProbe(ptrComObject).Value);
+            });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiLiveObjectProbe_Create(
+            long initialCount,
+            IntPtr* ptrComObject,
+            FfiCallResult* result)
+        {
+            if (ptrComObject == null)
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Live object probe output pointer is null.");
+            }
+
+            return Execute(result, () =>
+            {
+                using var powerShell = PowerShell.Create();
+                powerShell
+                    .AddScript("param([long]$initialCount) [pscustomobject]@{ Count = $initialCount }", useLocalScope: true)
+                    .AddArgument(initialCount);
+                Collection<PSObject> output = powerShell.Invoke();
+                if (output.Count != 1)
+                {
+                    throw new InvalidOperationException("Live object probe did not produce exactly one PowerShell object.");
+                }
+
+                *ptrComObject = ExportLiveObjectProbe(output[0]);
+            });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiLiveObjectProbe_Release(IntPtr ptrComObject, FfiCallResult* result)
+        {
+            return Execute(result, () =>
+            {
+                if (!FfiLiveObjectProbes.TryGetValue(ptrComObject, out FfiLiveObjectProbeEntry entry) ||
+                    !entry.TryReleaseTransitReference())
+                {
+                    throw new InvalidOperationException("Live object probe transit reference is invalid.");
+                }
+
+                ReleaseComInterface(ptrComObject);
+            });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiLiveObjectProbe_Unregister(IntPtr ptrComObject, FfiCallResult* result)
+        {
+            return Execute(result, () =>
+            {
+                if (!FfiLiveObjectProbes.TryRemove(ptrComObject, out FfiLiveObjectProbeEntry entry) ||
+                    !entry.IsTransitReferenceReleased)
+                {
+                    throw new InvalidOperationException("Live object probe pointer is invalid.");
+                }
             });
         }
 
@@ -1453,6 +1626,135 @@ namespace NativeHost
             public bool IsCompleted { get; set; }
         }
 
+        [GeneratedComClass]
+        internal sealed partial class FfiLiveObjectProbeBroker : IPowerShellLiveObjectProbe
+        {
+            private const int EFail = unchecked((int)0x80004005);
+            private readonly object gate = new object();
+
+            public FfiLiveObjectProbeBroker(PSObject value)
+            {
+                Value = value ?? throw new ArgumentNullException(nameof(value));
+            }
+
+            public PSObject Value { get; }
+
+            public int GetCount(out long count)
+            {
+                lock (gate)
+                {
+                    return TryGetCount(out count) ? FfiStatusSuccess : EFail;
+                }
+            }
+
+            public int Increment(out long count)
+            {
+                lock (gate)
+                {
+                    if (!TryGetCount(out count) || count == long.MaxValue)
+                    {
+                        return EFail;
+                    }
+
+                    count++;
+                    Value.Properties["Count"].Value = count;
+                    return FfiStatusSuccess;
+                }
+            }
+
+            private bool TryGetCount(out long count)
+            {
+                if (Value.Properties["Count"]?.Value is long value)
+                {
+                    count = value;
+                    return true;
+                }
+
+                count = default;
+                return false;
+            }
+        }
+
+        private sealed class FfiLiveObjectProbeEntry
+        {
+            private readonly WeakReference<FfiLiveObjectProbeBroker> broker;
+            private int transitReferenceActive = 1;
+
+            public FfiLiveObjectProbeEntry(FfiLiveObjectProbeBroker broker)
+            {
+                this.broker = new WeakReference<FfiLiveObjectProbeBroker>(broker);
+            }
+
+            public bool TryGetBroker(out FfiLiveObjectProbeBroker value)
+            {
+                return broker.TryGetTarget(out value);
+            }
+
+            public bool TryReleaseTransitReference()
+            {
+                return Interlocked.Exchange(ref transitReferenceActive, 0) == 1;
+            }
+
+            public bool IsTransitReferenceReleased => Volatile.Read(ref transitReferenceActive) == 0;
+        }
+
+        private static IntPtr ExportLiveObjectProbe(PSObject value)
+        {
+            var broker = new FfiLiveObjectProbeBroker(value);
+            IntPtr ptrComObject = FfiLiveObjectComWrappers.GetOrCreateComInterfaceForObject(
+                broker,
+                CreateComInterfaceFlags.None);
+            if (ptrComObject == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Live object probe did not create an IUnknown pointer.");
+            }
+
+            var entry = new FfiLiveObjectProbeEntry(broker);
+            while (!FfiLiveObjectProbes.TryAdd(ptrComObject, entry))
+            {
+                if (FfiLiveObjectProbes.TryGetValue(ptrComObject, out FfiLiveObjectProbeEntry existing) &&
+                    existing.TryGetBroker(out _))
+                {
+                    ReleaseComInterface(ptrComObject);
+                    throw new InvalidOperationException("Live object probe pointer collision.");
+                }
+
+                FfiLiveObjectProbes.TryRemove(ptrComObject, out _);
+            }
+
+            return ptrComObject;
+        }
+
+        private static FfiLiveObjectProbeBroker GetLiveObjectProbe(IntPtr ptrComObject)
+        {
+            if (ptrComObject == IntPtr.Zero ||
+                !FfiLiveObjectProbes.TryGetValue(ptrComObject, out FfiLiveObjectProbeEntry entry) ||
+                !entry.TryGetBroker(out FfiLiveObjectProbeBroker broker))
+            {
+                FfiLiveObjectProbes.TryRemove(ptrComObject, out _);
+                throw new InvalidOperationException("Live object probe pointer is invalid or no longer alive.");
+            }
+
+            return broker;
+        }
+
+        private static unsafe void ReleaseComInterface(IntPtr ptrComObject)
+        {
+            if (ptrComObject == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Live object probe pointer is null.");
+            }
+
+            IntPtr* vtable = *(IntPtr**)ptrComObject;
+            if (vtable == null || vtable[2] == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Live object probe pointer has an invalid IUnknown vtable.");
+            }
+
+            var release = (delegate* unmanaged[MemberFunction]<IntPtr, uint>)vtable[2];
+            _ = release(ptrComObject);
+        }
+
         private sealed class FfiPowerShellPipeline : IDisposable
         {
             private int disposed;
@@ -1532,6 +1834,8 @@ namespace NativeHost
             private readonly bool addToHistory;
             private readonly uint errorPreference;
             private readonly List<FfiSessionEvent> events = new List<FfiSessionEvent>(FfiMaxSessionEvents);
+            private readonly Dictionary<string, FfiLiveObjectLease> liveObjectVariables =
+                new Dictionary<string, FfiLiveObjectLease>(StringComparer.OrdinalIgnoreCase);
             private int leaseCount = 1;
             private int activePipelineCount;
             private long eventSequence;
@@ -1801,6 +2105,7 @@ namespace NativeHost
                 lock (gate)
                 {
                     activePipelineCount = Math.Max(0, activePipelineCount - 1);
+                    ReconcileLiveObjectVariablesLocked();
                     invocationCount++;
                     if (addToHistory)
                     {
@@ -1870,6 +2175,43 @@ namespace NativeHost
                     EnsureVariableMutationAllowed();
                     ValidateVariableName(name);
                     runspace.SessionStateProxy.SetVariable(name, value);
+                    ReconcileLiveObjectVariablesLocked();
+                }
+            }
+
+            public void SetLiveObjectVariable(string name, IntPtr ptrComObject)
+            {
+                SetLiveObjectVariable(name, FfiLiveObjectProbeContract, ptrComObject);
+            }
+
+            public void SetLiveObjectVariable(
+                string name,
+                PowerShellLiveObjectContract contract,
+                IntPtr ptrComObject)
+            {
+                if (ptrComObject == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException("Live session object pointer is null.");
+                }
+
+                FfiLiveObjectLease value = FfiLiveObjectContracts.CreateLease(contract, ptrComObject);
+
+                lock (gate)
+                {
+                    try
+                    {
+                        EnsureVariableMutationAllowed();
+                        ValidateVariableName(name);
+                        runspace.SessionStateProxy.SetVariable(name, value.Value);
+                    }
+                    catch
+                    {
+                        value.Dispose();
+                        throw;
+                    }
+
+                    ReconcileLiveObjectVariablesLocked();
+                    liveObjectVariables.Add(name, value);
                 }
             }
 
@@ -1886,6 +2228,7 @@ namespace NativeHost
                     }
 
                     runspace.SessionStateProxy.PSVariable.Remove(name);
+                    ReconcileLiveObjectVariablesLocked();
                     return true;
                 }
             }
@@ -2037,11 +2380,131 @@ namespace NativeHost
 
                 disposed = true;
                 AddEventLocked(StateClosed);
+                ReleaseAllLiveObjectVariablesLocked();
                 if (ownsRunspace)
                 {
                     runspace.Dispose();
                 }
             }
+
+            private void ReleaseLiveObjectVariableLocked(string name)
+            {
+                if (liveObjectVariables.Remove(name, out FfiLiveObjectLease value))
+                {
+                    value.Dispose();
+                }
+            }
+
+            private void ReconcileLiveObjectVariablesLocked()
+            {
+                PSVariable[] variables = runspace.SessionStateProxy.InvokeProvider.Item
+                    .Get("Variable:\\*")
+                    .Select(static variable => variable.BaseObject as PSVariable)
+                    .Where(static variable => variable is not null)
+                    .Select(static variable => variable!)
+                    .ToArray();
+                var reconciled = new Dictionary<string, FfiLiveObjectLease>(StringComparer.OrdinalIgnoreCase);
+                foreach (KeyValuePair<string, FfiLiveObjectLease> entry in liveObjectVariables)
+                {
+                    object value = entry.Value.Value;
+                    PSVariable variable = variables.FirstOrDefault(variable => ReferenceEquals(variable.Value, value));
+                    if (variable is not null && !reconciled.ContainsKey(variable.Name))
+                    {
+                        reconciled.Add(variable.Name, entry.Value);
+                    }
+                    else
+                    {
+                        entry.Value.Dispose();
+                    }
+                }
+
+                liveObjectVariables.Clear();
+                foreach (KeyValuePair<string, FfiLiveObjectLease> entry in reconciled)
+                {
+                    liveObjectVariables.Add(entry.Key, entry.Value);
+                }
+            }
+
+            private void ReleaseAllLiveObjectVariablesLocked()
+            {
+                FfiLiveObjectLease[] values = liveObjectVariables.Values.ToArray();
+                liveObjectVariables.Clear();
+                foreach (FfiLiveObjectLease value in values)
+                {
+                    value.Dispose();
+                }
+            }
+        }
+
+        public sealed class FfiLiveSessionObjectProbeProxy : IDisposable
+        {
+            private readonly object gate = new object();
+            private IPowerShellLiveObjectProbe probe;
+            private ComObject comObject;
+
+            private FfiLiveSessionObjectProbeProxy(
+                IPowerShellLiveObjectProbe probe,
+                ComObject comObject)
+            {
+                this.probe = probe;
+                this.comObject = comObject;
+            }
+
+            public long Count => Invoke(static (IPowerShellLiveObjectProbe value, out long count) => value.GetCount(out count));
+
+            public long Increment()
+            {
+                return Invoke(static (IPowerShellLiveObjectProbe value, out long count) => value.Increment(out count));
+            }
+
+            public static FfiLiveSessionObjectProbeProxy Create(IntPtr ptrComObject)
+            {
+                object projected = FfiLiveObjectComWrappers.GetOrCreateObjectForComInstance(
+                    ptrComObject,
+                    CreateObjectFlags.UniqueInstance);
+                ComObject comObject = projected as ComObject
+                    ?? throw new InvalidOperationException("Live session object probe did not create a source-generated COM wrapper.");
+                IPowerShellLiveObjectProbe probe = projected as IPowerShellLiveObjectProbe;
+                if (probe is null)
+                {
+                    comObject.FinalRelease();
+                    throw new InvalidOperationException("Live session object probe has an unexpected COM contract.");
+                }
+
+                return new FfiLiveSessionObjectProbeProxy(probe, comObject);
+            }
+
+            public void Dispose()
+            {
+                lock (gate)
+                {
+                    ComObject value = comObject;
+                    probe = null;
+                    comObject = null;
+                    value?.FinalRelease();
+                }
+            }
+
+            private long Invoke(ProbeOperation operation)
+            {
+                lock (gate)
+                {
+                    if (probe is null)
+                    {
+                        throw new ObjectDisposedException(nameof(FfiLiveSessionObjectProbeProxy));
+                    }
+
+                    int hresult = operation(probe, out long count);
+                    if (hresult != FfiStatusSuccess)
+                    {
+                        throw new COMException("The .NET session object probe call failed.", hresult);
+                    }
+
+                    return count;
+                }
+            }
+
+            private delegate int ProbeOperation(IPowerShellLiveObjectProbe value, out long count);
         }
 
         private readonly struct FfiSessionSnapshot

--- a/dotnet/bindings/LiveObjectContractPackRegistry.cs
+++ b/dotnet/bindings/LiveObjectContractPackRegistry.cs
@@ -1,0 +1,238 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+namespace NativeHost;
+
+internal abstract class FfiLiveObjectLease : IDisposable
+{
+    internal abstract object Value { get; }
+
+    public abstract void Dispose();
+}
+
+internal sealed class FfiManagedLiveObjectLease : FfiLiveObjectLease
+{
+    private IDisposable? value;
+
+    internal FfiManagedLiveObjectLease(object value)
+    {
+        Value = value ?? throw new ArgumentNullException(nameof(value));
+        this.value = value as IDisposable
+            ?? throw new ArgumentException("The live object payload proxy must be disposable.", nameof(value));
+    }
+
+    internal override object Value { get; }
+
+    public override void Dispose()
+    {
+        IDisposable? value = Interlocked.Exchange(ref this.value, null);
+        value?.Dispose();
+    }
+}
+
+internal sealed unsafe class FfiExternalLiveObjectLease : FfiLiveObjectLease
+{
+    private readonly delegate* unmanaged<IntPtr, void> release;
+    private IntPtr proxyHandle;
+
+    internal FfiExternalLiveObjectLease(
+        IntPtr proxyHandle,
+        delegate* unmanaged<IntPtr, void> release)
+    {
+        if (proxyHandle == IntPtr.Zero)
+        {
+            throw new ArgumentException("The payload contract pack returned a null proxy handle.", nameof(proxyHandle));
+        }
+
+        this.proxyHandle = proxyHandle;
+        this.release = release;
+    }
+
+    internal override object Value
+    {
+        get
+        {
+            IntPtr value = Volatile.Read(ref proxyHandle);
+            if (value == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(FfiExternalLiveObjectLease));
+            }
+
+            try
+            {
+                return GCHandle.FromIntPtr(value).Target
+                    ?? throw new InvalidOperationException("The payload contract pack proxy handle has no target.");
+            }
+            catch (InvalidOperationException exception)
+            {
+                throw new InvalidOperationException("The payload contract pack returned an invalid proxy handle.", exception);
+            }
+        }
+    }
+
+    public override void Dispose()
+    {
+        IntPtr value = Interlocked.Exchange(ref proxyHandle, IntPtr.Zero);
+        if (value != IntPtr.Zero)
+        {
+            release(value);
+        }
+    }
+}
+
+internal unsafe sealed class FfiLiveObjectContractPackRegistry
+{
+    private const uint PackAbiVersion = 1;
+    private const uint MaximumPacks = 16;
+    private const uint MaximumContracts = 32;
+
+    private readonly object gate = new();
+    private readonly Dictionary<PowerShellLiveObjectContract, Registration> registrations = new();
+
+    internal FfiLiveObjectContractPackRegistry(
+        PowerShellLiveObjectContract probeContract,
+        Func<IntPtr, FfiLiveObjectLease> createProbeLease)
+    {
+        registrations.Add(probeContract, Registration.CreateManaged(createProbeLease));
+    }
+
+    internal void Register(IntPtr apiPointer)
+    {
+        RegisterMany(&apiPointer, 1);
+    }
+
+    internal void RegisterMany(IntPtr* apiPointers, uint apiCount)
+    {
+        if (apiPointers == null || apiCount == 0 || apiCount > MaximumPacks)
+        {
+            throw new InvalidOperationException("Live object contract pack input is invalid.");
+        }
+
+        var additions = new Dictionary<PowerShellLiveObjectContract, Registration>();
+        for (uint packIndex = 0; packIndex < apiCount; packIndex++)
+        {
+            IntPtr apiPointer = apiPointers[packIndex];
+            if (apiPointer == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Live object contract pack API pointer is null.");
+            }
+
+            NativeLiveObjectContractPackApi api = *(NativeLiveObjectContractPackApi*)apiPointer;
+            if (api.Size < (nuint)sizeof(NativeLiveObjectContractPackApi) ||
+                api.AbiVersion != PackAbiVersion ||
+                api.ContractCount == 0 ||
+                api.ContractCount > MaximumContracts ||
+                api.Contracts == null ||
+                api.CreatePayloadProxy == IntPtr.Zero ||
+                api.ReleasePayloadProxy == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Live object contract pack API is invalid.");
+            }
+
+            var create = (delegate* unmanaged<IntPtr, IntPtr*, int>)api.CreatePayloadProxy;
+            var release = (delegate* unmanaged<IntPtr, void>)api.ReleasePayloadProxy;
+            for (uint contractIndex = 0; contractIndex < api.ContractCount; contractIndex++)
+            {
+                PowerShellLiveObjectContract contract =
+                    PowerShellLiveObjectContract.FromNative(api.Contracts[contractIndex]);
+                if ((contract.Directions & PowerShellLiveObjectDirection.ConsumerToSession) == 0 ||
+                    !additions.TryAdd(contract, Registration.CreateExternal(create, release)))
+                {
+                    throw new InvalidOperationException("Live object contract pack contains duplicate or unsupported contracts.");
+                }
+            }
+        }
+
+        lock (gate)
+        {
+            foreach (PowerShellLiveObjectContract contract in additions.Keys)
+            {
+                if (registrations.ContainsKey(contract))
+                {
+                    throw new InvalidOperationException("A live object contract has already been registered.");
+                }
+            }
+
+            foreach (KeyValuePair<PowerShellLiveObjectContract, Registration> entry in additions)
+            {
+                registrations.Add(entry.Key, entry.Value);
+            }
+        }
+    }
+
+    internal FfiLiveObjectLease CreateLease(
+        PowerShellLiveObjectContract contract,
+        IntPtr comObject)
+    {
+        if ((contract.Directions & PowerShellLiveObjectDirection.ConsumerToSession) == 0 ||
+            comObject == IntPtr.Zero)
+        {
+            throw new InvalidOperationException("Live object transfer metadata is invalid.");
+        }
+
+        Registration? registration;
+        lock (gate)
+        {
+            if (!registrations.TryGetValue(contract, out registration))
+            {
+                throw new InvalidOperationException("The live object contract is not registered by the payload.");
+            }
+        }
+
+        return registration!.CreateLease(comObject);
+    }
+
+    private sealed class Registration
+    {
+        private readonly Func<IntPtr, FfiLiveObjectLease>? managedFactory;
+        private readonly delegate* unmanaged<IntPtr, IntPtr*, int> create;
+        private readonly delegate* unmanaged<IntPtr, void> release;
+
+        private Registration(Func<IntPtr, FfiLiveObjectLease> managedFactory)
+        {
+            this.managedFactory = managedFactory;
+        }
+
+        private Registration(
+            delegate* unmanaged<IntPtr, IntPtr*, int> create,
+            delegate* unmanaged<IntPtr, void> release)
+        {
+            this.create = create;
+            this.release = release;
+        }
+
+        internal static Registration CreateManaged(Func<IntPtr, FfiLiveObjectLease> factory)
+        {
+            return new Registration(factory);
+        }
+
+        internal static Registration CreateExternal(
+            delegate* unmanaged<IntPtr, IntPtr*, int> create,
+            delegate* unmanaged<IntPtr, void> release)
+        {
+            return new Registration(create, release);
+        }
+
+        internal FfiLiveObjectLease CreateLease(IntPtr comObject)
+        {
+            if (managedFactory is not null)
+            {
+                return managedFactory(comObject);
+            }
+
+            IntPtr proxyHandle = IntPtr.Zero;
+            int hresult = create(comObject, &proxyHandle);
+            if (hresult != 0 || proxyHandle == IntPtr.Zero)
+            {
+                throw new COMException("The payload contract pack could not project the live object.", hresult);
+            }
+
+            return new FfiExternalLiveObjectLease(proxyHandle, release);
+        }
+    }
+}

--- a/dotnet/interop/PowerShellLiveObjectContract.cs
+++ b/dotnet/interop/PowerShellLiveObjectContract.cs
@@ -1,0 +1,146 @@
+#nullable enable
+
+using System;
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+
+namespace Devolutions.PowerShell.Ffi.LiveObjects;
+
+[Flags]
+public enum PowerShellLiveObjectDirection : uint
+{
+    None = 0,
+    PayloadToConsumer = 1,
+    ConsumerToSession = 1 << 1,
+}
+
+/// <summary>
+/// Identifies one explicitly registered cross-runtime live-object contract.
+/// </summary>
+public readonly struct PowerShellLiveObjectContract : IEquatable<PowerShellLiveObjectContract>
+{
+    private const PowerShellLiveObjectDirection KnownDirections =
+        PowerShellLiveObjectDirection.PayloadToConsumer |
+        PowerShellLiveObjectDirection.ConsumerToSession;
+
+    public PowerShellLiveObjectContract(
+        Guid interfaceId,
+        ushort majorVersion,
+        ushort minorVersion,
+        PowerShellLiveObjectDirection directions)
+    {
+        InterfaceId = interfaceId;
+        MajorVersion = majorVersion;
+        MinorVersion = minorVersion;
+        Directions = directions;
+        Validate();
+    }
+
+    public Guid InterfaceId { get; }
+
+    public ushort MajorVersion { get; }
+
+    public ushort MinorVersion { get; }
+
+    public PowerShellLiveObjectDirection Directions { get; }
+
+    public bool Equals(PowerShellLiveObjectContract other)
+    {
+        return InterfaceId == other.InterfaceId &&
+            MajorVersion == other.MajorVersion &&
+            MinorVersion == other.MinorVersion &&
+            Directions == other.Directions;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is PowerShellLiveObjectContract other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(InterfaceId, MajorVersion, MinorVersion, Directions);
+    }
+
+    public static bool operator ==(PowerShellLiveObjectContract left, PowerShellLiveObjectContract right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(PowerShellLiveObjectContract left, PowerShellLiveObjectContract right)
+    {
+        return !left.Equals(right);
+    }
+
+    internal NativeLiveObjectContractDescriptor ToNative()
+    {
+        Validate();
+        Span<byte> interfaceId = stackalloc byte[16];
+        if (!InterfaceId.TryWriteBytes(interfaceId))
+        {
+            throw new InvalidOperationException("The live object contract interface identifier is invalid.");
+        }
+
+        return new NativeLiveObjectContractDescriptor
+        {
+            Size = checked((uint)Marshal.SizeOf<NativeLiveObjectContractDescriptor>()),
+            Directions = checked((uint)Directions),
+            InterfaceIdLow = BinaryPrimitives.ReadUInt64LittleEndian(interfaceId),
+            InterfaceIdHigh = BinaryPrimitives.ReadUInt64LittleEndian(interfaceId[8..]),
+            MajorVersion = MajorVersion,
+            MinorVersion = MinorVersion,
+        };
+    }
+
+    internal static PowerShellLiveObjectContract FromNative(NativeLiveObjectContractDescriptor descriptor)
+    {
+        if (descriptor.Size < (uint)Marshal.SizeOf<NativeLiveObjectContractDescriptor>() ||
+            descriptor.Reserved != 0)
+        {
+            throw new InvalidOperationException("Live object contract descriptor is invalid.");
+        }
+
+        Span<byte> interfaceId = stackalloc byte[16];
+        BinaryPrimitives.WriteUInt64LittleEndian(interfaceId, descriptor.InterfaceIdLow);
+        BinaryPrimitives.WriteUInt64LittleEndian(interfaceId[8..], descriptor.InterfaceIdHigh);
+        return new PowerShellLiveObjectContract(
+            new Guid(interfaceId),
+            descriptor.MajorVersion,
+            descriptor.MinorVersion,
+            checked((PowerShellLiveObjectDirection)descriptor.Directions));
+    }
+
+    private void Validate()
+    {
+        if (InterfaceId == Guid.Empty ||
+            MajorVersion == 0 ||
+            Directions == PowerShellLiveObjectDirection.None ||
+            (Directions & ~KnownDirections) != 0)
+        {
+            throw new ArgumentException("Live object contract metadata is invalid.");
+        }
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct NativeLiveObjectContractDescriptor
+{
+    public uint Size;
+    public uint Directions;
+    public ulong InterfaceIdLow;
+    public ulong InterfaceIdHigh;
+    public ushort MajorVersion;
+    public ushort MinorVersion;
+    public uint Reserved;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public unsafe struct NativeLiveObjectContractPackApi
+{
+    public nuint Size;
+    public uint AbiVersion;
+    public uint ContractCount;
+    public NativeLiveObjectContractDescriptor* Contracts;
+    public IntPtr CreatePayloadProxy;
+    public IntPtr ReleasePayloadProxy;
+}

--- a/dotnet/interop/PowerShellLiveObjectProbeContract.cs
+++ b/dotnet/interop/PowerShellLiveObjectProbeContract.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Devolutions.PowerShell.Ffi.LiveObjects;
+
+[GeneratedComInterface]
+[Guid("9A2A6F07-319B-422A-A7A4-6C3A32C7B379")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal partial interface IPowerShellLiveObjectProbe
+{
+    [PreserveSig]
+    int GetCount(out long count);
+
+    [PreserveSig]
+    int Increment(out long count);
+}

--- a/dotnet/interop/PowerShellLiveObjectTestContract.cs
+++ b/dotnet/interop/PowerShellLiveObjectTestContract.cs
@@ -1,0 +1,32 @@
+#nullable enable
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Devolutions.PowerShell.Ffi.LiveObjects;
+
+/// <summary>
+/// Internal acceptance contract used to verify application-provided live-object
+/// contract packs without adding contract-specific native plumbing.
+/// </summary>
+public static class PowerShellLiveObjectTestContracts
+{
+    public static readonly PowerShellLiveObjectContract Count = new(
+        typeof(IPowerShellLiveObjectTestCount).GUID,
+        majorVersion: 1,
+        minorVersion: 0,
+        PowerShellLiveObjectDirection.ConsumerToSession);
+}
+
+[GeneratedComInterface]
+[Guid("C9A4FEA0-4EA6-48BE-8B4F-B30BB328CCBD")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public partial interface IPowerShellLiveObjectTestCount
+{
+    [PreserveSig]
+    int GetCount(out long count);
+
+    [PreserveSig]
+    int Increment(out long count);
+}

--- a/dotnet/live-object-test-pack/LiveObjectTestPack.cs
+++ b/dotnet/live-object-test-pack/LiveObjectTestPack.cs
@@ -1,0 +1,146 @@
+#nullable enable
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+namespace Devolutions.MultiPwsh.LiveObject.TestPack;
+
+public static unsafe class LiveObjectTestPack
+{
+    private const int EFail = unchecked((int)0x80004005);
+    private static readonly StrategyBasedComWrappers ComWrappers = new();
+    private static readonly IntPtr Api = CreateApi();
+
+    [UnmanagedCallersOnly]
+    public static IntPtr GetLiveObjectContractPackV1()
+    {
+        return Api;
+    }
+
+    [UnmanagedCallersOnly]
+    private static int CreatePayloadProxy(IntPtr comObject, IntPtr* proxyHandle)
+    {
+        if (comObject == IntPtr.Zero || proxyHandle == null)
+        {
+            return EFail;
+        }
+
+        *proxyHandle = IntPtr.Zero;
+        try
+        {
+            var proxy = TestCountProxy.Create(comObject);
+            *proxyHandle = GCHandle.ToIntPtr(GCHandle.Alloc(proxy));
+            return 0;
+        }
+        catch (COMException exception)
+        {
+            return exception.HResult;
+        }
+        catch
+        {
+            return EFail;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    private static void ReleasePayloadProxy(IntPtr proxyHandle)
+    {
+        if (proxyHandle != IntPtr.Zero)
+        {
+            GCHandle handle = GCHandle.FromIntPtr(proxyHandle);
+            if (handle.Target is IDisposable proxy)
+            {
+                proxy.Dispose();
+            }
+
+            handle.Free();
+        }
+    }
+
+    private static IntPtr CreateApi()
+    {
+        NativeLiveObjectContractDescriptor* contract =
+            (NativeLiveObjectContractDescriptor*)NativeMemory.Alloc((nuint)sizeof(NativeLiveObjectContractDescriptor));
+        *contract = PowerShellLiveObjectTestContracts.Count.ToNative();
+
+        NativeLiveObjectContractPackApi* api =
+            (NativeLiveObjectContractPackApi*)NativeMemory.Alloc((nuint)sizeof(NativeLiveObjectContractPackApi));
+        *api = new NativeLiveObjectContractPackApi
+        {
+            Size = (nuint)sizeof(NativeLiveObjectContractPackApi),
+            AbiVersion = 1,
+            ContractCount = 1,
+            Contracts = contract,
+            CreatePayloadProxy = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr*, int>)&CreatePayloadProxy,
+            ReleasePayloadProxy = (IntPtr)(delegate* unmanaged<IntPtr, void>)&ReleasePayloadProxy,
+        };
+        return (IntPtr)api;
+    }
+
+    public sealed class TestCountProxy : IDisposable
+    {
+        private readonly object gate = new();
+        private IPowerShellLiveObjectTestCount? value;
+        private ComObject? comObject;
+
+        private TestCountProxy(IPowerShellLiveObjectTestCount value, ComObject comObject)
+        {
+            this.value = value;
+            this.comObject = comObject;
+        }
+
+        public long Count => Invoke(static (IPowerShellLiveObjectTestCount value, out long count) => value.GetCount(out count));
+
+        public long Increment()
+        {
+            return Invoke(static (IPowerShellLiveObjectTestCount value, out long count) => value.Increment(out count));
+        }
+
+        public static TestCountProxy Create(IntPtr pointer)
+        {
+            object projected = ComWrappers.GetOrCreateObjectForComInstance(
+                pointer,
+                CreateObjectFlags.UniqueInstance);
+            ComObject comObject = projected as ComObject
+                ?? throw new InvalidOperationException("Live object did not create a source-generated COM wrapper.");
+            if (projected is not IPowerShellLiveObjectTestCount value)
+            {
+                comObject.FinalRelease();
+                throw new InvalidOperationException("Live object has an unexpected COM contract.");
+            }
+
+            return new TestCountProxy(value, comObject);
+        }
+
+        public void Dispose()
+        {
+            lock (gate)
+            {
+                ComObject? release = comObject;
+                value = null;
+                comObject = null;
+                release?.FinalRelease();
+            }
+        }
+
+        private long Invoke(TestCountOperation operation)
+        {
+            lock (gate)
+            {
+                IPowerShellLiveObjectTestCount contract = value
+                    ?? throw new ObjectDisposedException(nameof(TestCountProxy));
+                int hresult = operation(contract, out long count);
+                if (hresult != 0)
+                {
+                    throw new COMException("The external live object contract call failed.", hresult);
+                }
+
+                return count;
+            }
+        }
+
+        private delegate int TestCountOperation(IPowerShellLiveObjectTestCount value, out long count);
+    }
+}

--- a/dotnet/live-object-test-pack/LiveObjectTestPack.csproj
+++ b/dotnet/live-object-test-pack/LiveObjectTestPack.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>Devolutions.MultiPwsh.LiveObject.TestPack</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\interop\PowerShellLiveObjectContract.cs"
+             Link="PowerShellLiveObjectContract.cs" />
+    <Compile Include="..\interop\PowerShellLiveObjectTestContract.cs"
+             Link="PowerShellLiveObjectTestContract.cs" />
+  </ItemGroup>
+</Project>

--- a/dotnet/nativeaot-sample/GenericCountBroker.cs
+++ b/dotnet/nativeaot-sample/GenericCountBroker.cs
@@ -1,0 +1,57 @@
+using System.Runtime.InteropServices.Marshalling;
+using Devolutions.PowerShell.Ffi;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+namespace NativeAotFfiSample;
+
+[GeneratedComClass]
+internal sealed partial class GenericCountBroker : IPowerShellLiveObjectTestCount, IPowerShellLiveObjectBroker
+{
+    private const int EFail = unchecked((int)0x80004005);
+    private readonly object gate = new();
+    private long count;
+    private bool disposed;
+
+    internal GenericCountBroker(long initialCount)
+    {
+        count = initialCount;
+    }
+
+    public int GetCount(out long value)
+    {
+        lock (gate)
+        {
+            if (disposed)
+            {
+                value = default;
+                return EFail;
+            }
+
+            value = count;
+            return 0;
+        }
+    }
+
+    public int Increment(out long value)
+    {
+        lock (gate)
+        {
+            if (disposed || count == long.MaxValue)
+            {
+                value = default;
+                return EFail;
+            }
+
+            value = ++count;
+            return 0;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            disposed = true;
+        }
+    }
+}

--- a/dotnet/nativeaot-sample/NativeAotFfiSample.csproj
+++ b/dotnet/nativeaot-sample/NativeAotFfiSample.csproj
@@ -16,13 +16,20 @@
   <PropertyGroup>
     <RepositoryRoot>$(MSBuildThisFileDirectory)..\..</RepositoryRoot>
     <PwshFfiNativeLibrary>$(RepositoryRoot)\target\release\multi_pwsh_sdk.dll</PwshFfiNativeLibrary>
+    <LiveObjectTestPackProject>$(MSBuildThisFileDirectory)..\live-object-test-pack\LiveObjectTestPack.csproj</LiveObjectTestPackProject>
+    <LiveObjectTestPackAssembly>$(MSBuildThisFileDirectory)..\live-object-test-pack\bin\$(Configuration)\net8.0\Devolutions.MultiPwsh.LiveObject.TestPack.dll</LiveObjectTestPackAssembly>
   </PropertyGroup>
 
   <Target Name="BuildAndStagePwshFfiNativeLibrary" BeforeTargets="Publish">
     <Exec Command="cargo build --release -p pwsh-sdk-ffi" WorkingDirectory="$(RepositoryRoot)" />
+    <MSBuild Projects="$(LiveObjectTestPackProject)"
+             Targets="Build"
+             Properties="Configuration=$(Configuration)" />
   </Target>
 
   <Target Name="CopyPwshFfiNativeLibrary" AfterTargets="Publish">
     <Copy SourceFiles="$(PwshFfiNativeLibrary)" DestinationFiles="$(PublishDir)multi-pwsh-sdk.dll" />
+    <Copy SourceFiles="$(LiveObjectTestPackAssembly)"
+          DestinationFiles="$(PublishDir)Devolutions.MultiPwsh.LiveObject.TestPack.dll" />
   </Target>
 </Project>

--- a/dotnet/nativeaot-sample/NativeAotFfiSample.csproj
+++ b/dotnet/nativeaot-sample/NativeAotFfiSample.csproj
@@ -23,7 +23,7 @@
   <Target Name="BuildAndStagePwshFfiNativeLibrary" BeforeTargets="Publish">
     <Exec Command="cargo build --release -p pwsh-sdk-ffi" WorkingDirectory="$(RepositoryRoot)" />
     <MSBuild Projects="$(LiveObjectTestPackProject)"
-             Targets="Build"
+             Targets="Restore;Build"
              Properties="Configuration=$(Configuration)" />
   </Target>
 

--- a/dotnet/nativeaot-sample/Program.cs
+++ b/dotnet/nativeaot-sample/Program.cs
@@ -4,15 +4,33 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using Devolutions.PowerShell.Ffi;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+using NativeAotFfiSample;
+
+string contractPackPath = System.IO.Path.Combine(
+    AppContext.BaseDirectory,
+    "Devolutions.MultiPwsh.LiveObject.TestPack.dll");
+if (!System.IO.File.Exists(contractPackPath))
+{
+    Console.Error.WriteLine("NativeAOT facade did not publish the external live-object contract pack.");
+    return 1;
+}
+
+PowerShellLiveObjectContractPack[] contractPacks =
+[
+    new PowerShellLiveObjectContractPack(
+        contractPackPath,
+        "Devolutions.MultiPwsh.LiveObject.TestPack.LiveObjectTestPack, Devolutions.MultiPwsh.LiveObject.TestPack"),
+];
 
 PowerShellRuntime runtime;
 switch (args.Length)
 {
     case 0:
-        runtime = PowerShellRuntime.Activate();
+        runtime = PowerShellRuntime.Activate(contractPacks);
         break;
     case 1:
-        runtime = PowerShellRuntime.Activate(args[0]);
+        runtime = PowerShellRuntime.Activate(args[0], contractPacks);
         break;
     default:
         Console.Error.WriteLine("Usage: NativeAotFfiSample [payload-directory]");
@@ -48,6 +66,39 @@ if (output.Output.Records.Count != 1 ||
     return 1;
 }
 
+using (PowerShellLiveObjectProbe liveProbe = runtime.CreateLiveObjectProbe(41))
+{
+    if (liveProbe.Count != 41 || liveProbe.Increment() != 42)
+    {
+        Console.Error.WriteLine("NativeAOT facade did not project the live payload object.");
+        return 1;
+    }
+
+    using PowerShell liveObjectRoundTrip = runtime.Create();
+    PowerShellInvocationResult liveObjectOutput = liveObjectRoundTrip
+        .AddScript("param($value) $value.Count += 1; $value.Count", useLocalScope: true)
+        .AddArgument(liveProbe)
+        .Invoke();
+    if (liveObjectOutput.Output.Records.Count != 1 ||
+        liveObjectOutput.Output.Records[0].DisplayText != "43" ||
+        liveProbe.Count != 43)
+    {
+        Console.Error.WriteLine("NativeAOT facade did not preserve live payload object identity.");
+        return 1;
+    }
+
+    liveProbe.Dispose();
+    try
+    {
+        _ = liveProbe.Count;
+        Console.Error.WriteLine("NativeAOT facade allowed use of a disposed live object probe.");
+        return 1;
+    }
+    catch (ObjectDisposedException)
+    {
+    }
+}
+
 using (PowerShellSession session = runtime.CreateSession(
     new PowerShellSessionOptions(
         historyMode: PowerShellSessionHistoryMode.Enabled,
@@ -68,6 +119,87 @@ using (PowerShell sessionPowerShell = session.CreatePowerShell())
     {
         Console.Error.WriteLine("NativeAOT facade did not preserve bounded session settings and state.");
         return 1;
+    }
+
+    using (var reverseProbe = new PowerShellSessionObjectProbe(64))
+    {
+        session.SetLiveObjectVariable("reverseProbe", reverseProbe);
+        using PowerShell incrementProbe = session.CreatePowerShell();
+        PowerShellInvocationResult incrementOutput = incrementProbe
+            .AddScript("$reverseProbe.Increment()")
+            .Invoke();
+        if (incrementOutput.Output.Records.Count != 1 ||
+            incrementOutput.Output.Records[0].DisplayText != "65" ||
+            reverseProbe.Count != 65)
+        {
+            Console.Error.WriteLine("NativeAOT facade did not invoke the .NET session object through PowerShell.");
+            return 1;
+        }
+
+        using PowerShell readProbe = session.CreatePowerShell();
+        PowerShellInvocationResult readOutput = readProbe
+            .AddScript("$reverseProbe.Count")
+            .Invoke();
+        if (readOutput.Output.Records.Count != 1 ||
+            readOutput.Output.Records[0].DisplayText != "65" ||
+            !session.RemoveVariable("reverseProbe"))
+        {
+            Console.Error.WriteLine("NativeAOT facade did not retain the .NET session object across PowerShell invocations.");
+            return 1;
+        }
+
+        reverseProbe.Dispose();
+        try
+        {
+            _ = reverseProbe.Count;
+            Console.Error.WriteLine("NativeAOT facade allowed use of a disposed .NET session object probe.");
+            return 1;
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    var genericBroker = new GenericCountBroker(96);
+    using (var genericLiveObject = new PowerShellLiveObject<IPowerShellLiveObjectTestCount>(
+        PowerShellLiveObjectTestContracts.Count,
+        genericBroker))
+    {
+        session.SetLiveObjectVariable("genericProbe", genericLiveObject);
+        using PowerShell incrementGenericProbe = session.CreatePowerShell();
+        PowerShellInvocationResult genericIncrementOutput = incrementGenericProbe
+            .AddScript("$genericProbe.Increment()")
+            .Invoke();
+        if (genericIncrementOutput.Output.Records.Count != 1 ||
+            genericIncrementOutput.Output.Records[0].DisplayText != "97" ||
+            genericBroker.GetCount(out long genericCount) != 0 ||
+            genericCount != 97)
+        {
+            Console.Error.WriteLine("NativeAOT facade did not invoke the external contract-pack live object.");
+            return 1;
+        }
+
+        using PowerShell aliasGenericProbe = session.CreatePowerShell();
+        PowerShellInvocationResult aliasOutput = aliasGenericProbe
+            .AddScript("$genericAlias = $genericProbe; Remove-Variable genericProbe")
+            .Invoke();
+        if (aliasOutput.HadErrors)
+        {
+            Console.Error.WriteLine("NativeAOT facade could not rebind the external contract-pack live object.");
+            return 1;
+        }
+
+        using PowerShell readGenericProbe = session.CreatePowerShell();
+        PowerShellInvocationResult genericReadOutput = readGenericProbe
+            .AddScript("$genericAlias.Increment()")
+            .Invoke();
+        if (genericReadOutput.Output.Records.Count != 1 ||
+            genericReadOutput.Output.Records[0].DisplayText != "98" ||
+            !session.RemoveVariable("genericAlias"))
+        {
+            Console.Error.WriteLine("NativeAOT facade did not retain the external contract-pack live object.");
+            return 1;
+        }
     }
 }
 

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -28,6 +28,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\interop\PowerShellLiveObjectProbeContract.cs"
+             Link="PowerShellLiveObjectProbeContract.cs" />
+    <Compile Include="..\interop\PowerShellLiveObjectContract.cs"
+             Link="PowerShellLiveObjectContract.cs" />
+    <Compile Include="..\interop\PowerShellLiveObjectTestContract.cs"
+             Link="PowerShellLiveObjectTestContract.cs" />
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="buildTransitive\Devolutions.MultiPwsh.Sdk.targets"
           Pack="true"

--- a/dotnet/sdk-ffi/NativeMethods.cs
+++ b/dotnet/sdk-ffi/NativeMethods.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Devolutions.PowerShell.Ffi.LiveObjects;
 
 namespace Devolutions.PowerShell.Ffi;
 
@@ -39,6 +40,15 @@ internal unsafe struct NativeCapabilityRegistration
     internal NativeDataValue* Definitions;
     internal nint DispatchCallback;
     internal nint CancelCallback;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal unsafe struct NativeLiveObjectContractPack
+{
+    internal uint Size;
+    internal uint Flags;
+    internal NativeUtf8Span PayloadAdapterAssemblyPath;
+    internal NativeUtf8Span PayloadAdapterTypeName;
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -117,6 +127,21 @@ internal static unsafe partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial int InitializeFromPath(NativeCallResult* result);
 
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_initialize_from_path_with_contract_packs")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int InitializeFromPathWithContractPacks(
+        NativeLiveObjectContractPack* packs,
+        nuint packCount,
+        NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_initialize_with_contract_packs_utf8")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int InitializeWithContractPacks(
+        NativeUtf8Span payloadPath,
+        NativeLiveObjectContractPack* packs,
+        nuint packCount,
+        NativeCallResult* result);
+
     [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_get_payload_path_utf8")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial int GetPayloadPath(
@@ -128,6 +153,18 @@ internal static unsafe partial class NativeMethods
     [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_create")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial int Create(ulong* handle, NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_live_object_probe_create")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int CreateLiveObjectProbe(long initialCount, nint* comObject, NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_live_object_probe_release")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int ReleaseLiveObjectProbe(nint comObject, NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_live_object_probe_unregister")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int UnregisterLiveObjectProbe(nint comObject, NativeCallResult* result);
 
     [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_release")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -182,6 +219,13 @@ internal static unsafe partial class NativeMethods
     internal static partial int AddArgumentValue(
         ulong handle,
         NativeDataValue* value,
+        NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_add_argument_live_object")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int AddArgumentLiveObject(
+        ulong handle,
+        nint comObject,
         NativeCallResult* result);
 
     [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_add_parameter_value")]
@@ -437,6 +481,23 @@ internal static unsafe partial class NativeMethods
         ulong sessionHandle,
         NativeUtf8Span name,
         NativeDataValue* value,
+        NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_session_set_live_object_variable")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int SetSessionLiveObjectVariable(
+        ulong sessionHandle,
+        NativeUtf8Span name,
+        nint comObject,
+        NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_session_set_live_object_contract_variable")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int SetSessionLiveObjectContractVariable(
+        ulong sessionHandle,
+        NativeUtf8Span name,
+        NativeLiveObjectContractDescriptor* contract,
+        nint comObject,
         NativeCallResult* result);
 
     [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_session_remove_variable")]

--- a/dotnet/sdk-ffi/PowerShell.cs
+++ b/dotnet/sdk-ffi/PowerShell.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,12 +27,16 @@ public sealed unsafe class PowerShell : IDisposable
     private const ulong SessionConfigurationFeature = 1UL << 14;
     private const ulong SessionVariablesFeature = 1UL << 15;
     private const ulong CapabilityRpcFeature = 1UL << 16;
+    private const ulong LiveObjectProbeFeature = 1UL << 17;
+    private const ulong LiveSessionObjectProbeFeature = 1UL << 18;
+    private const ulong LiveObjectContractsFeature = 1UL << 19;
     private const ulong RequiredFeatures =
         StructuredInvocationErrorsFeature | PerCallDiagnosticsFeature | Utf8SpansFeature |
         ImmutableResultsFeature | TaggedValuesFeature | CommandOptionsFeature | BoundedInputFeature |
         InvocationMetadataFeature | AsyncOperationsFeature | SessionsFeature |
         SessionPollingFeature | SessionPoolRejectionFeature | SnapshotProjectionsFeature |
-        SessionConfigurationFeature | SessionVariablesFeature | CapabilityRpcFeature;
+        SessionConfigurationFeature | SessionVariablesFeature | CapabilityRpcFeature |
+        LiveObjectProbeFeature | LiveSessionObjectProbeFeature | LiveObjectContractsFeature;
     private const uint ResultTerminatingFailure = 1;
     private const uint ResultSequenceTruncated = 1 << 1;
     private const uint StreamTruncated = 1;
@@ -86,6 +91,170 @@ public sealed unsafe class PowerShell : IDisposable
                 },
                 &result);
             NativeCall.ThrowIfFailed(status, result, diagnostic);
+        }
+    }
+
+    public static void Initialize(IReadOnlyList<PowerShellLiveObjectContractPack> contractPacks)
+    {
+        ArgumentNullException.ThrowIfNull(contractPacks);
+        if (contractPacks.Count == 0)
+        {
+            Initialize();
+            return;
+        }
+
+        EnsureLiveObjectContractsSupported();
+        var assemblyPathHandles = new GCHandle[contractPacks.Count];
+        var typeNameHandles = new GCHandle[contractPacks.Count];
+        var nativePacks = new NativeLiveObjectContractPack[contractPacks.Count];
+        try
+        {
+            for (int index = 0; index < contractPacks.Count; index++)
+            {
+                PowerShellLiveObjectContractPack pack = contractPacks[index]
+                    ?? throw new ArgumentException("Live object contract packs cannot contain null.", nameof(contractPacks));
+                if (!File.Exists(pack.PayloadAdapterAssemblyPath))
+                {
+                    throw new FileNotFoundException(
+                        "The live object contract pack payload adapter assembly does not exist.",
+                        pack.PayloadAdapterAssemblyPath);
+                }
+
+                byte[] assemblyPath = EncodeUtf8(pack.PayloadAdapterAssemblyPath);
+                byte[] typeName = EncodeUtf8(pack.PayloadAdapterTypeName);
+                assemblyPathHandles[index] = GCHandle.Alloc(assemblyPath, GCHandleType.Pinned);
+                typeNameHandles[index] = GCHandle.Alloc(typeName, GCHandleType.Pinned);
+                nativePacks[index] = new NativeLiveObjectContractPack
+                {
+                    Size = checked((uint)sizeof(NativeLiveObjectContractPack)),
+                    PayloadAdapterAssemblyPath = new NativeUtf8Span
+                    {
+                        Data = (byte*)assemblyPathHandles[index].AddrOfPinnedObject(),
+                        Length = checked((nuint)assemblyPath.Length),
+                    },
+                    PayloadAdapterTypeName = new NativeUtf8Span
+                    {
+                        Data = (byte*)typeNameHandles[index].AddrOfPinnedObject(),
+                        Length = checked((nuint)typeName.Length),
+                    },
+                };
+            }
+
+            fixed (NativeLiveObjectContractPack* nativePacksPointer = nativePacks)
+            {
+                byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+                NativeCallResult result = NativeCall.CreateResult(diagnostic);
+                int status = NativeMethods.InitializeFromPathWithContractPacks(
+                    nativePacksPointer,
+                    checked((nuint)nativePacks.Length),
+                    &result);
+                NativeCall.ThrowIfFailed(status, result, diagnostic);
+            }
+        }
+        finally
+        {
+            foreach (GCHandle handle in assemblyPathHandles)
+            {
+                if (handle.IsAllocated)
+                {
+                    handle.Free();
+                }
+            }
+
+            foreach (GCHandle handle in typeNameHandles)
+            {
+                if (handle.IsAllocated)
+                {
+                    handle.Free();
+                }
+            }
+        }
+    }
+
+    public static void Initialize(
+        string payloadDirectory,
+        IReadOnlyList<PowerShellLiveObjectContractPack> contractPacks)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(payloadDirectory);
+        ArgumentNullException.ThrowIfNull(contractPacks);
+        if (contractPacks.Count == 0)
+        {
+            Initialize(payloadDirectory);
+            return;
+        }
+
+        EnsureLiveObjectContractsSupported();
+        byte[] payloadBytes = EncodeUtf8(payloadDirectory);
+        var assemblyPathHandles = new GCHandle[contractPacks.Count];
+        var typeNameHandles = new GCHandle[contractPacks.Count];
+        var nativePacks = new NativeLiveObjectContractPack[contractPacks.Count];
+        try
+        {
+            for (int index = 0; index < contractPacks.Count; index++)
+            {
+                PowerShellLiveObjectContractPack pack = contractPacks[index]
+                    ?? throw new ArgumentException("Live object contract packs cannot contain null.", nameof(contractPacks));
+                if (!File.Exists(pack.PayloadAdapterAssemblyPath))
+                {
+                    throw new FileNotFoundException(
+                        "The live object contract pack payload adapter assembly does not exist.",
+                        pack.PayloadAdapterAssemblyPath);
+                }
+
+                byte[] assemblyPath = EncodeUtf8(pack.PayloadAdapterAssemblyPath);
+                byte[] typeName = EncodeUtf8(pack.PayloadAdapterTypeName);
+                assemblyPathHandles[index] = GCHandle.Alloc(assemblyPath, GCHandleType.Pinned);
+                typeNameHandles[index] = GCHandle.Alloc(typeName, GCHandleType.Pinned);
+                nativePacks[index] = new NativeLiveObjectContractPack
+                {
+                    Size = checked((uint)sizeof(NativeLiveObjectContractPack)),
+                    PayloadAdapterAssemblyPath = new NativeUtf8Span
+                    {
+                        Data = (byte*)assemblyPathHandles[index].AddrOfPinnedObject(),
+                        Length = checked((nuint)assemblyPath.Length),
+                    },
+                    PayloadAdapterTypeName = new NativeUtf8Span
+                    {
+                        Data = (byte*)typeNameHandles[index].AddrOfPinnedObject(),
+                        Length = checked((nuint)typeName.Length),
+                    },
+                };
+            }
+
+            fixed (byte* payloadPointer = payloadBytes)
+            fixed (NativeLiveObjectContractPack* nativePacksPointer = nativePacks)
+            {
+                byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+                NativeCallResult result = NativeCall.CreateResult(diagnostic);
+                int status = NativeMethods.InitializeWithContractPacks(
+                    new NativeUtf8Span
+                    {
+                        Data = payloadPointer,
+                        Length = checked((nuint)payloadBytes.Length),
+                    },
+                    nativePacksPointer,
+                    checked((nuint)nativePacks.Length),
+                    &result);
+                NativeCall.ThrowIfFailed(status, result, diagnostic);
+            }
+        }
+        finally
+        {
+            foreach (GCHandle handle in assemblyPathHandles)
+            {
+                if (handle.IsAllocated)
+                {
+                    handle.Free();
+                }
+            }
+
+            foreach (GCHandle handle in typeNameHandles)
+            {
+                if (handle.IsAllocated)
+                {
+                    handle.Free();
+                }
+            }
         }
     }
 
@@ -188,6 +357,13 @@ public sealed unsafe class PowerShell : IDisposable
     {
         ArgumentNullException.ThrowIfNull(value);
         InvokeValueForHandle(value, static (nativeHandle, nativeValue, result) => NativeMethods.AddArgumentValue(nativeHandle, nativeValue, result));
+        return this;
+    }
+
+    public PowerShell AddArgument(PowerShellLiveObjectProbe value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        value.AddTo(this);
         return this;
     }
 
@@ -419,6 +595,39 @@ public sealed unsafe class PowerShell : IDisposable
             throw new PowerShellFfiException(
                 PowerShellFfiStatus.UnsupportedCapability,
                 "The selected PowerShell payload does not support bounded capability RPC.");
+        }
+    }
+
+    internal static void EnsureLiveObjectProbeSupported()
+    {
+        EnsureSupportedAbi();
+        if ((FeatureFlags & LiveObjectProbeFeature) == 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.UnsupportedCapability,
+                "The selected PowerShell payload does not support the live object probe.");
+        }
+    }
+
+    internal static void EnsureLiveSessionObjectProbeSupported()
+    {
+        EnsureSupportedAbi();
+        if ((FeatureFlags & LiveSessionObjectProbeFeature) == 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.UnsupportedCapability,
+                "The selected PowerShell payload does not support live session object probes.");
+        }
+    }
+
+    internal static void EnsureLiveObjectContractsSupported()
+    {
+        EnsureSupportedAbi();
+        if ((FeatureFlags & LiveObjectContractsFeature) == 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.UnsupportedCapability,
+                "The selected PowerShell payload does not support registered live object contracts.");
         }
     }
 
@@ -899,6 +1108,16 @@ public sealed unsafe class PowerShell : IDisposable
             int status = operation(lease.Value, &nativeValue, &result);
             NativeCall.ThrowIfFailed(status, result, diagnostic);
         }
+    }
+
+    internal void AddLiveObjectProbe(nint comObject)
+    {
+        if (comObject == 0)
+        {
+            throw new ArgumentException("Live object probe pointer is null.", nameof(comObject));
+        }
+
+        InvokeForHandle((nativeHandle, result) => NativeMethods.AddArgumentLiveObject(nativeHandle, comObject, result));
     }
 
     internal static NativeDataValue CreateNativeValue(PowerShellValue value, byte* payload)

--- a/dotnet/sdk-ffi/PowerShellLiveObject.cs
+++ b/dotnet/sdk-ffi/PowerShellLiveObject.cs
@@ -1,0 +1,104 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+namespace Devolutions.PowerShell.Ffi;
+
+/// <summary>
+/// Marks a consumer-owned generated-COM broker whose disposal makes future
+/// contract calls fail according to that contract's HRESULT policy.
+/// </summary>
+public interface IPowerShellLiveObjectBroker : IDisposable
+{
+}
+
+/// <summary>
+/// Owns the consumer-side COM lease for one registered live-object contract.
+/// </summary>
+public sealed unsafe class PowerShellLiveObject<TContract> : IDisposable
+    where TContract : class
+{
+    private static readonly StrategyBasedComWrappers ComWrappers = new();
+
+    private readonly object gate = new();
+    private IPowerShellLiveObjectBroker? broker;
+
+    public PowerShellLiveObject(
+        PowerShellLiveObjectContract contract,
+        TContract broker)
+    {
+        ArgumentNullException.ThrowIfNull(broker);
+        if (!typeof(TContract).IsInterface || contract.InterfaceId != typeof(TContract).GUID)
+        {
+            throw new ArgumentException(
+                "The live object contract must identify the generated COM interface.",
+                nameof(contract));
+        }
+
+        this.broker = broker as IPowerShellLiveObjectBroker
+            ?? throw new ArgumentException(
+                "The live object broker must implement IPowerShellLiveObjectBroker.",
+                nameof(broker));
+        Contract = contract;
+    }
+
+    public PowerShellLiveObjectContract Contract { get; }
+
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            IPowerShellLiveObjectBroker? value = broker;
+            if (value is null)
+            {
+                return;
+            }
+
+            broker = null;
+            value.Dispose();
+        }
+    }
+
+    internal void AssignToSession(Action<nint> assignment)
+    {
+        ArgumentNullException.ThrowIfNull(assignment);
+
+        lock (gate)
+        {
+            IPowerShellLiveObjectBroker value = broker
+                ?? throw new ObjectDisposedException(nameof(PowerShellLiveObject<TContract>));
+            nint pointer = ComWrappers.GetOrCreateComInterfaceForObject(
+                value,
+                CreateComInterfaceFlags.None);
+            if (pointer == 0)
+            {
+                throw new PowerShellFfiException(
+                    PowerShellFfiStatus.ManagedFailure,
+                    "The live object broker did not create an IUnknown pointer.");
+            }
+
+            try
+            {
+                assignment(pointer);
+            }
+            finally
+            {
+                ReleaseTransitReference(pointer);
+            }
+        }
+    }
+
+    private static void ReleaseTransitReference(nint pointer)
+    {
+        IntPtr* vtable = *(IntPtr**)pointer;
+        if (vtable == null || vtable[2] == IntPtr.Zero)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "The live object broker has an invalid IUnknown vtable.");
+        }
+
+        var release = (delegate* unmanaged[MemberFunction]<nint, uint>)vtable[2];
+        _ = release(pointer);
+    }
+}

--- a/dotnet/sdk-ffi/PowerShellLiveObjectContractPack.cs
+++ b/dotnet/sdk-ffi/PowerShellLiveObjectContractPack.cs
@@ -1,0 +1,28 @@
+namespace Devolutions.PowerShell.Ffi;
+
+/// <summary>
+/// Declares a trusted net8 payload adapter assembly for registered live-object
+/// contracts. The adapter is loaded only during runtime activation.
+/// </summary>
+public sealed class PowerShellLiveObjectContractPack
+{
+    public PowerShellLiveObjectContractPack(
+        string payloadAdapterAssemblyPath,
+        string payloadAdapterTypeName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(payloadAdapterAssemblyPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payloadAdapterTypeName);
+        if (!Path.IsPathFullyQualified(payloadAdapterAssemblyPath) ||
+            payloadAdapterTypeName.Length > 512)
+        {
+            throw new ArgumentException("The live object contract pack metadata is invalid.");
+        }
+
+        PayloadAdapterAssemblyPath = Path.GetFullPath(payloadAdapterAssemblyPath);
+        PayloadAdapterTypeName = payloadAdapterTypeName;
+    }
+
+    public string PayloadAdapterAssemblyPath { get; }
+
+    public string PayloadAdapterTypeName { get; }
+}

--- a/dotnet/sdk-ffi/PowerShellLiveObjectProbe.cs
+++ b/dotnet/sdk-ffi/PowerShellLiveObjectProbe.cs
@@ -1,0 +1,156 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+namespace Devolutions.PowerShell.Ffi;
+
+/// <summary>
+/// Experimental proof that a payload-owned PowerShell object can be projected
+/// through a portable in-process <c>IUnknown</c> contract.
+/// </summary>
+public sealed unsafe class PowerShellLiveObjectProbe : IDisposable
+{
+    private static readonly StrategyBasedComWrappers ComWrappers = new();
+
+    private readonly object gate = new();
+    private IPowerShellLiveObjectProbe? proxy;
+    private ComObject? comObject;
+    private nint pointer;
+
+    private PowerShellLiveObjectProbe(
+        IPowerShellLiveObjectProbe proxy,
+        ComObject comObject,
+        nint pointer)
+    {
+        this.proxy = proxy;
+        this.comObject = comObject;
+        this.pointer = pointer;
+    }
+
+    public long Count => Invoke(static (IPowerShellLiveObjectProbe value, out long count) => value.GetCount(out count));
+
+    public long Increment()
+    {
+        return Invoke(static (IPowerShellLiveObjectProbe value, out long count) => value.Increment(out count));
+    }
+
+    internal static PowerShellLiveObjectProbe Create(long initialCount)
+    {
+        nint pointer = 0;
+        byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+        NativeCallResult result = NativeCall.CreateResult(diagnostic);
+        int status = NativeMethods.CreateLiveObjectProbe(initialCount, &pointer, &result);
+        NativeCall.ThrowIfFailed(status, result, diagnostic);
+        if (pointer == 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned a null live object probe pointer.");
+        }
+
+        ComObject? comObject = null;
+        bool transitReleaseAttempted = false;
+        try
+        {
+            object projected = ComWrappers.GetOrCreateObjectForComInstance(
+                pointer,
+                CreateObjectFlags.UniqueInstance);
+            comObject = projected as ComObject
+                ?? throw new PowerShellFfiException(
+                    PowerShellFfiStatus.ManagedFailure,
+                    "Native PowerShell FFI did not create a source-generated COM wrapper.");
+            var proxy = projected as IPowerShellLiveObjectProbe
+                ?? throw new PowerShellFfiException(
+                    PowerShellFfiStatus.ManagedFailure,
+                    "Native PowerShell FFI returned an object with an unexpected COM contract.");
+
+            transitReleaseAttempted = true;
+            ReleaseTransitReference(pointer);
+            return new PowerShellLiveObjectProbe(proxy, comObject, pointer);
+        }
+        catch
+        {
+            if (comObject is not null)
+            {
+                comObject.FinalRelease();
+            }
+
+            if (!transitReleaseAttempted)
+            {
+                ReleaseTransitReference(pointer);
+            }
+
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            ComObject? value = comObject;
+            nint valuePointer = pointer;
+            if (value is null || valuePointer == 0)
+            {
+                return;
+            }
+
+            Unregister(valuePointer);
+            proxy = null;
+            comObject = null;
+            pointer = 0;
+            value.FinalRelease();
+        }
+    }
+
+    internal void AddTo(PowerShell powerShell)
+    {
+        lock (gate)
+        {
+            ArgumentNullException.ThrowIfNull(powerShell);
+            if (proxy is null || pointer == 0)
+            {
+                throw new ObjectDisposedException(nameof(PowerShellLiveObjectProbe));
+            }
+
+            powerShell.AddLiveObjectProbe(pointer);
+        }
+    }
+
+    private long Invoke(ProbeOperation operation)
+    {
+        lock (gate)
+        {
+            if (proxy is null)
+            {
+                throw new ObjectDisposedException(nameof(PowerShellLiveObjectProbe));
+            }
+
+            int hresult = operation(proxy, out long count);
+            if (hresult != 0)
+            {
+                throw new COMException("The payload live object probe call failed.", hresult);
+            }
+
+            return count;
+        }
+    }
+
+    private static void ReleaseTransitReference(nint pointer)
+    {
+        byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+        NativeCallResult result = NativeCall.CreateResult(diagnostic);
+        int status = NativeMethods.ReleaseLiveObjectProbe(pointer, &result);
+        NativeCall.ThrowIfFailed(status, result, diagnostic);
+    }
+
+    private static void Unregister(nint pointer)
+    {
+        byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+        NativeCallResult result = NativeCall.CreateResult(diagnostic);
+        int status = NativeMethods.UnregisterLiveObjectProbe(pointer, &result);
+        NativeCall.ThrowIfFailed(status, result, diagnostic);
+    }
+
+    private delegate int ProbeOperation(IPowerShellLiveObjectProbe value, out long count);
+}

--- a/dotnet/sdk-ffi/PowerShellRuntime.cs
+++ b/dotnet/sdk-ffi/PowerShellRuntime.cs
@@ -31,6 +31,24 @@ public sealed class PowerShellRuntime
         return CreateActivatedRuntime();
     }
 
+    public static PowerShellRuntime Activate(
+        IReadOnlyList<PowerShellLiveObjectContractPack> contractPacks)
+    {
+        ArgumentNullException.ThrowIfNull(contractPacks);
+        PowerShell.Initialize(contractPacks);
+        return CreateActivatedRuntime();
+    }
+
+    public static PowerShellRuntime Activate(
+        string payloadDirectory,
+        IReadOnlyList<PowerShellLiveObjectContractPack> contractPacks)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(payloadDirectory);
+        ArgumentNullException.ThrowIfNull(contractPacks);
+        PowerShell.Initialize(payloadDirectory, contractPacks);
+        return CreateActivatedRuntime();
+    }
+
     private static PowerShellRuntime CreateActivatedRuntime()
     {
         return new PowerShellRuntime(
@@ -42,6 +60,16 @@ public sealed class PowerShellRuntime
     public PowerShell Create()
     {
         return PowerShell.Create();
+    }
+
+    /// <summary>
+    /// Creates an experimental live payload-object probe for validating the
+    /// cross-runtime <c>IUnknown</c> transport.
+    /// </summary>
+    public PowerShellLiveObjectProbe CreateLiveObjectProbe(long initialCount)
+    {
+        PowerShell.EnsureLiveObjectProbeSupported();
+        return PowerShellLiveObjectProbe.Create(initialCount);
     }
 
     public PowerShellInvocationResult Invoke(

--- a/dotnet/sdk-ffi/PowerShellSession.cs
+++ b/dotnet/sdk-ffi/PowerShellSession.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Devolutions.PowerShell.Ffi.LiveObjects;
 
 namespace Devolutions.PowerShell.Ffi;
 
@@ -147,6 +148,71 @@ public sealed unsafe class PowerShellSession : IDisposable
                 &result);
             NativeCall.ThrowIfFailed(status, result, diagnostic);
         }
+    }
+
+    /// <summary>
+    /// Replaces a named session variable with an experimental .NET-owned live
+    /// object probe. The probe must outlive its session-variable binding.
+    /// </summary>
+    public void SetLiveObjectVariable(string name, PowerShellSessionObjectProbe value)
+    {
+        ValidateVariableName(name);
+        ArgumentNullException.ThrowIfNull(value);
+        PowerShell.EnsureLiveSessionObjectProbeSupported();
+
+        value.AssignToSession(pointer =>
+        {
+            byte[] nameBytes = PowerShell.EncodeUtf8(name);
+            using PowerShellSessionHandle.HandleLease lease = handle.Borrow();
+            fixed (byte* namePointer = nameBytes)
+            {
+                byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+                NativeCallResult result = NativeCall.CreateResult(diagnostic);
+                int status = NativeMethods.SetSessionLiveObjectVariable(
+                    lease.Value,
+                    new NativeUtf8Span { Data = namePointer, Length = (nuint)nameBytes.Length },
+                    pointer,
+                    &result);
+                NativeCall.ThrowIfFailed(status, result, diagnostic);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Replaces a named session variable with a registered consumer-owned live
+    /// object. The selected payload must have loaded a matching contract pack.
+    /// </summary>
+    public void SetLiveObjectVariable<TContract>(string name, PowerShellLiveObject<TContract> value)
+        where TContract : class
+    {
+        ValidateVariableName(name);
+        ArgumentNullException.ThrowIfNull(value);
+        if ((value.Contract.Directions & PowerShellLiveObjectDirection.ConsumerToSession) == 0)
+        {
+            throw new ArgumentException(
+                "The live object contract does not support consumer-to-session projection.",
+                nameof(value));
+        }
+
+        PowerShell.EnsureLiveObjectContractsSupported();
+        value.AssignToSession(pointer =>
+        {
+            byte[] nameBytes = PowerShell.EncodeUtf8(name);
+            NativeLiveObjectContractDescriptor contract = value.Contract.ToNative();
+            using PowerShellSessionHandle.HandleLease lease = handle.Borrow();
+            fixed (byte* namePointer = nameBytes)
+            {
+                byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+                NativeCallResult result = NativeCall.CreateResult(diagnostic);
+                int status = NativeMethods.SetSessionLiveObjectContractVariable(
+                    lease.Value,
+                    new NativeUtf8Span { Data = namePointer, Length = (nuint)nameBytes.Length },
+                    &contract,
+                    pointer,
+                    &result);
+                NativeCall.ThrowIfFailed(status, result, diagnostic);
+            }
+        });
     }
 
     /// <summary>

--- a/dotnet/sdk-ffi/PowerShellSessionObjectProbe.cs
+++ b/dotnet/sdk-ffi/PowerShellSessionObjectProbe.cs
@@ -1,0 +1,165 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+namespace Devolutions.PowerShell.Ffi;
+
+/// <summary>
+/// Experimental proof that a .NET 10-owned object can be invoked from a
+/// PowerShell session variable through a portable in-process <c>IUnknown</c>.
+/// </summary>
+public sealed unsafe partial class PowerShellSessionObjectProbe : IDisposable
+{
+    private static readonly StrategyBasedComWrappers ComWrappers = new();
+
+    private readonly object gate = new();
+    private readonly FfiSessionObjectProbeBroker broker;
+    private bool disposed;
+
+    public PowerShellSessionObjectProbe(long initialCount)
+    {
+        broker = new FfiSessionObjectProbeBroker(initialCount);
+    }
+
+    public long Count => Invoke(static (FfiSessionObjectProbeBroker value, out long count) => value.GetCount(out count));
+
+    public long Increment()
+    {
+        return Invoke(static (FfiSessionObjectProbeBroker value, out long count) => value.Increment(out count));
+    }
+
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            broker.Dispose();
+            disposed = true;
+        }
+    }
+
+    internal void AssignToSession(Action<nint> assignment)
+    {
+        ArgumentNullException.ThrowIfNull(assignment);
+
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            nint pointer = ComWrappers.GetOrCreateComInterfaceForObject(
+                broker,
+                CreateComInterfaceFlags.None);
+            if (pointer == 0)
+            {
+                throw new PowerShellFfiException(
+                    PowerShellFfiStatus.ManagedFailure,
+                    "The .NET session object probe did not create an IUnknown pointer.");
+            }
+
+            try
+            {
+                assignment(pointer);
+            }
+            finally
+            {
+                ReleaseTransitReference(pointer);
+            }
+        }
+    }
+
+    internal static void ReleaseTransitReference(nint pointer)
+    {
+        if (pointer == 0)
+        {
+            throw new ArgumentException("Live object probe pointer is null.", nameof(pointer));
+        }
+
+        IntPtr* vtable = *(IntPtr**)pointer;
+        if (vtable == null || vtable[2] == IntPtr.Zero)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "The .NET session object probe has an invalid IUnknown vtable.");
+        }
+
+        var release = (delegate* unmanaged[MemberFunction]<nint, uint>)vtable[2];
+        _ = release(pointer);
+    }
+
+    private long Invoke(ProbeOperation operation)
+    {
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            int hresult = operation(broker, out long count);
+            if (hresult != 0)
+            {
+                throw new COMException("The .NET session object probe call failed.", hresult);
+            }
+
+            return count;
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+    }
+
+    private delegate int ProbeOperation(FfiSessionObjectProbeBroker value, out long count);
+
+    [GeneratedComClass]
+    private sealed partial class FfiSessionObjectProbeBroker : IPowerShellLiveObjectProbe
+    {
+        private const int EFail = unchecked((int)0x80004005);
+        private readonly object gate = new();
+        private long count;
+        private bool disposed;
+
+        public FfiSessionObjectProbeBroker(long initialCount)
+        {
+            count = initialCount;
+        }
+
+        public int GetCount(out long value)
+        {
+            lock (gate)
+            {
+                if (disposed)
+                {
+                    value = default;
+                    return EFail;
+                }
+
+                value = count;
+                return 0;
+            }
+        }
+
+        public int Increment(out long value)
+        {
+            lock (gate)
+            {
+                if (disposed || count == long.MaxValue)
+                {
+                    value = default;
+                    return EFail;
+                }
+
+                value = ++count;
+                return 0;
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (gate)
+            {
+                disposed = true;
+            }
+        }
+    }
+}

--- a/tests/PwshFfiApiBaseline.txt
+++ b/tests/PwshFfiApiBaseline.txt
@@ -510,3 +510,78 @@ facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata
 facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParseError
 facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParser
 facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParseResult
+bindings:FfiLiveObjectContractPack_Register
+bindings:FfiLiveObjectContractPack_RegisterMany
+bindings:FfiLiveObjectProbe_Create
+bindings:FfiLiveObjectProbe_Release
+bindings:FfiLiveObjectProbe_Unregister
+bindings:FfiPowerShell_AddArgumentLiveObject
+bindings:FfiPowerShellSession_SetLiveObjectContractVariable
+bindings:FfiPowerShellSession_SetLiveObjectVariable
+facade:ctor:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Void .ctor(System.Guid, UInt16, UInt16, Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1::Void .ctor(Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract, TContract)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack::Void .ctor(System.String, System.String)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Void .ctor(Int64)
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt16 MajorVersion
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt16 MinorVersion
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt32 Directions
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt32 Reserved
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt32 Size
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt64 InterfaceIdHigh
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt64 InterfaceIdLow
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor* Contracts
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::IntPtr CreatePayloadProxy
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::IntPtr ReleasePayloadProxy
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::UInt32 AbiVersion
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::UInt32 ContractCount
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::UIntPtr Size
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection ConsumerToSession
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection None
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection PayloadToConsumer
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectTestContracts::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract Count
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 GetCount(Int64 ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 Increment(Int64 ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Boolean Equals(Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Boolean Equals(System.Object)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Int32 GetHashCode()
+facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell AddArgument(Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe)
+facade:method:Devolutions.PowerShell.Ffi.PowerShell::Void Initialize(System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
+facade:method:Devolutions.PowerShell.Ffi.PowerShell::Void Initialize(System.String, System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1::Void Dispose()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe::Int64 Increment()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe::Void Dispose()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe CreateLiveObjectProbe(Int64)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellRuntime Activate(System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellRuntime Activate(System.String, System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void SetLiveObjectVariable(System.String, Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void SetLiveObjectVariable[TContract](System.String, Devolutions.PowerShell.Ffi.PowerShellLiveObject`1[TContract])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Int64 Increment()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Void Dispose()
+facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection Directions
+facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::System.Guid InterfaceId
+facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::UInt16 MajorVersion
+facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::UInt16 MinorVersion
+facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract Contract
+facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack::System.String PayloadAdapterAssemblyPath
+facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack::System.String PayloadAdapterTypeName
+facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe::Int64 Count
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Int64 Count
+facade:type:Devolutions.PowerShell.Ffi.IPowerShellLiveObjectBroker
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectTestContracts
+facade:type:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1
+facade:type:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack
+facade:type:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe
+facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe
+native:multi_pwsh_add_argument_live_object
+native:multi_pwsh_initialize_from_path_with_contract_packs
+native:multi_pwsh_initialize_with_contract_packs_utf8
+native:multi_pwsh_live_object_probe_create
+native:multi_pwsh_live_object_probe_release
+native:multi_pwsh_live_object_probe_unregister
+native:multi_pwsh_session_set_live_object_contract_variable
+native:multi_pwsh_session_set_live_object_variable

--- a/tests/PwshFfiApiBaselineInspector/Program.cs
+++ b/tests/PwshFfiApiBaselineInspector/Program.cs
@@ -36,7 +36,10 @@ foreach (Type type in facadeAssembly.GetExportedTypes().OrderBy(type => type.Ful
 }
 
 NativeStructInspection[] nativeStructs = facadeAssembly.GetTypes()
-    .Where(type => type.Namespace == "Devolutions.PowerShell.Ffi" && type.IsValueType && type.Name.StartsWith("Native", StringComparison.Ordinal))
+    .Where(type =>
+        type.Namespace is "Devolutions.PowerShell.Ffi" or "Devolutions.PowerShell.Ffi.LiveObjects" &&
+        type.IsValueType &&
+        type.Name.StartsWith("Native", StringComparison.Ordinal))
     .OrderBy(type => type.Name, StringComparer.Ordinal)
     .Select(type => new NativeStructInspection(
         type.Name,
@@ -108,9 +111,9 @@ static void ValidateAbiCompatibility(Assembly facadeAssembly, BindingFlags stati
         throw new InvalidOperationException("The facade must retain an ABI validation overload that accepts NativeAbiInfo.");
     }
 
-    const ulong allRequiredFeatures = 0x1FDFF;
+    const ulong allRequiredFeatures = 0xFFDFF;
     ensureSupportedAbi.Invoke(null, [CreateAbiInfo(abiInfoType, allRequiredFeatures, abiVersion: 2, minimumCompatibleAbiVersion: 2)]);
-    for (int bit = 0; bit <= 16; bit++)
+    for (int bit = 0; bit <= 19; bit++)
     {
         if ((allRequiredFeatures & (1UL << bit)) == 0)
         {

--- a/tests/Verify-PwshFfiApiBaseline.ps1
+++ b/tests/Verify-PwshFfiApiBaseline.ps1
@@ -149,9 +149,12 @@ $expectedManagedStructs = [ordered]@{
     'NativeDataValue' = @{ Size = 32; Fields = @('Size|0|System.UInt32', 'Kind|4|System.UInt32', 'Flags|8|System.UInt32', 'Reserved|12|System.UInt32', 'Data|16|System.Byte*', 'DataLength|24|System.UIntPtr') }
     'NativeCallResult' = @{ Size = 48; Fields = @('Size|0|System.UInt32', 'Status|4|System.Int32', 'Flags|8|System.UInt32', 'Reserved|12|System.UInt32', 'Diagnostic|16|System.Byte*', 'DiagnosticCapacity|24|System.UIntPtr', 'DiagnosticRequired|32|System.UIntPtr', 'DiagnosticWritten|40|System.UIntPtr') }
     'NativeCapabilityRegistration' = @{ Size = 32; Fields = @('Size|0|System.UInt32', 'Flags|4|System.UInt32', 'Definitions|8|Devolutions.PowerShell.Ffi.NativeDataValue*', 'DispatchCallback|16|System.IntPtr', 'CancelCallback|24|System.IntPtr') }
+    'NativeLiveObjectContractPack' = @{ Size = 40; Fields = @('Size|0|System.UInt32', 'Flags|4|System.UInt32', 'PayloadAdapterAssemblyPath|8|Devolutions.PowerShell.Ffi.NativeUtf8Span', 'PayloadAdapterTypeName|24|Devolutions.PowerShell.Ffi.NativeUtf8Span') }
     'NativeSessionOptions' = @{ Size = 216; Fields = @('Size|0|System.UInt32', 'RunspaceMode|4|System.UInt32', 'InitialConfiguration|8|System.UInt32', 'HistoryMode|12|System.UInt32', 'ErrorPreference|16|System.UInt32', 'WarningPreference|20|System.UInt32', 'VerbosePreference|24|System.UInt32', 'DebugPreference|28|System.UInt32', 'InformationPreference|32|System.UInt32', 'Flags|36|System.UInt32', 'Reserved|40|System.UInt32', 'AllowedModulePath|48|Devolutions.PowerShell.Ffi.NativeUtf8Span', 'ExecutionPolicy|64|System.UInt32', 'ConfigurationFlags|68|System.UInt32', 'InitialVariables|72|Devolutions.PowerShell.Ffi.NativeDataValue', 'ModuleImports|104|Devolutions.PowerShell.Ffi.NativeDataValue', 'AllowedModulePaths|136|Devolutions.PowerShell.Ffi.NativeDataValue', 'WorkingDirectory|168|Devolutions.PowerShell.Ffi.NativeUtf8Span', 'Environment|184|Devolutions.PowerShell.Ffi.NativeDataValue') }
     'NativeSessionSnapshot' = @{ Size = 40; Fields = @('Size|0|System.UInt32', 'State|4|System.UInt32', 'RunspaceState|8|System.UInt32', 'Flags|12|System.UInt32', 'ActivePipelineCount|16|System.UInt32', 'EventCount|20|System.UInt32', 'InvocationCount|24|System.UInt64', 'HistoryCount|32|System.UInt64') }
     'NativeSessionPoolOptions' = @{ Size = 20; Fields = @('Size|0|System.UInt32', 'MinimumSessions|4|System.UInt32', 'MaximumSessions|8|System.UInt32', 'Flags|12|System.UInt32', 'Reserved|16|System.UInt32') }
+    'NativeLiveObjectContractDescriptor' = @{ Size = 32; Fields = @('Size|0|System.UInt32', 'Directions|4|System.UInt32', 'InterfaceIdLow|8|System.UInt64', 'InterfaceIdHigh|16|System.UInt64', 'MajorVersion|24|System.UInt16', 'MinorVersion|26|System.UInt16', 'Reserved|28|System.UInt32') }
+    'NativeLiveObjectContractPackApi' = @{ Size = 40; Fields = @('Size|0|System.UIntPtr', 'AbiVersion|8|System.UInt32', 'ContractCount|12|System.UInt32', 'Contracts|16|Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor*', 'CreatePayloadProxy|24|System.IntPtr', 'ReleasePayloadProxy|32|System.IntPtr') }
 }
 
 Assert-Sequence -Actual @(
@@ -281,10 +284,18 @@ $expectedTableSlots = @(
     @{ Field = 'PowerShellSession_RemoveVariable'; Rust = 'session_remove_variable_fn'; Alias = 'FnFfiPowerShellSessionRemoveVariable'; Method = 'FfiPowerShellSession_RemoveVariable'; Signature = 'IntPtr,byte*,int,uint*,FfiCallResult*,int' }
     @{ Field = 'PowerShellSession_GetVariableSnapshot'; Rust = 'session_get_variable_snapshot_fn'; Alias = 'FnFfiPowerShellSessionGetVariableSnapshot'; Method = 'FfiPowerShellSession_GetVariableSnapshot'; Signature = 'IntPtr,byte*,int,uint*,uint*,byte*,int,int*,FfiCallResult*,int' }
     @{ Field = 'PowerShell_SetCapabilityContext'; Rust = 'power_shell_set_capability_context_fn'; Alias = 'FnFfiPowerShellSetCapabilityContext'; Method = 'FfiPowerShell_SetCapabilityContext'; Signature = 'IntPtr,ulong,ulong,IntPtr,FfiCallResult*,int' }
+    @{ Field = 'LiveObjectProbe_Create'; Rust = 'live_object_probe_create_fn'; Alias = 'FnFfiLiveObjectProbeCreate'; Method = 'FfiLiveObjectProbe_Create'; Signature = 'long,IntPtr*,FfiCallResult*,int' }
+    @{ Field = 'LiveObjectProbe_Release'; Rust = 'live_object_probe_release_fn'; Alias = 'FnFfiLiveObjectProbeRelease'; Method = 'FfiLiveObjectProbe_Release'; Signature = 'IntPtr,FfiCallResult*,int' }
+    @{ Field = 'LiveObjectProbe_Unregister'; Rust = 'live_object_probe_unregister_fn'; Alias = 'FnFfiLiveObjectProbeUnregister'; Method = 'FfiLiveObjectProbe_Unregister'; Signature = 'IntPtr,FfiCallResult*,int' }
+    @{ Field = 'PowerShell_AddArgumentLiveObject'; Rust = 'power_shell_add_argument_live_object_fn'; Alias = 'FnFfiPowerShellAddLiveObject'; Method = 'FfiPowerShell_AddArgumentLiveObject'; Signature = 'IntPtr,IntPtr,FfiCallResult*,int' }
+    @{ Field = 'PowerShellSession_SetLiveObjectVariable'; Rust = 'power_shell_session_set_live_object_variable_fn'; Alias = 'FnFfiPowerShellSessionSetLiveObjectVariable'; Method = 'FfiPowerShellSession_SetLiveObjectVariable'; Signature = 'IntPtr,byte*,int,IntPtr,FfiCallResult*,int' }
+    @{ Field = 'LiveObjectContractPack_Register'; Rust = 'live_object_contract_pack_register_fn'; Alias = 'FnFfiLiveObjectContractPackRegister'; Method = 'FfiLiveObjectContractPack_Register'; Signature = 'IntPtr,FfiCallResult*,int' }
+    @{ Field = 'PowerShellSession_SetLiveObjectContractVariable'; Rust = 'power_shell_session_set_live_object_contract_variable_fn'; Alias = 'FnFfiPowerShellSessionSetLiveObjectContractVariable'; Method = 'FfiPowerShellSession_SetLiveObjectContractVariable'; Signature = 'IntPtr,byte*,int,NativeLiveObjectContractDescriptor*,IntPtr,FfiCallResult*,int' }
+    @{ Field = 'LiveObjectContractPack_RegisterMany'; Rust = 'live_object_contract_pack_register_many_fn'; Alias = 'FnFfiLiveObjectContractPackRegisterMany'; Method = 'FfiLiveObjectContractPack_RegisterMany'; Signature = 'IntPtr*,uint,FfiCallResult*,int' }
 )
 
 $ffiApiType = $bindingsAssemblyObject.GetType('NativeHost.Bindings+FfiApiV2', $true)
-Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiType)) -Expected 360 -Description 'Managed FfiApiV2 size'
+Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiType)) -Expected 424 -Description 'Managed FfiApiV2 size'
 $ffiApiFields = @($ffiApiType.GetFields($instanceFields) | Sort-Object MetadataToken)
 $expectedFfiApiFieldNames = @('Size', 'AbiVersion', 'FeatureFlags') + @($expectedTableSlots | ForEach-Object { $_.Field })
 Assert-Sequence -Actual @($ffiApiFields | ForEach-Object Name) -Expected $expectedFfiApiFieldNames -Description 'Managed FfiApiV2 slot order'
@@ -297,7 +308,7 @@ for ($index = 0; $index -lt $ffiApiFields.Count; $index++) {
 }
 
 $compactFfiBindingsSource = $ffiBindingsSource -replace '\s+', ''
-$expectedBridgeFeatures = 'FeatureFlags=(1UL<<4)|(1UL<<5)|(1UL<<6)|FfiFeatureAsyncOperationPrimitives|FfiFeatureSessionPrimitives|FfiFeatureSessionPolling|FfiFeatureSnapshotProjections|FfiFeatureSessionConfiguration|FfiFeatureSessionVariables|FfiFeatureCapabilityRpc'
+$expectedBridgeFeatures = 'FeatureFlags=(1UL<<4)|(1UL<<5)|(1UL<<6)|FfiFeatureAsyncOperationPrimitives|FfiFeatureSessionPrimitives|FfiFeatureSessionPolling|FfiFeatureSnapshotProjections|FfiFeatureSessionConfiguration|FfiFeatureSessionVariables|FfiFeatureCapabilityRpc|FfiFeatureLiveObjectProbe|FfiFeatureLiveSessionObjectProbe|FfiFeatureLiveObjectContracts'
 if (-not $compactFfiBindingsSource.Contains($expectedBridgeFeatures)) {
     throw 'Managed FfiApiV2 feature flags no longer advertise the checked bridge capabilities.'
 }
@@ -366,6 +377,14 @@ FnFfiPowerShellSessionSetVariable|unsafeextern"system"fn(PowerShellHandle,*const
 FnFfiPowerShellSessionRemoveVariable|unsafeextern"system"fn(PowerShellHandle,*constu8,i32,*mutu32,*mutFfiCallResult)->i32
 FnFfiPowerShellSessionGetVariableSnapshot|unsafeextern"system"fn(PowerShellHandle,*constu8,i32,*mutu32,*mutu32,*mutu8,i32,*muti32,*mutFfiCallResult)->i32
 FnFfiPowerShellSetCapabilityContext|unsafeextern"system"fn(PowerShellHandle,u64,u64,*constlibc::c_void,*mutFfiCallResult)->i32
+FnFfiLiveObjectProbeCreate|unsafeextern"system"fn(i64,*mut*mutlibc::c_void,*mutFfiCallResult)->i32
+FnFfiLiveObjectProbeRelease|unsafeextern"system"fn(*mutlibc::c_void,*mutFfiCallResult)->i32
+FnFfiLiveObjectProbeUnregister|unsafeextern"system"fn(*mutlibc::c_void,*mutFfiCallResult)->i32
+FnFfiPowerShellAddLiveObject|unsafeextern"system"fn(PowerShellHandle,*mutlibc::c_void,*mutFfiCallResult)->i32
+FnFfiPowerShellSessionSetLiveObjectVariable|unsafeextern"system"fn(PowerShellHandle,*constu8,i32,*mutlibc::c_void,*mutFfiCallResult)->i32
+FnFfiLiveObjectContractPackRegister|unsafeextern"system"fn(*mutlibc::c_void,*mutFfiCallResult)->i32
+FnFfiPowerShellSessionSetLiveObjectContractVariable|unsafeextern"system"fn(PowerShellHandle,*constu8,i32,*constFfiLiveObjectContractDescriptor,*mutlibc::c_void,*mutFfiCallResult)->i32
+FnFfiLiveObjectContractPackRegisterMany|unsafeextern"system"fn(*const*mutlibc::c_void,u32,*mutFfiCallResult)->i32
 '@ -split [Environment]::NewLine | Where-Object { $_ }
 
 foreach ($expectedAlias in $expectedRustFunctionAliases) {


### PR DESCRIPTION
## Summary

- add preview typed live-object contracts, consumer-owned leases, and activation-time net8 payload adapter packs
- register complete adapter-pack sets atomically and reconcile payload proxy leases across script replacement, removal, and aliases
- reject unsafe nested/off-thread FFI calls while a pipeline runs while preserving cancellation and operation polling
- add an external net8 contract-pack acceptance fixture and NativeAOT sample coverage

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj -p:PwshExePath=<PowerShell 7.4>`
- `dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build`
- Release NativeAOT sample against PowerShell 7.4.17