### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "flate2",
  "home",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-sdk-ffi"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "pwsh-host",
  "winresource",

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/latest/download/in
 irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.15.0`):
+Install a specific tag (example `v0.16.0`):
 
 ```bash
-curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.15.0/install-multi-pwsh.sh | bash -s -- v0.15.0
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.16.0/install-multi-pwsh.sh | bash -s -- v0.16.0
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.15.0/install-multi-pwsh.ps1))) -Version v0.15.0
+& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.16.0/install-multi-pwsh.ps1))) -Version v0.16.0
 ```
 
 Uninstall bootstrap scripts:
@@ -289,7 +289,7 @@ Package authors can consume the launchers privately and map them into their own 
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.15.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.16.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -311,7 +311,7 @@ For a simple single-RID project, AppHost mode can copy the selected binary direc
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.15.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.16.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/multi-pwsh"

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/crates/pwsh-sdk-ffi/Cargo.toml
+++ b/crates/pwsh-sdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-sdk-ffi"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 publish = false

--- a/docs/host-and-venv.md
+++ b/docs/host-and-venv.md
@@ -33,7 +33,7 @@ Typical downstream vendored-SDK usage:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.15.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.16.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Devolutions.MultiPwsh.Sdk</AssemblyName>
     <PackageId>Devolutions.MultiPwsh.Sdk</PackageId>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.15.0</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.16.0</PackageVersion>
     <Authors>Devolutions</Authors>
     <Description>Experimental dynamically selected PowerShell payload facade for the in-process NativeAOT Devolutions Rust FFI.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/nuget/Devolutions.MultiPwsh.Cli/README.md
+++ b/nuget/Devolutions.MultiPwsh.Cli/README.md
@@ -6,7 +6,7 @@ The normal CLI payload is copied under `runtimes/<rid>/native/` for build and pu
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.15.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.16.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -28,7 +28,7 @@ AppHost mode is inert by default; set `MultiPwshAppHostEnabled=true` to copy the
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.15.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.16.0" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>


### PR DESCRIPTION
## Summary
- bump Rust crate and SDK package versions to 0.16.0
- refresh Cargo.lock and release/package-reference documentation

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- targeted FFI negative-matrix test passes when run independently
- `dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj`
- `dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build`

Note: `cargo test --all-targets` encountered an existing order-sensitive FFI negative-matrix test failure; the targeted test passes independently.