### PR TITLE
feat(ffi): add bounded typed result paging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
         shell: pwsh
         run: dotnet run --project dotnet/live-contract-generator-tests/Devolutions.MultiPwsh.LiveContract.Generator.Tests.csproj -c Release
 
+      - name: Run DTO contract generator tests
+        shell: pwsh
+        run: dotnet run --project dotnet/dto-contract-generator-tests/Devolutions.MultiPwsh.DtoContract.Generator.Tests.csproj -c Release
+
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/crates/pwsh-host/src/bindings.rs
+++ b/crates/pwsh-host/src/bindings.rs
@@ -14,6 +14,7 @@ pub(crate) use self::ffi::FfiBindings;
 pub use self::ffi::{
     FfiBindingError, FfiInvocationResult, FfiLiveInvocation, FfiLiveObjectContractDescriptor, FfiLiveStreamBatch,
     FfiLiveStreamRecord, FfiPowerShell, FfiPowerShellSession, FfiSessionEvent, FfiSessionSnapshot, FfiSnapshotValue,
+    FfiTypedResultInvocation, FfiTypedResultPage, FfiTypedResultRecord,
 };
 use crate::loader::HostedRuntime;
 

--- a/crates/pwsh-host/src/bindings/ffi.rs
+++ b/crates/pwsh-host/src/bindings/ffi.rs
@@ -13,6 +13,7 @@ use super::bindings_generated::PowerShellHandle;
 
 const FFI_BINDINGS_ABI_VERSION: u32 = 2;
 const FFI_BINDINGS_LIVE_STREAM_ABI_VERSION: u32 = 3;
+const FFI_BINDINGS_TYPED_RESULT_PAGING_ABI_VERSION: u32 = 4;
 const FFI_CALL_DIAGNOSTIC_CAPACITY: usize = 4096;
 const FFI_FEATURE_ASYNC_OPERATION_PRIMITIVES: u64 = 1 << 8;
 const FFI_FEATURE_SESSION_PRIMITIVES: u64 = 1 << 10;
@@ -25,6 +26,7 @@ const FFI_FEATURE_LIVE_OBJECT_PROBE: u64 = 1 << 17;
 const FFI_FEATURE_LIVE_SESSION_OBJECT_PROBE: u64 = 1 << 18;
 const FFI_FEATURE_LIVE_OBJECT_CONTRACTS: u64 = 1 << 19;
 const FFI_FEATURE_LIVE_STREAM_POLLING: u64 = 1 << 20;
+const FFI_FEATURE_TYPED_RESULT_PAGING: u64 = 1 << 21;
 const STATUS_SUCCESS: i32 = 0;
 const STATUS_BUFFER_TOO_SMALL: i32 = 1;
 
@@ -127,8 +129,27 @@ struct FfiApiV3 {
     live_invocation_release_fn: *const libc::c_void,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct FfiApiV4 {
+    size: usize,
+    abi_version: u32,
+    feature_flags: u64,
+    power_shell_begin_typed_result_invocation_fn: *const libc::c_void,
+    typed_result_invocation_poll_fn: *const libc::c_void,
+    typed_result_invocation_read_page_fn: *const libc::c_void,
+    typed_result_invocation_complete_fn: *const libc::c_void,
+    typed_result_invocation_stop_fn: *const libc::c_void,
+    typed_result_invocation_release_fn: *const libc::c_void,
+    typed_result_page_get_info_fn: *const libc::c_void,
+    typed_result_page_get_record_info_fn: *const libc::c_void,
+    typed_result_page_copy_record_value_fn: *const libc::c_void,
+    typed_result_page_release_fn: *const libc::c_void,
+}
+
 type FnBindingsGetFfiApiV2 = unsafe extern "system" fn() -> *const FfiApiV2;
 type FnBindingsGetFfiApiV3 = unsafe extern "system" fn() -> *const FfiApiV3;
+type FnBindingsGetFfiApiV4 = unsafe extern "system" fn() -> *const FfiApiV4;
 type FnFfiPowerShellCreate = unsafe extern "system" fn(*mut PowerShellHandle, *mut FfiCallResult) -> i32;
 type FnFfiPowerShellRelease = unsafe extern "system" fn(PowerShellHandle, *mut FfiCallResult) -> i32;
 type FnFfiPowerShellAddUtf8 = unsafe extern "system" fn(PowerShellHandle, *const u8, i32, *mut FfiCallResult) -> i32;
@@ -161,6 +182,27 @@ type FnFfiLiveInvocationBatchCopyRecordTextToUtf8 =
 type FnFfiLiveInvocationRelease = unsafe extern "system" fn(PowerShellHandle, *mut FfiCallResult) -> i32;
 type FnFfiLiveInvocationComplete =
     unsafe extern "system" fn(PowerShellHandle, *mut PowerShellHandle, *mut FfiCallResult) -> i32;
+type FnFfiPowerShellBeginTypedResultInvocation =
+    unsafe extern "system" fn(PowerShellHandle, i32, i32, *mut PowerShellHandle, *mut FfiCallResult) -> i32;
+type FnFfiTypedResultInvocationPoll = unsafe extern "system" fn(PowerShellHandle, *mut i32, *mut FfiCallResult) -> i32;
+type FnFfiTypedResultInvocationReadPage =
+    unsafe extern "system" fn(PowerShellHandle, i64, i32, *mut PowerShellHandle, *mut FfiCallResult) -> i32;
+type FnFfiTypedResultInvocationComplete = unsafe extern "system" fn(PowerShellHandle, *mut FfiCallResult) -> i32;
+type FnFfiTypedResultPageGetInfo = unsafe extern "system" fn(
+    PowerShellHandle,
+    *mut i64,
+    *mut i64,
+    *mut i64,
+    *mut i64,
+    *mut i32,
+    *mut u32,
+    *mut i32,
+    *mut FfiCallResult,
+) -> i32;
+type FnFfiTypedResultPageGetRecordInfo =
+    unsafe extern "system" fn(PowerShellHandle, i32, *mut i64, *mut u32, *mut FfiCallResult) -> i32;
+type FnFfiTypedResultPageCopyRecordValue =
+    unsafe extern "system" fn(PowerShellHandle, i32, *mut u32, *mut u8, i32, *mut i32, *mut FfiCallResult) -> i32;
 type FnFfiInvocationResultRelease = unsafe extern "system" fn(PowerShellHandle, *mut FfiCallResult) -> i32;
 type FnFfiInvocationResultGetInfo =
     unsafe extern "system" fn(PowerShellHandle, *mut u32, *mut i32, *mut FfiCallResult) -> i32;
@@ -346,6 +388,7 @@ pub(crate) struct FfiBindings {
     power_shell_session_set_live_object_contract_variable_fn: FnFfiPowerShellSessionSetLiveObjectContractVariable,
     live_object_contract_pack_register_many_fn: FnFfiLiveObjectContractPackRegisterMany,
     live_stream: Option<FfiLiveStreamBindings>,
+    typed_result_paging: Option<FfiTypedResultPagingBindings>,
 }
 
 #[derive(Clone, Copy)]
@@ -360,6 +403,20 @@ struct FfiLiveStreamBindings {
     live_invocation_complete_fn: FnFfiLiveInvocationComplete,
     live_invocation_stop_fn: FnFfiLiveInvocationRelease,
     live_invocation_release_fn: FnFfiLiveInvocationRelease,
+}
+
+#[derive(Clone, Copy)]
+struct FfiTypedResultPagingBindings {
+    power_shell_begin_typed_result_invocation_fn: FnFfiPowerShellBeginTypedResultInvocation,
+    typed_result_invocation_poll_fn: FnFfiTypedResultInvocationPoll,
+    typed_result_invocation_read_page_fn: FnFfiTypedResultInvocationReadPage,
+    typed_result_invocation_complete_fn: FnFfiTypedResultInvocationComplete,
+    typed_result_invocation_stop_fn: FnFfiTypedResultInvocationComplete,
+    typed_result_invocation_release_fn: FnFfiTypedResultInvocationComplete,
+    typed_result_page_get_info_fn: FnFfiTypedResultPageGetInfo,
+    typed_result_page_get_record_info_fn: FnFfiTypedResultPageGetRecordInfo,
+    typed_result_page_copy_record_value_fn: FnFfiTypedResultPageCopyRecordValue,
+    typed_result_page_release_fn: FnFfiTypedResultInvocationComplete,
 }
 
 #[derive(Debug)]
@@ -600,6 +657,100 @@ impl FfiBindings {
             Err(_) => None,
         };
 
+        let typed_result_paging = match get_function_pointer(
+            fn_loader,
+            pdcstr!("NativeHost.Bindings, Devolutions.PowerShell.SDK.Bindings"),
+            pdcstr!("Bindings_GetFfiApiV4"),
+        ) {
+            Ok(pointer) => {
+                let get_api_fn: FnBindingsGetFfiApiV4 = unsafe { mem::transmute(pointer) };
+                let api_ptr = unsafe { get_api_fn() };
+                if api_ptr.is_null() {
+                    return Err(Error::IO(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "managed typed result paging binding table is null",
+                    )));
+                }
+                let api = unsafe { *api_ptr };
+                let fields = [
+                    api.power_shell_begin_typed_result_invocation_fn,
+                    api.typed_result_invocation_poll_fn,
+                    api.typed_result_invocation_read_page_fn,
+                    api.typed_result_invocation_complete_fn,
+                    api.typed_result_invocation_stop_fn,
+                    api.typed_result_invocation_release_fn,
+                    api.typed_result_page_get_info_fn,
+                    api.typed_result_page_get_record_info_fn,
+                    api.typed_result_page_copy_record_value_fn,
+                    api.typed_result_page_release_fn,
+                ];
+                if api.abi_version != FFI_BINDINGS_TYPED_RESULT_PAGING_ABI_VERSION
+                    || api.size < mem::size_of::<FfiApiV4>()
+                    || api.feature_flags & FFI_FEATURE_TYPED_RESULT_PAGING == 0
+                    || fields.iter().any(|field| field.is_null())
+                {
+                    return Err(Error::IO(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "managed typed result paging bindings are incompatible",
+                    )));
+                }
+
+                Some(FfiTypedResultPagingBindings {
+                    power_shell_begin_typed_result_invocation_fn: unsafe {
+                        mem::transmute::<*const libc::c_void, FnFfiPowerShellBeginTypedResultInvocation>(
+                            api.power_shell_begin_typed_result_invocation_fn,
+                        )
+                    },
+                    typed_result_invocation_poll_fn: unsafe {
+                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationPoll>(
+                            api.typed_result_invocation_poll_fn,
+                        )
+                    },
+                    typed_result_invocation_read_page_fn: unsafe {
+                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationReadPage>(
+                            api.typed_result_invocation_read_page_fn,
+                        )
+                    },
+                    typed_result_invocation_complete_fn: unsafe {
+                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
+                            api.typed_result_invocation_complete_fn,
+                        )
+                    },
+                    typed_result_invocation_stop_fn: unsafe {
+                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
+                            api.typed_result_invocation_stop_fn,
+                        )
+                    },
+                    typed_result_invocation_release_fn: unsafe {
+                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
+                            api.typed_result_invocation_release_fn,
+                        )
+                    },
+                    typed_result_page_get_info_fn: unsafe {
+                        mem::transmute::<*const libc::c_void, FnFfiTypedResultPageGetInfo>(
+                            api.typed_result_page_get_info_fn,
+                        )
+                    },
+                    typed_result_page_get_record_info_fn: unsafe {
+                        mem::transmute::<*const libc::c_void, FnFfiTypedResultPageGetRecordInfo>(
+                            api.typed_result_page_get_record_info_fn,
+                        )
+                    },
+                    typed_result_page_copy_record_value_fn: unsafe {
+                        mem::transmute::<*const libc::c_void, FnFfiTypedResultPageCopyRecordValue>(
+                            api.typed_result_page_copy_record_value_fn,
+                        )
+                    },
+                    typed_result_page_release_fn: unsafe {
+                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
+                            api.typed_result_page_release_fn,
+                        )
+                    },
+                })
+            }
+            Err(_) => None,
+        };
+
         Ok(Self {
             create_fn: unsafe { mem::transmute::<*const libc::c_void, FnFfiPowerShellCreate>(api.create_fn) },
             release_fn: unsafe { mem::transmute::<*const libc::c_void, FnFfiPowerShellRelease>(api.release_fn) },
@@ -788,6 +939,7 @@ impl FfiBindings {
                 )
             },
             live_stream,
+            typed_result_paging,
         })
     }
 
@@ -1092,6 +1244,52 @@ impl FfiPowerShell {
 
     pub fn supports_live_stream_polling(&self) -> bool {
         self.bindings.live_stream.is_some()
+    }
+
+    pub fn supports_typed_result_paging(&self) -> bool {
+        self.bindings.typed_result_paging.is_some()
+    }
+
+    pub fn begin_typed_result_invocation(
+        &self,
+        maximum_buffered_records: u32,
+        maximum_page_records: u32,
+    ) -> Result<FfiTypedResultInvocation, FfiBindingError> {
+        if maximum_buffered_records == 0
+            || maximum_buffered_records > 64
+            || maximum_page_records == 0
+            || maximum_page_records > maximum_buffered_records
+        {
+            return Err(FfiBindingError::from_status(
+                -1,
+                "typed result invocation bounds are invalid".to_owned(),
+            ));
+        }
+        let typed_result_paging = self.bindings.typed_result_paging.ok_or_else(|| {
+            FfiBindingError::from_status(-17, "managed bindings do not support typed result paging".to_owned())
+        })?;
+        let mut typed_result_handle = std::ptr::null_mut();
+        self.call(|handle, result| unsafe {
+            (typed_result_paging.power_shell_begin_typed_result_invocation_fn)(
+                handle,
+                maximum_buffered_records as i32,
+                maximum_page_records as i32,
+                &mut typed_result_handle,
+                result,
+            )
+        })?;
+        if typed_result_handle.is_null() {
+            return Err(FfiBindingError::from_status(
+                -6,
+                "managed typed result invocation returned a null handle".to_owned(),
+            ));
+        }
+
+        Ok(FfiTypedResultInvocation {
+            _runtime: Arc::clone(&self._runtime),
+            bindings: self.bindings,
+            handle: Some(typed_result_handle),
+        })
     }
 
     pub fn begin_live_invocation(&self) -> Result<FfiLiveInvocation, FfiBindingError> {
@@ -1511,6 +1709,299 @@ impl Drop for FfiLiveInvocation {
         let mut call_result = new_call_result(&mut diagnostic);
         unsafe {
             (live_stream.live_invocation_release_fn)(handle, &mut call_result);
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct FfiTypedResultRecord {
+    pub sequence: u64,
+    pub kind: u32,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct FfiTypedResultPage {
+    pub acknowledged_sequence: u64,
+    pub next_sequence: u64,
+    pub total_record_count: u64,
+    pub dropped_record_count: u64,
+    pub terminal_status: i32,
+    pub is_terminal: bool,
+    pub is_truncated: bool,
+    pub is_complete: bool,
+    pub records: Vec<FfiTypedResultRecord>,
+}
+
+pub struct FfiTypedResultInvocation {
+    _runtime: Arc<HostedRuntime>,
+    bindings: FfiBindings,
+    handle: Option<PowerShellHandle>,
+}
+
+impl FfiTypedResultInvocation {
+    pub fn poll(&self) -> Result<bool, FfiBindingError> {
+        let typed_result_paging = self.typed_result_paging()?;
+        let mut completed = 0_i32;
+        self.call(|handle, result| unsafe {
+            (typed_result_paging.typed_result_invocation_poll_fn)(handle, &mut completed, result)
+        })?;
+        match completed {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(FfiBindingError::from_status(
+                -6,
+                "managed typed result invocation returned invalid completion metadata".to_owned(),
+            )),
+        }
+    }
+
+    pub fn read_page(
+        &self,
+        acknowledged_through: u64,
+        maximum_records: u32,
+    ) -> Result<FfiTypedResultPage, FfiBindingError> {
+        if acknowledged_through > i64::MAX as u64 || maximum_records == 0 || maximum_records > 64 {
+            return Err(FfiBindingError::from_status(
+                -1,
+                "typed result page cursor or limit is invalid".to_owned(),
+            ));
+        }
+
+        let typed_result_paging = self.typed_result_paging()?;
+        let mut page_handle = std::ptr::null_mut();
+        self.call(|handle, result| unsafe {
+            (typed_result_paging.typed_result_invocation_read_page_fn)(
+                handle,
+                acknowledged_through as i64,
+                maximum_records as i32,
+                &mut page_handle,
+                result,
+            )
+        })?;
+        if page_handle.is_null() {
+            return Err(FfiBindingError::from_status(
+                -6,
+                "managed typed result invocation returned a null page handle".to_owned(),
+            ));
+        }
+
+        let page = (|| {
+            let mut acknowledged_sequence = 0_i64;
+            let mut next_sequence = 0_i64;
+            let mut total_record_count = 0_i64;
+            let mut dropped_record_count = 0_i64;
+            let mut terminal_status = 0_i32;
+            let mut flags = 0_u32;
+            let mut record_count = 0_i32;
+            let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+            let mut call_result = new_call_result(&mut diagnostic);
+            let status = unsafe {
+                (typed_result_paging.typed_result_page_get_info_fn)(
+                    page_handle,
+                    &mut acknowledged_sequence,
+                    &mut next_sequence,
+                    &mut total_record_count,
+                    &mut dropped_record_count,
+                    &mut terminal_status,
+                    &mut flags,
+                    &mut record_count,
+                    &mut call_result,
+                )
+            };
+            check_status(status, &call_result, &diagnostic)?;
+            let acknowledged_sequence = u64::try_from(acknowledged_sequence).map_err(|_| {
+                FfiBindingError::from_status(-6, "managed typed result acknowledgement is invalid".to_owned())
+            })?;
+            let next_sequence = u64::try_from(next_sequence)
+                .map_err(|_| FfiBindingError::from_status(-6, "managed typed result cursor is invalid".to_owned()))?;
+            let total_record_count = u64::try_from(total_record_count)
+                .map_err(|_| FfiBindingError::from_status(-6, "managed typed result total is invalid".to_owned()))?;
+            let dropped_record_count = u64::try_from(dropped_record_count).map_err(|_| {
+                FfiBindingError::from_status(-6, "managed typed result drop count is invalid".to_owned())
+            })?;
+            if acknowledged_sequence != acknowledged_through
+                || next_sequence < acknowledged_sequence
+                || next_sequence > total_record_count
+                || dropped_record_count > total_record_count
+                || record_count < 0
+                || record_count > maximum_records as i32
+                || flags & !0x7 != 0
+            {
+                return Err(FfiBindingError::from_status(
+                    -6,
+                    "managed typed result page metadata is invalid".to_owned(),
+                ));
+            }
+
+            let is_terminal = flags & 1 != 0;
+            let is_truncated = flags & (1 << 1) != 0;
+            let is_complete = flags & (1 << 2) != 0;
+            if (!is_terminal && terminal_status != 0)
+                || (is_complete && (!is_terminal || terminal_status != 0 || is_truncated))
+            {
+                return Err(FfiBindingError::from_status(
+                    -6,
+                    "managed typed result terminal metadata is inconsistent".to_owned(),
+                ));
+            }
+
+            let mut records = Vec::with_capacity(record_count as usize);
+            let mut previous_sequence = acknowledged_sequence;
+            for index in 0..record_count {
+                let mut sequence = 0_i64;
+                let mut kind = 0_u32;
+                call_result = new_call_result(&mut diagnostic);
+                let status = unsafe {
+                    (typed_result_paging.typed_result_page_get_record_info_fn)(
+                        page_handle,
+                        index,
+                        &mut sequence,
+                        &mut kind,
+                        &mut call_result,
+                    )
+                };
+                check_status(status, &call_result, &diagnostic)?;
+                let sequence = u64::try_from(sequence).map_err(|_| {
+                    FfiBindingError::from_status(-6, "managed typed result record sequence is invalid".to_owned())
+                })?;
+                if kind > 14 || sequence <= previous_sequence || sequence > next_sequence {
+                    return Err(FfiBindingError::from_status(
+                        -6,
+                        "managed typed result records are unordered or unsupported".to_owned(),
+                    ));
+                }
+                previous_sequence = sequence;
+
+                let mut required_length = 0_i32;
+                call_result = new_call_result(&mut diagnostic);
+                let status = unsafe {
+                    (typed_result_paging.typed_result_page_copy_record_value_fn)(
+                        page_handle,
+                        index,
+                        &mut kind,
+                        std::ptr::null_mut(),
+                        0,
+                        &mut required_length,
+                        &mut call_result,
+                    )
+                };
+                if status != STATUS_SUCCESS && status != STATUS_BUFFER_TOO_SMALL {
+                    check_status(status, &call_result, &diagnostic)?;
+                }
+                if kind > 14 || required_length < 0 || required_length as usize > 64 * 1024 {
+                    return Err(FfiBindingError::from_status(
+                        -6,
+                        "managed typed result value exceeds its fixed bound".to_owned(),
+                    ));
+                }
+                let mut payload = vec![0_u8; required_length as usize];
+                call_result = new_call_result(&mut diagnostic);
+                let status = unsafe {
+                    (typed_result_paging.typed_result_page_copy_record_value_fn)(
+                        page_handle,
+                        index,
+                        &mut kind,
+                        payload.as_mut_ptr(),
+                        required_length,
+                        &mut required_length,
+                        &mut call_result,
+                    )
+                };
+                check_status(status, &call_result, &diagnostic)?;
+                if kind > 14 || required_length as usize != payload.len() {
+                    return Err(FfiBindingError::from_status(
+                        -6,
+                        "managed typed result value changed during copy".to_owned(),
+                    ));
+                }
+                records.push(FfiTypedResultRecord {
+                    sequence,
+                    kind,
+                    payload,
+                });
+            }
+
+            if records.is_empty() {
+                if next_sequence != acknowledged_sequence {
+                    return Err(FfiBindingError::from_status(
+                        -6,
+                        "managed typed result page cursor is inconsistent".to_owned(),
+                    ));
+                }
+            } else if next_sequence != previous_sequence {
+                return Err(FfiBindingError::from_status(
+                    -6,
+                    "managed typed result page cursor is inconsistent".to_owned(),
+                ));
+            }
+
+            Ok(FfiTypedResultPage {
+                acknowledged_sequence,
+                next_sequence,
+                total_record_count,
+                dropped_record_count,
+                terminal_status,
+                is_terminal,
+                is_truncated,
+                is_complete,
+                records,
+            })
+        })();
+
+        let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+        let mut call_result = new_call_result(&mut diagnostic);
+        let release_status =
+            unsafe { (typed_result_paging.typed_result_page_release_fn)(page_handle, &mut call_result) };
+        match (page, check_status(release_status, &call_result, &diagnostic)) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+        }
+    }
+
+    pub fn complete(&self) -> Result<(), FfiBindingError> {
+        let typed_result_paging = self.typed_result_paging()?;
+        self.call(|handle, result| unsafe { (typed_result_paging.typed_result_invocation_complete_fn)(handle, result) })
+    }
+
+    pub fn stop(&self) -> Result<(), FfiBindingError> {
+        let typed_result_paging = self.typed_result_paging()?;
+        self.call(|handle, result| unsafe { (typed_result_paging.typed_result_invocation_stop_fn)(handle, result) })
+    }
+
+    fn typed_result_paging(&self) -> Result<FfiTypedResultPagingBindings, FfiBindingError> {
+        self.bindings.typed_result_paging.ok_or_else(|| {
+            FfiBindingError::from_status(-17, "managed bindings do not support typed result paging".to_owned())
+        })
+    }
+
+    fn call<F>(&self, operation: F) -> Result<(), FfiBindingError>
+    where
+        F: FnOnce(PowerShellHandle, *mut FfiCallResult) -> i32,
+    {
+        let handle = self.handle.ok_or_else(|| {
+            FfiBindingError::from_status(-4, "Typed result invocation handle has been released".to_owned())
+        })?;
+        let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+        let mut call_result = new_call_result(&mut diagnostic);
+        let status = operation(handle, &mut call_result);
+        check_status(status, &call_result, &diagnostic)
+    }
+}
+
+impl Drop for FfiTypedResultInvocation {
+    fn drop(&mut self) {
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        let Some(typed_result_paging) = self.bindings.typed_result_paging else {
+            return;
+        };
+        let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
+        let mut call_result = new_call_result(&mut diagnostic);
+        unsafe {
+            (typed_result_paging.typed_result_invocation_release_fn)(handle, &mut call_result);
         }
     }
 }

--- a/crates/pwsh-host/src/lib.rs
+++ b/crates/pwsh-host/src/lib.rs
@@ -27,7 +27,7 @@ mod pdcstring;
 pub use bindings::{
     FfiBindingError, FfiInvocationResult, FfiLiveInvocation, FfiLiveObjectContractDescriptor, FfiLiveStreamBatch,
     FfiLiveStreamRecord, FfiPowerShell, FfiPowerShellSession, FfiSessionEvent, FfiSessionSnapshot, FfiSnapshotValue,
-    PowerShell,
+    FfiTypedResultInvocation, FfiTypedResultPage, FfiTypedResultRecord, PowerShell,
 };
 pub use host_detect::find_pwsh_dir;
 pub use loader::{get_assembly_delegate_loader_for_pwsh_dir, HostedRuntime, LiveObjectContractPack};

--- a/crates/pwsh-sdk-ffi/src/lib.rs
+++ b/crates/pwsh-sdk-ffi/src/lib.rs
@@ -19,7 +19,7 @@ use pwsh_host::FfiLiveStreamRecord;
 use pwsh_host::{
     find_pwsh_dir, FfiBindingError, FfiInvocationResult, FfiLiveInvocation, FfiLiveObjectContractDescriptor,
     FfiLiveStreamBatch, FfiPowerShell, FfiPowerShellSession, FfiSessionEvent, FfiSessionSnapshot, FfiSnapshotValue,
-    HostedRuntime, LiveObjectContractPack,
+    FfiTypedResultInvocation, FfiTypedResultPage, FfiTypedResultRecord, HostedRuntime, LiveObjectContractPack,
 };
 
 const ABI_VERSION: u32 = 2;
@@ -44,6 +44,7 @@ const FEATURE_LIVE_OBJECT_PROBE: u64 = 1 << 17;
 const FEATURE_LIVE_SESSION_OBJECT_PROBE: u64 = 1 << 18;
 const FEATURE_LIVE_OBJECT_CONTRACTS: u64 = 1 << 19;
 const FEATURE_LIVE_STREAM_POLLING: u64 = 1 << 20;
+const FEATURE_TYPED_RESULT_PAGING: u64 = 1 << 21;
 const CALL_RESULT_DIAGNOSTIC_TRUNCATED: u32 = 1;
 #[cfg(test)]
 const RESULT_RECORD_SCALAR_VALUE_PRESENT: u32 = 1 << 1;
@@ -57,6 +58,8 @@ const MAX_VALUE_DEPTH: u8 = 8;
 const MAX_OPERATION_DIAGNOSTIC_BYTES: usize = 4096;
 const MAX_OPERATION_STREAM_RECORDS: usize = 32;
 const MAX_OPERATION_STREAM_RECORD_BYTES: usize = 4096;
+const MAX_TYPED_RESULT_RECORDS: usize = 64;
+const MAX_TYPED_RESULT_PAYLOAD_BYTES: usize = 64 * 1024;
 const OPERATION_STREAM_RECORD_TEXT_TRUNCATED: u32 = 1;
 const MAX_SESSION_CONFIGURATION_ENTRIES: usize = 32;
 const MAX_SESSION_PATH_BYTES: usize = 16 * 1024;
@@ -122,6 +125,20 @@ pub struct OperationStreamBatchInfo {
     lost_record_count: u64,
     record_count: u32,
     _reserved: u32,
+}
+
+#[repr(C)]
+pub struct TypedResultPageInfo {
+    size: u32,
+    flags: u32,
+    terminal_status: i32,
+    _reserved: u32,
+    acknowledged_sequence: u64,
+    next_sequence: u64,
+    total_record_count: u64,
+    dropped_record_count: u64,
+    record_count: u32,
+    _reserved2: u32,
 }
 
 #[repr(C)]
@@ -259,11 +276,15 @@ struct State {
     results: HashMap<u64, Arc<InvocationResult>>,
     operations: HashMap<u64, Arc<Operation>>,
     operation_stream_batches: HashMap<u64, Arc<OperationStreamBatch>>,
+    typed_result_operations: HashMap<u64, Arc<TypedResultOperation>>,
+    typed_result_pages: HashMap<u64, Arc<FfiTypedResultPage>>,
     capabilities: HashMap<u64, Arc<CapabilityRegistrationState>>,
     next_handle: u64,
     next_result_handle: u64,
     next_operation_handle: u64,
     next_operation_stream_batch_handle: u64,
+    next_typed_result_operation_handle: u64,
+    next_typed_result_page_handle: u64,
     next_runspace_session_handle: u64,
     next_capability_handle: u64,
 }
@@ -368,6 +389,16 @@ struct OperationStreamBatch {
     source_dropped_record_count: u64,
     lost_record_count: u64,
     records: Vec<OperationStreamRecord>,
+}
+
+struct TypedResultOperation {
+    session: Arc<Session>,
+    capability: Option<CapabilityInvocation>,
+    invocation: Mutex<Option<FfiTypedResultInvocation>>,
+    pipeline_completed: AtomicBool,
+    cancellation_requested: AtomicBool,
+    finalized: AtomicBool,
+    worker_error: Mutex<Option<(Status, String)>>,
 }
 
 impl OperationStreamState {
@@ -488,6 +519,8 @@ unsafe impl Send for InvocationResult {}
 unsafe impl Sync for InvocationResult {}
 unsafe impl Send for Operation {}
 unsafe impl Sync for Operation {}
+unsafe impl Send for TypedResultOperation {}
+unsafe impl Sync for TypedResultOperation {}
 
 impl Operation {
     fn new(builder_handle: u64, session: Arc<Session>, capability: Option<CapabilityInvocation>) -> Self {
@@ -719,6 +752,135 @@ impl Operation {
     }
 }
 
+impl TypedResultOperation {
+    fn new(
+        session: Arc<Session>,
+        capability: Option<CapabilityInvocation>,
+        invocation: FfiTypedResultInvocation,
+    ) -> Self {
+        Self {
+            session,
+            capability,
+            invocation: Mutex::new(Some(invocation)),
+            pipeline_completed: AtomicBool::new(false),
+            cancellation_requested: AtomicBool::new(false),
+            finalized: AtomicBool::new(false),
+            worker_error: Mutex::new(None),
+        }
+    }
+
+    fn request_stop(&self) {
+        if !self.cancellation_requested.swap(true, Ordering::AcqRel) {
+            self.cancel_capability();
+            if let Some(invocation) = self
+                .invocation
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .as_ref()
+            {
+                let _ = invocation.stop();
+            }
+        }
+    }
+
+    fn read_page(
+        &self,
+        acknowledged_through: u64,
+        maximum_records: u32,
+    ) -> Result<FfiTypedResultPage, (Status, String)> {
+        if let Some(error) = self
+            .worker_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+        {
+            return Err(error);
+        }
+
+        let invocation = self.invocation.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let invocation = invocation.as_ref().ok_or_else(|| {
+            (
+                Status::InvalidHandle,
+                "typed result invocation has been released".to_owned(),
+            )
+        })?;
+        let mut page = invocation
+            .read_page(acknowledged_through, maximum_records)
+            .map_err(managed_failure)?;
+        if page.records.is_empty() && self.pipeline_completed.load(Ordering::Acquire) {
+            invocation.complete().map_err(managed_failure)?;
+            page = invocation
+                .read_page(acknowledged_through, maximum_records)
+                .map_err(managed_failure)?;
+            self.finalize();
+        }
+        Ok(page)
+    }
+
+    fn poll_pipeline(&self) -> Result<bool, (Status, String)> {
+        let invocation = self.invocation.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let invocation = invocation.as_ref().ok_or_else(|| {
+            (
+                Status::InvalidHandle,
+                "typed result invocation has been released".to_owned(),
+            )
+        })?;
+        invocation.poll().map_err(managed_failure)
+    }
+
+    fn record_worker_error(&self, error: (Status, String)) {
+        *self
+            .worker_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(error);
+        self.request_stop();
+    }
+
+    fn abort(&self) {
+        self.request_stop();
+        self.invocation
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        self.finalize();
+    }
+
+    fn finalize(&self) {
+        if self.finalized.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        if self.capability.is_some() {
+            let _ = unsafe { self.session.power_shell.set_capability_context(0, 0, std::ptr::null()) };
+        }
+        set_active_capability(&self.session, None);
+        finish_capability(self.capability.as_ref());
+        self.clear_session_operation();
+    }
+
+    fn clear_session_operation(&self) {
+        let mut active = self
+            .session
+            .operation_active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *active = false;
+        if let Some(runspace_session) = &self.session.runspace_session {
+            let mut active = runspace_session
+                .operation_active
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *active = false;
+        }
+    }
+
+    fn cancel_capability(&self) {
+        if let Some(capability) = &self.capability {
+            capability.cancel();
+        }
+    }
+}
+
 impl Default for State {
     fn default() -> Self {
         Self {
@@ -730,11 +892,15 @@ impl Default for State {
             results: HashMap::new(),
             operations: HashMap::new(),
             operation_stream_batches: HashMap::new(),
+            typed_result_operations: HashMap::new(),
+            typed_result_pages: HashMap::new(),
             capabilities: HashMap::new(),
             next_handle: 1,
             next_result_handle: 1_u64 << 63,
             next_operation_handle: 1_u64 << 62,
             next_operation_stream_batch_handle: 1_u64 << 59,
+            next_typed_result_operation_handle: 1_u64 << 58,
+            next_typed_result_page_handle: 1_u64 << 57,
             next_runspace_session_handle: 1_u64 << 61,
             next_capability_handle: 1_u64 << 60,
         }
@@ -1612,6 +1778,42 @@ fn begin_live_invocation_with_capability(
     }
 }
 
+fn begin_typed_result_invocation_with_capability(
+    session: &Session,
+    capability: Option<CapabilityInvocation>,
+    maximum_buffered_records: u32,
+    maximum_page_records: u32,
+) -> Result<FfiTypedResultInvocation, FfiBindingError> {
+    if let Some(capability) = capability {
+        set_active_capability(session, Some(capability.clone()));
+        let configured = unsafe {
+            session.power_shell.set_capability_context(
+                capability.registration.handle,
+                capability.invocation_id,
+                capability_dispatch as *const () as *const _,
+            )
+        };
+        if let Err(error) = configured {
+            set_active_capability(session, None);
+            capability.registration.end_invocation(capability.invocation_id);
+            return Err(error);
+        }
+        let invocation = session
+            .power_shell
+            .begin_typed_result_invocation(maximum_buffered_records, maximum_page_records);
+        if invocation.is_err() {
+            let _ = unsafe { session.power_shell.set_capability_context(0, 0, std::ptr::null()) };
+            set_active_capability(session, None);
+            capability.registration.end_invocation(capability.invocation_id);
+        }
+        invocation
+    } else {
+        session
+            .power_shell
+            .begin_typed_result_invocation(maximum_buffered_records, maximum_page_records)
+    }
+}
+
 fn status_from_callback(value: i32) -> Status {
     match value {
         0 => Status::Success,
@@ -2316,6 +2518,245 @@ fn start_operation(handle: u64) -> Result<u64, (Status, String)> {
     Ok(operation_handle)
 }
 
+fn start_typed_result_operation(
+    handle: u64,
+    maximum_buffered_records: u32,
+    maximum_page_records: u32,
+) -> Result<u64, (Status, String)> {
+    if maximum_buffered_records == 0
+        || maximum_buffered_records as usize > MAX_TYPED_RESULT_RECORDS
+        || maximum_page_records == 0
+        || maximum_page_records > maximum_buffered_records
+    {
+        return Err((
+            Status::InvalidArgument,
+            "typed result invocation bounds are invalid".to_owned(),
+        ));
+    }
+
+    let _operation_lock = SESSION_OPERATION_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let (session, capability) = {
+        let state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let session = state
+            .sessions
+            .get(&handle)
+            .cloned()
+            .ok_or_else(|| (Status::InvalidHandle, "PowerShell handle is invalid".to_owned()))?;
+        if !session.power_shell.supports_typed_result_paging() {
+            return Err((
+                Status::UnsupportedCapability,
+                "The selected PowerShell payload does not support typed result paging.".to_owned(),
+            ));
+        }
+        {
+            let mut active = session
+                .operation_active
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if *active {
+                return Err((
+                    Status::Backpressure,
+                    "PowerShell builder already has an active async operation.".to_owned(),
+                ));
+            }
+            *active = true;
+        }
+        if let Some(runspace_session) = &session.runspace_session {
+            let parent_active = {
+                let mut active = runspace_session
+                    .operation_active
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if *active {
+                    true
+                } else {
+                    *active = true;
+                    false
+                }
+            };
+            if parent_active {
+                let mut builder_active = session
+                    .operation_active
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                *builder_active = false;
+                return Err((
+                    Status::Backpressure,
+                    "PowerShell session already has a pending or running async operation.".to_owned(),
+                ));
+            }
+        }
+        let capability = take_session_capability(&session)?;
+        (session, capability)
+    };
+
+    let invocation = begin_typed_result_invocation_with_capability(
+        &session,
+        capability.clone(),
+        maximum_buffered_records,
+        maximum_page_records,
+    );
+    let invocation = match invocation {
+        Ok(invocation) => invocation,
+        Err(error) => {
+            let operation = TypedResultOperation {
+                session,
+                capability: None,
+                invocation: Mutex::new(None),
+                pipeline_completed: AtomicBool::new(false),
+                cancellation_requested: AtomicBool::new(false),
+                finalized: AtomicBool::new(false),
+                worker_error: Mutex::new(None),
+            };
+            operation.clear_session_operation();
+            return Err(managed_failure(error));
+        }
+    };
+
+    let operation = Arc::new(TypedResultOperation::new(session, capability, invocation));
+    let operation_handle = {
+        let mut state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let operation_handle = state.next_typed_result_operation_handle;
+        state.next_typed_result_operation_handle = state
+            .next_typed_result_operation_handle
+            .checked_add(1)
+            .filter(|value| *value != 0)
+            .unwrap_or(1_u64 << 58);
+        state
+            .typed_result_operations
+            .insert(operation_handle, Arc::clone(&operation));
+        operation_handle
+    };
+
+    if std::thread::Builder::new()
+        .name("pwsh-sdk-ffi-typed-result".to_owned())
+        .spawn({
+            let operation = Arc::clone(&operation);
+            move || run_typed_result_operation(operation)
+        })
+        .is_err()
+    {
+        state()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .typed_result_operations
+            .remove(&operation_handle);
+        operation.abort();
+        return Err((
+            Status::HostFailure,
+            "failed to create the native typed result operation thread".to_owned(),
+        ));
+    }
+
+    Ok(operation_handle)
+}
+
+fn run_typed_result_operation(operation: Arc<TypedResultOperation>) {
+    let _operation_lock = SESSION_OPERATION_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _execution_scope = InvocationExecutionScope::enter();
+    loop {
+        if operation.cancellation_requested.load(Ordering::Acquire) {
+            operation.request_stop();
+        }
+
+        match operation.poll_pipeline() {
+            Ok(true) => {
+                operation.pipeline_completed.store(true, Ordering::Release);
+                break;
+            }
+            Ok(false) => std::thread::sleep(Duration::from_millis(5)),
+            Err(error) => {
+                operation.record_worker_error(error);
+                break;
+            }
+        }
+    }
+}
+
+fn with_typed_result_operation<F>(handle: u64, operation: F) -> Result<Status, (Status, String)>
+where
+    F: FnOnce(&Arc<TypedResultOperation>) -> Result<Status, (Status, String)>,
+{
+    let operation_handle = {
+        let state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.typed_result_operations.get(&handle).cloned().ok_or_else(|| {
+            (
+                Status::InvalidHandle,
+                "typed result invocation handle is invalid".to_owned(),
+            )
+        })?
+    };
+    operation(&operation_handle)
+}
+
+fn read_typed_result_page(
+    handle: u64,
+    acknowledged_through: u64,
+    maximum_records: u32,
+) -> Result<u64, (Status, String)> {
+    let operation = {
+        let state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.typed_result_operations.get(&handle).cloned().ok_or_else(|| {
+            (
+                Status::InvalidHandle,
+                "typed result invocation handle is invalid".to_owned(),
+            )
+        })?
+    };
+    let page = Arc::new(operation.read_page(acknowledged_through, maximum_records)?);
+    let mut state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let page_handle = state.next_typed_result_page_handle;
+    state.next_typed_result_page_handle = state
+        .next_typed_result_page_handle
+        .checked_add(1)
+        .filter(|value| *value != 0)
+        .unwrap_or(1_u64 << 57);
+    state.typed_result_pages.insert(page_handle, page);
+    Ok(page_handle)
+}
+
+fn release_typed_result_operation(handle: u64) -> Result<Status, (Status, String)> {
+    let operation = {
+        let mut state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.typed_result_operations.remove(&handle).ok_or_else(|| {
+            (
+                Status::InvalidHandle,
+                "typed result invocation handle is invalid".to_owned(),
+            )
+        })?
+    };
+    operation.abort();
+    Ok(Status::Success)
+}
+
+fn with_typed_result_page<F>(handle: u64, operation: F) -> Result<Status, (Status, String)>
+where
+    F: FnOnce(&FfiTypedResultPage) -> Result<Status, (Status, String)>,
+{
+    let page = {
+        let state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state
+            .typed_result_pages
+            .get(&handle)
+            .cloned()
+            .ok_or_else(|| (Status::InvalidHandle, "typed result page handle is invalid".to_owned()))?
+    };
+    operation(&page)
+}
+
+fn release_typed_result_page(handle: u64) -> Result<Status, (Status, String)> {
+    let mut state = state().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    state
+        .typed_result_pages
+        .remove(&handle)
+        .map(|_| Status::Success)
+        .ok_or_else(|| (Status::InvalidHandle, "typed result page handle is invalid".to_owned()))
+}
+
 fn with_operation<F>(handle: u64, operation: F) -> Result<Status, (Status, String)>
 where
     F: FnOnce(&Arc<Operation>) -> Result<Status, (Status, String)>,
@@ -2559,6 +3000,18 @@ fn operation_stream_batch_record(
         (
             Status::InvalidArgument,
             "PowerShell operation stream batch record index is invalid".to_owned(),
+        )
+    })
+}
+
+fn typed_result_page_record(
+    page: &FfiTypedResultPage,
+    record_index: u32,
+) -> Result<&FfiTypedResultRecord, (Status, String)> {
+    page.records.get(record_index as usize).ok_or_else(|| {
+        (
+            Status::InvalidArgument,
+            "typed result page record index is invalid".to_owned(),
         )
     })
 }
@@ -3608,6 +4061,7 @@ fn feature_flags() -> u64 {
         | FEATURE_LIVE_SESSION_OBJECT_PROBE
         | FEATURE_LIVE_OBJECT_CONTRACTS
         | FEATURE_LIVE_STREAM_POLLING
+        | FEATURE_TYPED_RESULT_PAGING
 }
 
 fn create_live_object_probe(initial_count: i64) -> Result<*mut std::ffi::c_void, (Status, String)> {
@@ -4754,6 +5208,172 @@ pub unsafe extern "C" fn multi_pwsh_operation_stream_batch_release(batch_handle:
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_begin_typed_result_invocation(
+    handle: u64,
+    maximum_buffered_records: u32,
+    maximum_page_records: u32,
+    typed_result_handle: *mut u64,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || {
+        if typed_result_handle.is_null() {
+            return Err((
+                Status::InvalidArgument,
+                "typed result invocation handle output pointer is null".to_owned(),
+            ));
+        }
+        *typed_result_handle = start_typed_result_operation(handle, maximum_buffered_records, maximum_page_records)?;
+        Ok(Status::Success)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_typed_result_invocation_read_page(
+    handle: u64,
+    acknowledged_through: u64,
+    maximum_records: u32,
+    page_handle: *mut u64,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call_allow_active_pipeline(result, || {
+        if page_handle.is_null() {
+            return Err((
+                Status::InvalidArgument,
+                "typed result page handle output pointer is null".to_owned(),
+            ));
+        }
+        *page_handle = read_typed_result_page(handle, acknowledged_through, maximum_records)?;
+        Ok(Status::Success)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_typed_result_invocation_stop(handle: u64, result: *mut CallResult) -> i32 {
+    v2_call_allow_active_pipeline(result, || {
+        with_typed_result_operation(handle, |operation| {
+            operation.request_stop();
+            Ok(Status::Success)
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_typed_result_invocation_release(handle: u64, result: *mut CallResult) -> i32 {
+    v2_call_allow_active_pipeline(result, || release_typed_result_operation(handle))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_typed_result_page_get_info(
+    page_handle: u64,
+    info: *mut TypedResultPageInfo,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call_allow_active_pipeline(result, || {
+        if info.is_null() || (*info).size < mem::size_of::<TypedResultPageInfo>() as u32 {
+            return Err((
+                Status::InvalidArgument,
+                "typed result page info output is null or too small".to_owned(),
+            ));
+        }
+        with_typed_result_page(page_handle, |page| {
+            let mut flags = 0_u32;
+            if page.is_terminal {
+                flags |= 1;
+            }
+            if page.is_truncated {
+                flags |= 1 << 1;
+            }
+            if page.is_complete {
+                flags |= 1 << 2;
+            }
+            (*info).flags = flags;
+            (*info).terminal_status = page.terminal_status;
+            (*info)._reserved = 0;
+            (*info).acknowledged_sequence = page.acknowledged_sequence;
+            (*info).next_sequence = page.next_sequence;
+            (*info).total_record_count = page.total_record_count;
+            (*info).dropped_record_count = page.dropped_record_count;
+            (*info).record_count = u32::try_from(page.records.len()).map_err(|_| {
+                (
+                    Status::ManagedFailure,
+                    "typed result page record count exceeds its bound".to_owned(),
+                )
+            })?;
+            (*info)._reserved2 = 0;
+            Ok(Status::Success)
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_typed_result_page_get_record_info(
+    page_handle: u64,
+    record_index: u32,
+    sequence: *mut u64,
+    kind: *mut u32,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call_allow_active_pipeline(result, || {
+        if sequence.is_null() || kind.is_null() {
+            return Err((
+                Status::InvalidArgument,
+                "typed result page record output pointer is null".to_owned(),
+            ));
+        }
+        with_typed_result_page(page_handle, |page| {
+            let record = typed_result_page_record(page, record_index)?;
+            *sequence = record.sequence;
+            *kind = record.kind;
+            Ok(Status::Success)
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_typed_result_page_copy_record_value(
+    page_handle: u64,
+    record_index: u32,
+    kind: *mut u32,
+    buffer: *mut u8,
+    buffer_len: usize,
+    required_len: *mut usize,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call_allow_active_pipeline(result, || {
+        if kind.is_null() {
+            return Err((
+                Status::InvalidArgument,
+                "typed result value kind output pointer is null".to_owned(),
+            ));
+        }
+        with_typed_result_page(page_handle, |page| {
+            let record = typed_result_page_record(page, record_index)?;
+            if record.payload.len() > MAX_TYPED_RESULT_PAYLOAD_BYTES {
+                return Err((
+                    Status::ManagedFailure,
+                    "typed result value exceeds its fixed payload bound".to_owned(),
+                ));
+            }
+            *kind = record.kind;
+            match write_bytes(buffer, buffer_len, required_len, &record.payload) {
+                Status::Success => Ok(Status::Success),
+                Status::BufferTooSmall => Ok(Status::BufferTooSmall),
+                Status::InvalidArgument => Err((
+                    Status::InvalidArgument,
+                    "typed result value buffer arguments are invalid".to_owned(),
+                )),
+                _ => unreachable!(),
+            }
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_typed_result_page_release(page_handle: u64, result: *mut CallResult) -> i32 {
+    v2_call_allow_active_pipeline(result, || release_typed_result_page(page_handle))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn multi_pwsh_session_create(
     options: *const SessionOptions,
     session_handle: *mut u64,
@@ -5164,6 +5784,105 @@ mod tests {
         assert_ne!(flags & OPERATION_STREAM_RECORD_TEXT_TRUNCATED, 0);
     }
 
+    #[test]
+    fn typed_result_page_exports_preserve_metadata_and_release_handles() {
+        let _scope = TEST_PIPELINE_SCOPE_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let handle = u64::MAX - 92;
+        let page = FfiTypedResultPage {
+            acknowledged_sequence: 3,
+            next_sequence: 5,
+            total_record_count: 5,
+            dropped_record_count: 0,
+            terminal_status: 0,
+            is_terminal: true,
+            is_truncated: false,
+            is_complete: true,
+            records: vec![
+                FfiTypedResultRecord {
+                    sequence: 4,
+                    kind: 4,
+                    payload: 42_i32.to_le_bytes().to_vec(),
+                },
+                FfiTypedResultRecord {
+                    sequence: 5,
+                    kind: 3,
+                    payload: vec![1],
+                },
+            ],
+        };
+        state()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .typed_result_pages
+            .insert(handle, Arc::new(page));
+
+        let mut diagnostic = [0_u8; 256];
+        let mut result = v2_call_result(&mut diagnostic);
+        let mut info = TypedResultPageInfo {
+            size: mem::size_of::<TypedResultPageInfo>() as u32,
+            flags: 0,
+            terminal_status: 0,
+            _reserved: 0,
+            acknowledged_sequence: 0,
+            next_sequence: 0,
+            total_record_count: 0,
+            dropped_record_count: 0,
+            record_count: 0,
+            _reserved2: 0,
+        };
+        assert_eq!(
+            unsafe { multi_pwsh_typed_result_page_get_info(handle, &mut info, &mut result) },
+            Status::Success.value()
+        );
+        assert_eq!(info.flags, 0b101);
+        assert_eq!(info.acknowledged_sequence, 3);
+        assert_eq!(info.next_sequence, 5);
+        assert_eq!(info.total_record_count, 5);
+        assert_eq!(info.dropped_record_count, 0);
+        assert_eq!(info.record_count, 2);
+
+        let mut sequence = 0;
+        let mut kind = 0;
+        result = v2_call_result(&mut diagnostic);
+        assert_eq!(
+            unsafe { multi_pwsh_typed_result_page_get_record_info(handle, 0, &mut sequence, &mut kind, &mut result) },
+            Status::Success.value()
+        );
+        assert_eq!(sequence, 4);
+        assert_eq!(kind, 4);
+
+        let mut required_len = 0;
+        result = v2_call_result(&mut diagnostic);
+        assert_eq!(
+            unsafe {
+                multi_pwsh_typed_result_page_copy_record_value(
+                    handle,
+                    0,
+                    &mut kind,
+                    std::ptr::null_mut(),
+                    0,
+                    &mut required_len,
+                    &mut result,
+                )
+            },
+            Status::BufferTooSmall.value()
+        );
+        assert_eq!(required_len, mem::size_of::<i32>());
+
+        result = v2_call_result(&mut diagnostic);
+        assert_eq!(
+            unsafe { multi_pwsh_typed_result_page_release(handle, &mut result) },
+            Status::Success.value()
+        );
+        result = v2_call_result(&mut diagnostic);
+        assert_eq!(
+            unsafe { multi_pwsh_typed_result_page_release(handle, &mut result) },
+            Status::InvalidHandle.value()
+        );
+    }
+
     fn append_u32(output: &mut Vec<u8>, value: u32) {
         output.extend_from_slice(&value.to_le_bytes());
     }
@@ -5432,7 +6151,8 @@ mod tests {
             | FEATURE_LIVE_OBJECT_PROBE
             | FEATURE_LIVE_SESSION_OBJECT_PROBE
             | FEATURE_LIVE_OBJECT_CONTRACTS
-            | FEATURE_LIVE_STREAM_POLLING;
+            | FEATURE_LIVE_STREAM_POLLING
+            | FEATURE_TYPED_RESULT_PAGING;
 
         assert_eq!(ABI_VERSION, 2);
         assert_eq!(MINIMUM_COMPATIBLE_ABI_VERSION, 2);

--- a/crates/pwsh-sdk-ffi/src/lib.rs
+++ b/crates/pwsh-sdk-ffi/src/lib.rs
@@ -522,6 +522,21 @@ unsafe impl Sync for Operation {}
 unsafe impl Send for TypedResultOperation {}
 unsafe impl Sync for TypedResultOperation {}
 
+impl Session {
+    fn clear_operation_active(&self) {
+        *self
+            .operation_active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = false;
+        if let Some(runspace_session) = &self.runspace_session {
+            *runspace_session
+                .operation_active
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = false;
+        }
+    }
+}
+
 impl Operation {
     fn new(builder_handle: u64, session: Arc<Session>, capability: Option<CapabilityInvocation>) -> Self {
         Self {
@@ -2588,7 +2603,13 @@ fn start_typed_result_operation(
                 ));
             }
         }
-        let capability = take_session_capability(&session)?;
+        let capability = match take_session_capability(&session) {
+            Ok(capability) => capability,
+            Err(error) => {
+                session.clear_operation_active();
+                return Err(error);
+            }
+        };
         (session, capability)
     };
 

--- a/dotnet/bindings/FfiBindings.cs
+++ b/dotnet/bindings/FfiBindings.cs
@@ -22,6 +22,7 @@ namespace NativeHost
     {
         private const uint FfiBindingsAbiVersion = 2;
         private const uint FfiBindingsLiveStreamAbiVersion = 3;
+        private const uint FfiBindingsTypedResultPagingAbiVersion = 4;
         private const uint FfiCallResultTruncatedDiagnostic = 1;
         private const int FfiStatusSuccess = 0;
         private const int FfiStatusInvalidArgument = -1;
@@ -30,6 +31,7 @@ namespace NativeHost
         private const int FfiStatusInputNotCompleted = -8;
         private const int FfiStatusBackpressure = -9;
         private const int FfiStatusUnsupportedValue = -10;
+        private const int FfiStatusOperationCancelled = -11;
         private const int FfiMaxStreamRecords = 32;
         private const int FfiMaxStreamFieldLength = 4096;
         private const int FfiStreamCount = 7;
@@ -62,6 +64,10 @@ namespace NativeHost
         private const ulong FfiFeatureLiveSessionObjectProbe = 1UL << 18;
         private const ulong FfiFeatureLiveObjectContracts = 1UL << 19;
         private const ulong FfiFeatureLiveStreamPolling = 1UL << 20;
+        private const ulong FfiFeatureTypedResultPaging = 1UL << 21;
+        private const uint FfiTypedResultPageTerminal = 1;
+        private const uint FfiTypedResultPageTruncated = 1 << 1;
+        private const uint FfiTypedResultPageComplete = 1 << 2;
         private const int FfiMaxSessionEvents = 32;
 
         [StructLayout(LayoutKind.Sequential)]
@@ -179,6 +185,24 @@ namespace NativeHost
             public IntPtr LiveInvocation_Release;
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        private struct FfiApiV4
+        {
+            public nuint Size;
+            public uint AbiVersion;
+            public ulong FeatureFlags;
+            public IntPtr PowerShell_BeginTypedResultInvocation;
+            public IntPtr TypedResultInvocation_Poll;
+            public IntPtr TypedResultInvocation_ReadPage;
+            public IntPtr TypedResultInvocation_Complete;
+            public IntPtr TypedResultInvocation_Stop;
+            public IntPtr TypedResultInvocation_Release;
+            public IntPtr TypedResultPage_GetInfo;
+            public IntPtr TypedResultPage_GetRecordInfo;
+            public IntPtr TypedResultPage_CopyRecordValue;
+            public IntPtr TypedResultPage_Release;
+        }
+
         private static string[] NormalizeDirectories(string[] directories, string description)
         {
             if (directories.Length > FfiMaxSessionEvents)
@@ -265,6 +289,7 @@ namespace NativeHost
         private static long FfiNextInvocationId;
         private static IntPtr FfiApiV2Ptr = IntPtr.Zero;
         private static IntPtr FfiApiV3Ptr = IntPtr.Zero;
+        private static IntPtr FfiApiV4Ptr = IntPtr.Zero;
 
         [UnmanagedCallersOnly]
         public static IntPtr Bindings_GetFfiApiV2()
@@ -304,6 +329,29 @@ namespace NativeHost
                     }
 
                     return FfiApiV3Ptr;
+                }
+            }
+            catch
+            {
+                return IntPtr.Zero;
+            }
+        }
+
+        [UnmanagedCallersOnly]
+        public static IntPtr Bindings_GetFfiApiV4()
+        {
+            try
+            {
+                lock (FfiApiV2Lock)
+                {
+                    if (FfiApiV4Ptr == IntPtr.Zero)
+                    {
+                        FfiApiV4 api = CreateFfiApiV4();
+                        FfiApiV4Ptr = Marshal.AllocCoTaskMem(Marshal.SizeOf<FfiApiV4>());
+                        Marshal.StructureToPtr(api, FfiApiV4Ptr, false);
+                    }
+
+                    return FfiApiV4Ptr;
                 }
             }
             catch
@@ -392,6 +440,26 @@ namespace NativeHost
                 LiveInvocation_Complete = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr*, FfiCallResult*, int>)&FfiLiveInvocation_Complete,
                 LiveInvocation_Stop = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiLiveInvocation_Stop,
                 LiveInvocation_Release = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiLiveInvocation_Release,
+            };
+        }
+
+        private static unsafe FfiApiV4 CreateFfiApiV4()
+        {
+            return new FfiApiV4
+            {
+                Size = (nuint)Marshal.SizeOf<FfiApiV4>(),
+                AbiVersion = FfiBindingsTypedResultPagingAbiVersion,
+                FeatureFlags = FfiFeatureTypedResultPaging,
+                PowerShell_BeginTypedResultInvocation = (IntPtr)(delegate* unmanaged<IntPtr, int, int, IntPtr*, FfiCallResult*, int>)&FfiPowerShell_BeginTypedResultInvocation,
+                TypedResultInvocation_Poll = (IntPtr)(delegate* unmanaged<IntPtr, int*, FfiCallResult*, int>)&FfiTypedResultInvocation_Poll,
+                TypedResultInvocation_ReadPage = (IntPtr)(delegate* unmanaged<IntPtr, long, int, IntPtr*, FfiCallResult*, int>)&FfiTypedResultInvocation_ReadPage,
+                TypedResultInvocation_Complete = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiTypedResultInvocation_Complete,
+                TypedResultInvocation_Stop = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiTypedResultInvocation_Stop,
+                TypedResultInvocation_Release = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiTypedResultInvocation_Release,
+                TypedResultPage_GetInfo = (IntPtr)(delegate* unmanaged<IntPtr, long*, long*, long*, long*, int*, uint*, int*, FfiCallResult*, int>)&FfiTypedResultPage_GetInfo,
+                TypedResultPage_GetRecordInfo = (IntPtr)(delegate* unmanaged<IntPtr, int, long*, uint*, FfiCallResult*, int>)&FfiTypedResultPage_GetRecordInfo,
+                TypedResultPage_CopyRecordValue = (IntPtr)(delegate* unmanaged<IntPtr, int, uint*, byte*, int, int*, FfiCallResult*, int>)&FfiTypedResultPage_CopyRecordValue,
+                TypedResultPage_Release = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiTypedResultPage_Release,
             };
         }
 
@@ -1383,6 +1451,231 @@ namespace NativeHost
                     throw;
                 }
             });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiPowerShell_BeginTypedResultInvocation(
+            IntPtr ptrHandle,
+            int maximumBufferedRecords,
+            int maximumPageRecords,
+            IntPtr* ptrTypedResultInvocationHandle,
+            FfiCallResult* result)
+        {
+            if (ptrTypedResultInvocationHandle == null ||
+                maximumBufferedRecords < 1 ||
+                maximumBufferedRecords > FfiMaxValueContainerEntries ||
+                maximumPageRecords < 1 ||
+                maximumPageRecords > maximumBufferedRecords)
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Typed result invocation bounds or output pointer are invalid.");
+            }
+
+            return Execute(result, () =>
+            {
+                FfiPowerShellPipeline pipeline = GetPowerShellPipeline(ptrHandle);
+                FfiInvocationResults.TryRemove(ptrHandle, out _);
+                var typedResults = new FfiTypedResultQueue(maximumBufferedRecords, maximumPageRecords);
+                var liveInvocation = new FfiLiveInvocation(
+                    pipeline.PowerShell,
+                    TakeCompletedInput(ptrHandle),
+                    pipeline.Session,
+                    pipeline.TakeCapabilityContext(),
+                    typedResults);
+                try
+                {
+                    liveInvocation.Start();
+                    GCHandle handle = GCHandle.Alloc(liveInvocation, GCHandleType.Normal);
+                    *ptrTypedResultInvocationHandle = GCHandle.ToIntPtr(handle);
+                }
+                catch
+                {
+                    liveInvocation.Dispose();
+                    throw;
+                }
+            });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiTypedResultInvocation_Poll(
+            IntPtr ptrTypedResultInvocationHandle,
+            int* isCompleted,
+            FfiCallResult* result)
+        {
+            if (isCompleted == null)
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Typed result invocation completion output pointer is null.");
+            }
+
+            return Execute(result, () =>
+            {
+                *isCompleted = GetLiveInvocation(ptrTypedResultInvocationHandle).IsCompleted ? 1 : 0;
+            });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiTypedResultInvocation_ReadPage(
+            IntPtr ptrTypedResultInvocationHandle,
+            long acknowledgedThrough,
+            int maximumRecords,
+            IntPtr* ptrPageHandle,
+            FfiCallResult* result)
+        {
+            if (ptrPageHandle == null || acknowledgedThrough < 0 || maximumRecords < 1 || maximumRecords > FfiMaxValueContainerEntries)
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Typed result page arguments are invalid.");
+            }
+
+            return Execute(result, () =>
+            {
+                FfiTypedResultPage page = GetLiveInvocation(ptrTypedResultInvocationHandle)
+                    .ReadTypedResultPage(acknowledgedThrough, maximumRecords);
+                GCHandle handle = GCHandle.Alloc(page, GCHandleType.Normal);
+                *ptrPageHandle = GCHandle.ToIntPtr(handle);
+            });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiTypedResultInvocation_Complete(
+            IntPtr ptrTypedResultInvocationHandle,
+            FfiCallResult* result)
+        {
+            return Execute(result, () => GetLiveInvocation(ptrTypedResultInvocationHandle).CompleteTypedResults());
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiTypedResultInvocation_Stop(
+            IntPtr ptrTypedResultInvocationHandle,
+            FfiCallResult* result)
+        {
+            return Execute(result, () => GetLiveInvocation(ptrTypedResultInvocationHandle).Stop());
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiTypedResultInvocation_Release(
+            IntPtr ptrTypedResultInvocationHandle,
+            FfiCallResult* result)
+        {
+            if (!TryInitializeResult(result))
+            {
+                return FfiStatusInvalidArgument;
+            }
+
+            try
+            {
+                GCHandle handle = GCHandle.FromIntPtr(ptrTypedResultInvocationHandle);
+                if (!handle.IsAllocated || handle.Target is not FfiLiveInvocation invocation)
+                {
+                    return WriteFailure(result, FfiStatusInvalidHandle, "Typed result invocation handle is invalid.");
+                }
+
+                handle.Free();
+                invocation.Dispose();
+                return WriteSuccess(result);
+            }
+            catch (Exception exception)
+            {
+                return WriteFailure(result, FfiStatusInvalidHandle, exception);
+            }
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiTypedResultPage_GetInfo(
+            IntPtr ptrPageHandle,
+            long* acknowledgedSequence,
+            long* nextSequence,
+            long* totalRecordCount,
+            long* droppedRecordCount,
+            int* terminalStatus,
+            uint* flags,
+            int* recordCount,
+            FfiCallResult* result)
+        {
+            if (acknowledgedSequence == null ||
+                nextSequence == null ||
+                totalRecordCount == null ||
+                droppedRecordCount == null ||
+                terminalStatus == null ||
+                flags == null ||
+                recordCount == null)
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Typed result page info output pointer is null.");
+            }
+
+            return Execute(result, () =>
+            {
+                FfiTypedResultPage page = GetTypedResultPage(ptrPageHandle);
+                *acknowledgedSequence = page.AcknowledgedSequence;
+                *nextSequence = page.NextSequence;
+                *totalRecordCount = page.TotalRecordCount;
+                *droppedRecordCount = page.DroppedRecordCount;
+                *terminalStatus = page.TerminalStatus;
+                *flags = page.Flags;
+                *recordCount = page.Records.Length;
+            });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiTypedResultPage_GetRecordInfo(
+            IntPtr ptrPageHandle,
+            int recordIndex,
+            long* sequence,
+            uint* kind,
+            FfiCallResult* result)
+        {
+            if (sequence == null || kind == null)
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Typed result page record output pointer is null.");
+            }
+
+            return Execute(result, () =>
+            {
+                FfiTypedResultRecord record = GetTypedResultPage(ptrPageHandle).GetRecord(recordIndex);
+                *sequence = record.Sequence;
+                *kind = record.Value.Kind;
+            });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiTypedResultPage_CopyRecordValue(
+            IntPtr ptrPageHandle,
+            int recordIndex,
+            uint* kind,
+            byte* buffer,
+            int bufferLength,
+            int* requiredLength,
+            FfiCallResult* result)
+        {
+            if (kind == null || requiredLength == null || bufferLength < 0)
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Typed result page value buffer arguments are invalid.");
+            }
+
+            IntPtr outputBuffer = (IntPtr)buffer;
+            IntPtr outputRequiredLength = (IntPtr)requiredLength;
+            return Execute(result, () =>
+            {
+                FfiSnapshotValue value = GetTypedResultPage(ptrPageHandle).GetRecord(recordIndex).Value;
+                *kind = value.Kind;
+                Marshal.WriteInt32(outputRequiredLength, value.Payload.Length);
+                if (bufferLength < value.Payload.Length)
+                {
+                    throw new BufferTooSmallException();
+                }
+
+                if (value.Payload.Length != 0)
+                {
+                    Marshal.Copy(value.Payload, 0, outputBuffer, value.Payload.Length);
+                }
+            }, bufferTooSmallIsSuccess: true);
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiTypedResultPage_Release(IntPtr ptrPageHandle, FfiCallResult* result)
+        {
+            return ReleaseLiveHandle<FfiTypedResultPage>(
+                ptrPageHandle,
+                result,
+                "Typed result page handle is invalid.");
         }
 
         [UnmanagedCallersOnly]
@@ -3400,6 +3693,242 @@ namespace NativeHost
             }
         }
 
+        private sealed class FfiTypedResultRecord
+        {
+            public FfiTypedResultRecord(long sequence, FfiSnapshotValue value)
+            {
+                Sequence = sequence;
+                Value = value;
+            }
+
+            public long Sequence { get; }
+
+            public FfiSnapshotValue Value { get; }
+        }
+
+        private sealed class FfiTypedResultPage
+        {
+            public FfiTypedResultPage(
+                FfiTypedResultRecord[] records,
+                long acknowledgedSequence,
+                long nextSequence,
+                long totalRecordCount,
+                long droppedRecordCount,
+                int terminalStatus,
+                uint flags)
+            {
+                Records = records;
+                AcknowledgedSequence = acknowledgedSequence;
+                NextSequence = nextSequence;
+                TotalRecordCount = totalRecordCount;
+                DroppedRecordCount = droppedRecordCount;
+                TerminalStatus = terminalStatus;
+                Flags = flags;
+            }
+
+            public FfiTypedResultRecord[] Records { get; }
+
+            public long AcknowledgedSequence { get; }
+
+            public long NextSequence { get; }
+
+            public long TotalRecordCount { get; }
+
+            public long DroppedRecordCount { get; }
+
+            public int TerminalStatus { get; }
+
+            public uint Flags { get; }
+
+            public FfiTypedResultRecord GetRecord(int index)
+            {
+                if (index < 0 || index >= Records.Length)
+                {
+                    throw new InvalidOperationException("Typed result page record index is invalid.");
+                }
+
+                return Records[index];
+            }
+        }
+
+        private sealed class FfiTypedResultQueue : IDisposable
+        {
+            private readonly object gate = new object();
+            private readonly Queue<FfiTypedResultRecord> records;
+            private readonly int maximumBufferedRecords;
+            private readonly int maximumPageRecords;
+            private long nextSequence = 1;
+            private long acknowledgedSequence;
+            private long maximumAcknowledgableSequence;
+            private long totalRecordCount;
+            private int terminalStatus = FfiStatusSuccess;
+            private bool terminal;
+            private bool disposed;
+
+            public FfiTypedResultQueue(int maximumBufferedRecords, int maximumPageRecords)
+            {
+                this.maximumBufferedRecords = maximumBufferedRecords;
+                this.maximumPageRecords = maximumPageRecords;
+                records = new Queue<FfiTypedResultRecord>(maximumBufferedRecords);
+            }
+
+            public bool Write(FfiSnapshotValue value)
+            {
+                ArgumentNullException.ThrowIfNull(value);
+                lock (gate)
+                {
+                    while (!terminal && !disposed && records.Count == maximumBufferedRecords)
+                    {
+                        Monitor.Wait(gate, TimeSpan.FromMilliseconds(50));
+                    }
+
+                    if (terminal || disposed)
+                    {
+                        return false;
+                    }
+
+                    if (nextSequence == long.MaxValue || totalRecordCount == long.MaxValue)
+                    {
+                        Fail(FfiStatusManagedFailure);
+                        return false;
+                    }
+
+                    records.Enqueue(new FfiTypedResultRecord(
+                        nextSequence++,
+                        new FfiSnapshotValue(value.Kind, (byte[])value.Payload.Clone())));
+                    totalRecordCount++;
+                    Monitor.PulseAll(gate);
+                    return true;
+                }
+            }
+
+            public void Fail(int status)
+            {
+                lock (gate)
+                {
+                    if (disposed || terminal)
+                    {
+                        return;
+                    }
+
+                    terminal = true;
+                    terminalStatus = status;
+                    Monitor.PulseAll(gate);
+                }
+            }
+
+            public FfiTypedResultPage Read(long acknowledgedThrough, int maximumRecords)
+            {
+                lock (gate)
+                {
+                    ThrowIfDisposed();
+                    if (maximumRecords < 1 || maximumRecords > maximumPageRecords)
+                    {
+                        throw new InvalidOperationException("Typed result page limit exceeds the invocation bound.");
+                    }
+
+                    if (acknowledgedThrough < acknowledgedSequence ||
+                        acknowledgedThrough > maximumAcknowledgableSequence)
+                    {
+                        throw new InvalidOperationException("Typed result acknowledgement is outside the most recently returned page.");
+                    }
+
+                    Acknowledge(acknowledgedThrough);
+                    FfiTypedResultRecord[] page = records.Take(maximumRecords).ToArray();
+                    long next = page.Length == 0 ? acknowledgedSequence : page[^1].Sequence;
+                    maximumAcknowledgableSequence = next;
+                    uint flags = terminal ? FfiTypedResultPageTerminal : 0;
+                    if (terminal &&
+                        terminalStatus == FfiStatusSuccess &&
+                        totalRecordCount == acknowledgedSequence)
+                    {
+                        flags |= FfiTypedResultPageComplete;
+                    }
+
+                    return new FfiTypedResultPage(
+                        page,
+                        acknowledgedSequence,
+                        next,
+                        totalRecordCount,
+                        0,
+                        terminalStatus,
+                        flags);
+                }
+            }
+
+            public void Complete(int status)
+            {
+                lock (gate)
+                {
+                    if (disposed || terminal)
+                    {
+                        return;
+                    }
+
+                    terminal = true;
+                    terminalStatus = status;
+                    Monitor.PulseAll(gate);
+                }
+            }
+
+            public void Cancel()
+            {
+                lock (gate)
+                {
+                    if (disposed || terminal)
+                    {
+                        return;
+                    }
+
+                    terminal = true;
+                    terminalStatus = FfiStatusOperationCancelled;
+                    Monitor.PulseAll(gate);
+                }
+            }
+
+            public void Acknowledge(long sequence)
+            {
+                if (sequence < acknowledgedSequence || sequence > maximumAcknowledgableSequence)
+                {
+                    throw new InvalidOperationException("Typed result acknowledgement is outside the most recently returned page.");
+                }
+
+                while (records.Count != 0 && records.Peek().Sequence <= sequence)
+                {
+                    records.Dequeue();
+                }
+
+                acknowledgedSequence = sequence;
+                maximumAcknowledgableSequence = acknowledgedSequence;
+                Monitor.PulseAll(gate);
+            }
+
+            public void Dispose()
+            {
+                lock (gate)
+                {
+                    if (disposed)
+                    {
+                        return;
+                    }
+
+                    disposed = true;
+                    terminal = true;
+                    terminalStatus = FfiStatusOperationCancelled;
+                    records.Clear();
+                    Monitor.PulseAll(gate);
+                }
+            }
+
+            private void ThrowIfDisposed()
+            {
+                if (disposed)
+                {
+                    throw new ObjectDisposedException(nameof(FfiTypedResultQueue));
+                }
+            }
+        }
+
         private sealed class FfiSnapshotCollector
         {
             private const int FieldCount = 20;
@@ -4015,9 +4544,11 @@ namespace NativeHost
                     return true;
                 }
 
-                if (value is object[] array)
+                if (value is Array array)
                 {
-                    if (array.Length > FfiMaxValueContainerEntries || !ancestors.Add(array))
+                    if (array.Rank != 1 ||
+                        array.Length > FfiMaxValueContainerEntries ||
+                        !ancestors.Add(array))
                     {
                         return false;
                     }
@@ -4026,8 +4557,9 @@ namespace NativeHost
                     {
                         var bytes = new List<byte>(sizeof(uint));
                         WriteUInt32(bytes, checked((uint)array.Length));
-                        foreach (object item in array)
+                        for (int index = 0; index < array.Length; index++)
                         {
+                            object item = array.GetValue(index);
                             if (!TryEncodeCopiedValue(item, depth + 1, ancestors, out FfiSnapshotValue nested) ||
                                 !TryAppendNestedValue(bytes, nested))
                             {
@@ -4282,6 +4814,7 @@ namespace NativeHost
             private readonly FfiPowerShellSession session;
             private readonly FfiCapabilityContext capabilityContext;
             private readonly FfiSnapshotCollector collector = new FfiSnapshotCollector();
+            private readonly FfiTypedResultQueue typedResults;
             private PSDataCollection<PSObject> output;
             private PSDataCollection<object> inputCollection;
             private IAsyncResult asyncResult;
@@ -4305,12 +4838,14 @@ namespace NativeHost
                 PowerShell powerShell,
                 object[] input,
                 FfiPowerShellSession session,
-                FfiCapabilityContext capabilityContext)
+                FfiCapabilityContext capabilityContext,
+                FfiTypedResultQueue typedResults = null)
             {
                 this.powerShell = powerShell ?? throw new ArgumentNullException(nameof(powerShell));
                 this.input = input;
                 this.session = session;
                 this.capabilityContext = capabilityContext;
+                this.typedResults = typedResults;
             }
 
             public bool IsCompleted
@@ -4334,14 +4869,7 @@ namespace NativeHost
                     }
 
                     output = new PSDataCollection<PSObject> { DataAddedCount = 1 };
-                    outputAdded = (_, args) =>
-                    {
-                        lock (gate)
-                        {
-                            collector.AddOutput(output[args.Index]);
-                            output.Clear();
-                        }
-                    };
+                    outputAdded = (_, args) => AddOutput(args.Index);
                     errorAdded = (_, args) => AddError(args.Index);
                     warningAdded = (_, args) => AddText(FfiStreamKind.Warning, powerShell.Streams.Warning, args.Index);
                     verboseAdded = (_, args) => AddText(FfiStreamKind.Verbose, powerShell.Streams.Verbose, args.Index);
@@ -4410,8 +4938,16 @@ namespace NativeHost
                 }
             }
 
+            public FfiTypedResultPage ReadTypedResultPage(long acknowledgedThrough, int maximumRecords)
+            {
+                FfiTypedResultQueue queue = typedResults ?? throw new InvalidOperationException(
+                    "Live invocation does not have a typed result queue.");
+                return queue.Read(acknowledgedThrough, maximumRecords);
+            }
+
             public void Stop()
             {
+                typedResults?.Cancel();
                 powerShell.Stop();
             }
 
@@ -4455,8 +4991,22 @@ namespace NativeHost
                     }
 
                     snapshot = collector.Build();
+                    typedResults?.Complete(
+                        (snapshot.Flags & FfiResultTerminatingFailure) != 0
+                            ? FfiStatusManagedFailure
+                            : FfiStatusSuccess);
                     return snapshot;
                 }
+            }
+
+            public void CompleteTypedResults()
+            {
+                if (typedResults is null)
+                {
+                    throw new InvalidOperationException("Live invocation does not have a typed result queue.");
+                }
+
+                _ = Complete();
             }
 
             public void Dispose()
@@ -4470,6 +5020,7 @@ namespace NativeHost
                     }
 
                     disposed = true;
+                    typedResults?.Dispose();
                     if (asyncResult is null)
                     {
                         Cleanup();
@@ -4497,12 +5048,56 @@ namespace NativeHost
                 }
             }
 
+            private void AddOutput(int index)
+            {
+                FfiSnapshotValue typedValue = null;
+                bool typedValueSupported = typedResults is null;
+                lock (gate)
+                {
+                    PSObject value = output[index];
+                    collector.AddOutput(value);
+                    if (typedResults is not null)
+                    {
+                        typedValueSupported = TryEncodeTypedResultValue(value, out typedValue);
+                    }
+                    output.Clear();
+                }
+
+                if (typedResults is null)
+                {
+                    return;
+                }
+
+                if (!typedValueSupported)
+                {
+                    typedResults.Fail(FfiStatusUnsupportedValue);
+                    return;
+                }
+
+                _ = typedResults.Write(typedValue);
+            }
+
             private void AddText<T>(FfiStreamKind stream, PSDataCollection<T> records, int index)
             {
                 lock (gate)
                 {
                     collector.AddText(stream, records[index]);
                     records.Clear();
+                }
+            }
+
+            private static bool TryEncodeTypedResultValue(PSObject value, out FfiSnapshotValue typedValue)
+            {
+                typedValue = null;
+                try
+                {
+                    return FfiSnapshotCollector.TryEncodeCopiedValue(value?.BaseObject, depth: 0, out typedValue) ||
+                        FfiSnapshotCollector.TryEncodeCopiedValue(value, depth: 0, out typedValue);
+                }
+                catch
+                {
+                    typedValue = null;
+                    return false;
                 }
             }
 
@@ -4786,6 +5381,22 @@ namespace NativeHost
             }
 
             return batch;
+        }
+
+        private static FfiTypedResultPage GetTypedResultPage(IntPtr ptrPageHandle)
+        {
+            if (ptrPageHandle == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Typed result page handle is invalid.");
+            }
+
+            GCHandle handle = GCHandle.FromIntPtr(ptrPageHandle);
+            if (!handle.IsAllocated || handle.Target is not FfiTypedResultPage page)
+            {
+                throw new InvalidOperationException("Typed result page handle is invalid.");
+            }
+
+            return page;
         }
 
         private static unsafe int ReleaseLiveHandle<T>(IntPtr ptrHandle, FfiCallResult* result, string invalidMessage)

--- a/dotnet/dto-contract-generator-tests/Devolutions.MultiPwsh.DtoContract.Generator.Tests.csproj
+++ b/dotnet/dto-contract-generator-tests/Devolutions.MultiPwsh.DtoContract.Generator.Tests.csproj
@@ -10,6 +10,9 @@
                       AdditionalProperties="BuildPwshFfiNativeAsset=false" />
     <ProjectReference Include="..\dto-contract-generator\Devolutions.MultiPwsh.DtoContract.Generator.csproj"
                       OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+                      ReferenceOutputAssembly="true" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
   </ItemGroup>
 </Project>

--- a/dotnet/dto-contract-generator-tests/Devolutions.MultiPwsh.DtoContract.Generator.Tests.csproj
+++ b/dotnet/dto-contract-generator-tests/Devolutions.MultiPwsh.DtoContract.Generator.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\sdk-ffi\Devolutions.MultiPwsh.Sdk.csproj"
+                      AdditionalProperties="BuildPwshFfiNativeAsset=false" />
+    <ProjectReference Include="..\dto-contract-generator\Devolutions.MultiPwsh.DtoContract.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>

--- a/dotnet/dto-contract-generator-tests/Program.cs
+++ b/dotnet/dto-contract-generator-tests/Program.cs
@@ -1,0 +1,76 @@
+using Devolutions.PowerShell.Ffi;
+
+PowerShellValue valid = SampleDtoPowerShellDtoProjection.Write(new SampleDto
+{
+    Name = "alpha",
+    Enabled = true,
+    Identifiers = [1, 2, 3],
+});
+
+if (!SampleDtoPowerShellDtoProjection.TryRead(valid, out SampleDto? roundTrip, out PowerShellDtoProjectionError? error) ||
+    error is not null ||
+    roundTrip is not { Name: "alpha", Enabled: true } ||
+    !roundTrip.Identifiers.SequenceEqual([1L, 2L, 3L]))
+{
+    throw new InvalidOperationException("Generated PowerShell DTO projection did not round-trip a bounded contract.");
+}
+
+PowerShellValue unknown = PowerShellValue.PropertyBag(
+[
+    new("$version", PowerShellValue.UnsignedInteger(2)),
+    new("Name", PowerShellValue.String("alpha")),
+    new("Enabled", PowerShellValue.Boolean(true)),
+    new("Identifiers", PowerShellValue.Array([PowerShellValue.SignedInteger(1)])),
+    new("Unexpected", PowerShellValue.String("rejected")),
+]);
+if (SampleDtoPowerShellDtoProjection.TryRead(unknown, out _, out error) ||
+    error?.Failure != PowerShellDtoProjectionFailure.UnknownMember)
+{
+    throw new InvalidOperationException("Generated PowerShell DTO projection accepted an unknown member.");
+}
+
+PowerShellValue wrongVersion = PowerShellValue.PropertyBag(
+[
+    new("$version", PowerShellValue.UnsignedInteger(1)),
+    new("Name", PowerShellValue.String("alpha")),
+    new("Enabled", PowerShellValue.Boolean(true)),
+    new("Identifiers", PowerShellValue.Array([PowerShellValue.SignedInteger(1)])),
+]);
+if (SampleDtoPowerShellDtoProjection.TryRead(wrongVersion, out _, out error) ||
+    error?.Failure != PowerShellDtoProjectionFailure.InvalidVersion)
+{
+    throw new InvalidOperationException("Generated PowerShell DTO projection accepted an incompatible version.");
+}
+
+using (var pager = new PowerShellValuePager(new PowerShellValuePagerOptions(maximumBufferedRecords: 2, maximumPageRecords: 1)))
+{
+    pager.Write(PowerShellValue.String("one"));
+    pager.Write(PowerShellValue.String("two"));
+    PowerShellValuePage first = pager.Read(0);
+    if (first.Records.Count != 1 || first.NextSequence != 1)
+    {
+        throw new InvalidOperationException("Bounded pager did not return the first ordered page.");
+    }
+
+    pager.Acknowledge(first.NextSequence);
+    PowerShellValuePage second = pager.Read(first.NextSequence);
+    pager.Acknowledge(second.NextSequence);
+    pager.Complete();
+    if (!pager.GetCompletion().IsComplete)
+    {
+        throw new InvalidOperationException("Bounded pager reported a fully acknowledged terminal result as incomplete.");
+    }
+}
+
+[PowerShellDtoContract(2)]
+public sealed class SampleDto
+{
+    [PowerShellDtoMember(MaximumStringLength = 16)]
+    public string Name { get; set; } = string.Empty;
+
+    [PowerShellDtoMember]
+    public bool Enabled { get; set; }
+
+    [PowerShellDtoMember(MaximumCollectionCount = 8)]
+    public long[] Identifiers { get; set; } = [];
+}

--- a/dotnet/dto-contract-generator-tests/Program.cs
+++ b/dotnet/dto-contract-generator-tests/Program.cs
@@ -1,4 +1,7 @@
 using Devolutions.PowerShell.Ffi;
+using Devolutions.MultiPwsh.DtoContract.Generator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 PowerShellValue valid = SampleDtoPowerShellDtoProjection.Write(new SampleDto
 {
@@ -9,7 +12,7 @@ PowerShellValue valid = SampleDtoPowerShellDtoProjection.Write(new SampleDto
 
 if (!SampleDtoPowerShellDtoProjection.TryRead(valid, out SampleDto? roundTrip, out PowerShellDtoProjectionError? error) ||
     error is not null ||
-    roundTrip is not { Name: "alpha", Enabled: true } ||
+    roundTrip is not { Name: "alpha", Enabled: true, Identifiers: not null } ||
     !roundTrip.Identifiers.SequenceEqual([1L, 2L, 3L]))
 {
     throw new InvalidOperationException("Generated PowerShell DTO projection did not round-trip a bounded contract.");
@@ -42,6 +45,113 @@ if (SampleDtoPowerShellDtoProjection.TryRead(wrongVersion, out _, out error) ||
     throw new InvalidOperationException("Generated PowerShell DTO projection accepted an incompatible version.");
 }
 
+PowerShellValue keywordProperty = KeywordAndStringsDtoPowerShellDtoProjection.Write(new KeywordAndStringsDto
+{
+    @event = ["one", "two"],
+});
+if (!KeywordAndStringsDtoPowerShellDtoProjection.TryRead(keywordProperty, out KeywordAndStringsDto? keywordRoundTrip, out error) ||
+    error is not null ||
+    keywordRoundTrip is null ||
+    !keywordRoundTrip.@event.SequenceEqual(["one", "two"]))
+{
+    throw new InvalidOperationException("Generated PowerShell DTO projection did not support a keyword property identifier.");
+}
+
+ExpectValueTooLarge(
+    () => KeywordAndStringsDtoPowerShellDtoProjection.Write(new KeywordAndStringsDto { @event = ["exceeds"] }),
+    "Generated PowerShell DTO projection did not enforce nested string bounds when writing an array.");
+
+PowerShellValue firstShared = First.Contracts.SharedDtoPowerShellDtoProjection.Write(new First.Contracts.SharedDto { Name = "first" });
+PowerShellValue secondShared = Second.Contracts.SharedDtoPowerShellDtoProjection.Write(new Second.Contracts.SharedDto { Name = "second" });
+if (!firstShared.TryGetProperty("Name", out PowerShellValue? firstName) ||
+    !firstName!.TryGetString(out string? firstText) ||
+    firstText != "first" ||
+    !secondShared.TryGetProperty("Name", out PowerShellValue? secondName) ||
+    !secondName!.TryGetString(out string? secondText) ||
+    secondText != "second")
+{
+    throw new InvalidOperationException("Generated PowerShell DTO projections with duplicate simple type names conflicted.");
+}
+
+if (SixtyThreeMemberDtoPowerShellDtoProjection.Write(new SixtyThreeMemberDto()).GetPropertyBag().Count != 64)
+{
+    throw new InvalidOperationException("Generated PowerShell DTO projection did not reserve one property bag entry for $version.");
+}
+
+VerifyGeneratorDiagnostic(
+    """
+    using Devolutions.PowerShell.Ffi;
+    [PowerShellDtoContract(1)]
+    public abstract class AbstractDto
+    {
+        [PowerShellDtoMember] public bool Enabled { get; set; }
+    }
+    """,
+    "MPWDTO001",
+    "an abstract DTO");
+VerifyGeneratorDiagnostic(
+    """
+    using Devolutions.PowerShell.Ffi;
+    [PowerShellDtoContract(1)]
+    public class RequiredDto
+    {
+        [PowerShellDtoMember] public required string Name { get; set; }
+    }
+    """,
+    "MPWDTO002",
+    "a required DTO property");
+VerifyGeneratorDiagnostic(
+    """
+    using Devolutions.PowerShell.Ffi;
+    [PowerShellDtoContract(1)]
+    public class IndexedDto
+    {
+        [PowerShellDtoMember] public string this[int index] { get => string.Empty; set { } }
+    }
+    """,
+    "MPWDTO002",
+    "a DTO indexer");
+VerifyGeneratorDiagnostic(
+    """
+    using Devolutions.PowerShell.Ffi;
+    [PowerShellDtoContract(1)]
+    public class InitOnlyDto
+    {
+        [PowerShellDtoMember] public string Name { get; init; } = string.Empty;
+    }
+    """,
+    "MPWDTO002",
+    "an init-only DTO property");
+VerifyGeneratorDiagnostic(
+    """
+    using Devolutions.PowerShell.Ffi;
+    [PowerShellDtoContract(1)]
+    public class ReservedNameDto
+    {
+        [PowerShellDtoMember("$VERSION")] public bool Value { get; set; }
+    }
+    """,
+    "MPWDTO002",
+    "a case-insensitive $version member name");
+VerifyGeneratorDiagnostic(
+    """
+    using Devolutions.PowerShell.Ffi;
+    [PowerShellDtoContract(1)]
+    public struct ValueDto
+    {
+        [PowerShellDtoMember] public bool Value { get; set; }
+    }
+    """,
+    "MPWDTO001",
+    "a struct DTO");
+VerifyGeneratorDiagnostic(
+    "using Devolutions.PowerShell.Ffi; [PowerShellDtoContract(1)] public class TooManyMembersDto { " +
+    string.Concat(Enumerable.Range(1, 64).Select(static index =>
+        $"[PowerShellDtoMember] public bool Value{index} {{ get; set; }} ")) +
+    "}",
+    "MPWDTO001",
+    "a DTO with more than 63 members");
+
 using (var pager = new PowerShellValuePager(new PowerShellValuePagerOptions(maximumBufferedRecords: 2, maximumPageRecords: 1)))
 {
     pager.Write(PowerShellValue.String("one"));
@@ -62,6 +172,40 @@ using (var pager = new PowerShellValuePager(new PowerShellValuePagerOptions(maxi
     }
 }
 
+static void ExpectValueTooLarge(Action action, string description)
+{
+    try
+    {
+        action();
+    }
+    catch (PowerShellDtoProjectionException exception) when (exception.Error.Failure == PowerShellDtoProjectionFailure.ValueTooLarge)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException(description);
+}
+
+static void VerifyGeneratorDiagnostic(string source, string expectedDiagnostic, string description)
+{
+    CSharpCompilation compilation = CSharpCompilation.Create(
+        "DtoContractGeneratorRegression",
+        [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+        [
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(System.Reflection.Assembly.Load("System.Runtime").Location),
+            MetadataReference.CreateFromFile(typeof(PowerShellDtoContractAttribute).Assembly.Location),
+        ],
+        new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    GeneratorDriver driver = CSharpGeneratorDriver.Create(new DtoContractGenerator());
+    driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation output, out var generatorDiagnostics);
+    Diagnostic[] diagnostics = generatorDiagnostics.Concat(output.GetDiagnostics()).ToArray();
+    if (!diagnostics.Any(diagnostic => diagnostic.Id == expectedDiagnostic))
+    {
+        throw new InvalidOperationException($"The DTO generator did not reject {description} with {expectedDiagnostic}: {string.Join("; ", diagnostics.Select(static diagnostic => $"{diagnostic.Id}: {diagnostic.GetMessage()}"))}");
+    }
+}
+
 [PowerShellDtoContract(2)]
 public sealed class SampleDto
 {
@@ -73,4 +217,99 @@ public sealed class SampleDto
 
     [PowerShellDtoMember(MaximumCollectionCount = 8)]
     public long[] Identifiers { get; set; } = [];
+}
+
+[PowerShellDtoContract(1)]
+public sealed class KeywordAndStringsDto
+{
+    [PowerShellDtoMember(MaximumStringLength = 4, MaximumCollectionCount = 4)]
+    public string[] @event { get; set; } = [];
+}
+
+[PowerShellDtoContract(1)]
+public sealed class SixtyThreeMemberDto
+{
+    [PowerShellDtoMember] public bool Value01 { get; set; }
+    [PowerShellDtoMember] public bool Value02 { get; set; }
+    [PowerShellDtoMember] public bool Value03 { get; set; }
+    [PowerShellDtoMember] public bool Value04 { get; set; }
+    [PowerShellDtoMember] public bool Value05 { get; set; }
+    [PowerShellDtoMember] public bool Value06 { get; set; }
+    [PowerShellDtoMember] public bool Value07 { get; set; }
+    [PowerShellDtoMember] public bool Value08 { get; set; }
+    [PowerShellDtoMember] public bool Value09 { get; set; }
+    [PowerShellDtoMember] public bool Value10 { get; set; }
+    [PowerShellDtoMember] public bool Value11 { get; set; }
+    [PowerShellDtoMember] public bool Value12 { get; set; }
+    [PowerShellDtoMember] public bool Value13 { get; set; }
+    [PowerShellDtoMember] public bool Value14 { get; set; }
+    [PowerShellDtoMember] public bool Value15 { get; set; }
+    [PowerShellDtoMember] public bool Value16 { get; set; }
+    [PowerShellDtoMember] public bool Value17 { get; set; }
+    [PowerShellDtoMember] public bool Value18 { get; set; }
+    [PowerShellDtoMember] public bool Value19 { get; set; }
+    [PowerShellDtoMember] public bool Value20 { get; set; }
+    [PowerShellDtoMember] public bool Value21 { get; set; }
+    [PowerShellDtoMember] public bool Value22 { get; set; }
+    [PowerShellDtoMember] public bool Value23 { get; set; }
+    [PowerShellDtoMember] public bool Value24 { get; set; }
+    [PowerShellDtoMember] public bool Value25 { get; set; }
+    [PowerShellDtoMember] public bool Value26 { get; set; }
+    [PowerShellDtoMember] public bool Value27 { get; set; }
+    [PowerShellDtoMember] public bool Value28 { get; set; }
+    [PowerShellDtoMember] public bool Value29 { get; set; }
+    [PowerShellDtoMember] public bool Value30 { get; set; }
+    [PowerShellDtoMember] public bool Value31 { get; set; }
+    [PowerShellDtoMember] public bool Value32 { get; set; }
+    [PowerShellDtoMember] public bool Value33 { get; set; }
+    [PowerShellDtoMember] public bool Value34 { get; set; }
+    [PowerShellDtoMember] public bool Value35 { get; set; }
+    [PowerShellDtoMember] public bool Value36 { get; set; }
+    [PowerShellDtoMember] public bool Value37 { get; set; }
+    [PowerShellDtoMember] public bool Value38 { get; set; }
+    [PowerShellDtoMember] public bool Value39 { get; set; }
+    [PowerShellDtoMember] public bool Value40 { get; set; }
+    [PowerShellDtoMember] public bool Value41 { get; set; }
+    [PowerShellDtoMember] public bool Value42 { get; set; }
+    [PowerShellDtoMember] public bool Value43 { get; set; }
+    [PowerShellDtoMember] public bool Value44 { get; set; }
+    [PowerShellDtoMember] public bool Value45 { get; set; }
+    [PowerShellDtoMember] public bool Value46 { get; set; }
+    [PowerShellDtoMember] public bool Value47 { get; set; }
+    [PowerShellDtoMember] public bool Value48 { get; set; }
+    [PowerShellDtoMember] public bool Value49 { get; set; }
+    [PowerShellDtoMember] public bool Value50 { get; set; }
+    [PowerShellDtoMember] public bool Value51 { get; set; }
+    [PowerShellDtoMember] public bool Value52 { get; set; }
+    [PowerShellDtoMember] public bool Value53 { get; set; }
+    [PowerShellDtoMember] public bool Value54 { get; set; }
+    [PowerShellDtoMember] public bool Value55 { get; set; }
+    [PowerShellDtoMember] public bool Value56 { get; set; }
+    [PowerShellDtoMember] public bool Value57 { get; set; }
+    [PowerShellDtoMember] public bool Value58 { get; set; }
+    [PowerShellDtoMember] public bool Value59 { get; set; }
+    [PowerShellDtoMember] public bool Value60 { get; set; }
+    [PowerShellDtoMember] public bool Value61 { get; set; }
+    [PowerShellDtoMember] public bool Value62 { get; set; }
+    [PowerShellDtoMember] public bool Value63 { get; set; }
+}
+
+namespace First.Contracts
+{
+    [PowerShellDtoContract(1)]
+    public sealed class SharedDto
+    {
+        [PowerShellDtoMember]
+        public string Name { get; set; } = string.Empty;
+    }
+}
+
+namespace Second.Contracts
+{
+    [PowerShellDtoContract(1)]
+    public sealed class SharedDto
+    {
+        [PowerShellDtoMember]
+        public string Name { get; set; } = string.Empty;
+    }
 }

--- a/dotnet/dto-contract-generator/AnalyzerReleases.Unshipped.md
+++ b/dotnet/dto-contract-generator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,6 @@
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MPWDTO001 | MultiPwsh.DTO | Error | Reports invalid DTO contract declarations.
+MPWDTO002 | MultiPwsh.DTO | Error | Reports unsupported DTO member declarations.

--- a/dotnet/dto-contract-generator/Devolutions.MultiPwsh.DtoContract.Generator.csproj
+++ b/dotnet/dto-contract-generator/Devolutions.MultiPwsh.DtoContract.Generator.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/dotnet/dto-contract-generator/DtoContractGenerator.cs
+++ b/dotnet/dto-contract-generator/DtoContractGenerator.cs
@@ -1,0 +1,448 @@
+#nullable enable
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Devolutions.MultiPwsh.DtoContract.Generator;
+
+[Generator]
+public sealed class DtoContractGenerator : IIncrementalGenerator
+{
+    private const string ContractAttribute = "Devolutions.PowerShell.Ffi.PowerShellDtoContractAttribute";
+    private const string MemberAttribute = "Devolutions.PowerShell.Ffi.PowerShellDtoMemberAttribute";
+
+    private static readonly DiagnosticDescriptor InvalidContract = new(
+        "MPWDTO001",
+        "Invalid PowerShell DTO contract",
+        "PowerShell DTO contract '{0}' {1}",
+        "MultiPwsh.DTO",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor UnsupportedMember = new(
+        "MPWDTO002",
+        "Unsupported PowerShell DTO member",
+        "PowerShell DTO member '{0}' {1}",
+        "MultiPwsh.DTO",
+        DiagnosticSeverity.Error,
+        true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        IncrementalValuesProvider<INamedTypeSymbol> contracts = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) => node is Microsoft.CodeAnalysis.CSharp.Syntax.TypeDeclarationSyntax { AttributeLists.Count: > 0 },
+                static (syntax, _) => syntax.SemanticModel.GetDeclaredSymbol(syntax.Node) as INamedTypeSymbol)
+            .Where(static type => type is not null && HasAttribute(type, ContractAttribute))
+            .Select(static (type, _) => type!);
+
+        context.RegisterSourceOutput(contracts.Collect(), static (production, types) =>
+        {
+            foreach (INamedTypeSymbol? candidate in types.Distinct(SymbolEqualityComparer.Default))
+            {
+                if (candidate is not INamedTypeSymbol type)
+                {
+                    continue;
+                }
+
+                ContractInfo? contract = Analyze(type, production);
+                if (contract is not null)
+                {
+                    production.AddSource(
+                        $"{type.Name}.PowerShellDtoProjection.g.cs",
+                        SourceText.From(Emit(contract), Encoding.UTF8));
+                }
+            }
+        });
+    }
+
+    private static ContractInfo? Analyze(INamedTypeSymbol type, SourceProductionContext production)
+    {
+        AttributeData? attribute = GetAttribute(type, ContractAttribute);
+        if (type.DeclaredAccessibility != Accessibility.Public ||
+            type.ContainingType is not null ||
+            type.TypeParameters.Length != 0 ||
+            type.TypeKind is not (TypeKind.Class or TypeKind.Struct) ||
+            attribute is null ||
+            attribute.ConstructorArguments.Length != 1 ||
+            attribute.ConstructorArguments[0].Value is not int version ||
+            version < 1)
+        {
+            production.ReportDiagnostic(Diagnostic.Create(InvalidContract, Location(type), type.Name,
+                "must be a public, non-generic top-level class or struct with a positive version"));
+            return null;
+        }
+
+        bool rejectUnknown = GetNamedBoolean(attribute, "RejectUnknownMembers", true);
+        if (type.TypeKind == TypeKind.Class &&
+            !type.InstanceConstructors.Any(constructor => constructor.DeclaredAccessibility == Accessibility.Public &&
+                                                         constructor.Parameters.Length == 0))
+        {
+            production.ReportDiagnostic(Diagnostic.Create(InvalidContract, Location(type), type.Name,
+                "must have a public parameterless constructor"));
+            return null;
+        }
+
+        var members = new List<MemberInfo>();
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (IPropertySymbol property in type.GetMembers().OfType<IPropertySymbol>())
+        {
+            AttributeData? memberAttribute = GetAttribute(property, MemberAttribute);
+            if (memberAttribute is null)
+            {
+                continue;
+            }
+
+            if (property.IsStatic || property.SetMethod is null ||
+                property.SetMethod.DeclaredAccessibility != Accessibility.Public ||
+                property.GetMethod is null || property.GetMethod.DeclaredAccessibility != Accessibility.Public)
+            {
+                production.ReportDiagnostic(Diagnostic.Create(UnsupportedMember, Location(property), property.Name,
+                    "must have public instance getter and setter"));
+                continue;
+            }
+
+            string wireName = memberAttribute.ConstructorArguments.Length == 1 &&
+                              memberAttribute.ConstructorArguments[0].Value is string explicitName &&
+                              !string.IsNullOrWhiteSpace(explicitName)
+                ? explicitName
+                : property.Name;
+            int maxString = GetNamedInt(memberAttribute, "MaximumStringLength", 4096);
+            int maxCollection = GetNamedInt(memberAttribute, "MaximumCollectionCount", 64);
+            if (wireName == "$version" || wireName.Length > 128 || wireName.IndexOf('\0') >= 0 ||
+                !names.Add(wireName) || maxString < 0 || maxString > 64 * 1024 ||
+                maxCollection < 0 || maxCollection > 64)
+            {
+                production.ReportDiagnostic(Diagnostic.Create(UnsupportedMember, Location(property), property.Name,
+                    "has an invalid or duplicate wire name or bound"));
+                continue;
+            }
+
+            ProjectionKind kind = GetProjectionKind(property.Type);
+            if (kind == ProjectionKind.Unsupported)
+            {
+                production.ReportDiagnostic(Diagnostic.Create(UnsupportedMember, Location(property), property.Name,
+                    "must use a supported scalar or one-dimensional array of supported scalars"));
+                continue;
+            }
+
+            members.Add(new MemberInfo(
+                property.Name,
+                wireName,
+                property.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                kind,
+                GetNamedBoolean(memberAttribute, "Required", true),
+                maxString,
+                maxCollection));
+        }
+
+        if (members.Count == 0)
+        {
+            production.ReportDiagnostic(Diagnostic.Create(InvalidContract, Location(type), type.Name,
+                "must declare at least one [PowerShellDtoMember] property"));
+            return null;
+        }
+
+        return new ContractInfo(
+            type.ContainingNamespace.IsGlobalNamespace ? string.Empty : type.ContainingNamespace.ToDisplayString(),
+            type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            type.Name,
+            version,
+            rejectUnknown,
+            members);
+    }
+
+    private static string Emit(ContractInfo contract)
+    {
+        var source = new StringBuilder();
+        source.AppendLine("// <auto-generated/>");
+        source.AppendLine("#nullable enable");
+        if (!string.IsNullOrEmpty(contract.Namespace))
+        {
+            source.Append("namespace ").Append(contract.Namespace).AppendLine(";");
+            source.AppendLine();
+        }
+
+        source.Append("public static class ").Append(contract.Name).AppendLine("PowerShellDtoProjection");
+        source.AppendLine("{");
+        source.Append("    private static readonly global::System.Collections.Generic.IReadOnlySet<string> DeclaredMembers = new global::System.Collections.Generic.HashSet<string>(global::System.StringComparer.OrdinalIgnoreCase) { ");
+        foreach (MemberInfo member in contract.Members)
+        {
+            source.Append(Literal(member.WireName)).Append(", ");
+        }
+        source.AppendLine("};");
+        source.AppendLine();
+        source.Append("    public static bool TryRead(global::Devolutions.PowerShell.Ffi.PowerShellValue value, out ")
+            .Append(contract.TypeName)
+            .Append("? result, out global::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError? error)");
+        source.AppendLine();
+        source.AppendLine("    {");
+        source.Append("        if (!global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.TryGetPropertyBag(value, ")
+            .Append(contract.Version.ToString(CultureInfo.InvariantCulture)).Append(", ")
+            .Append(contract.RejectUnknown ? "true" : "false")
+            .AppendLine(", DeclaredMembers, string.Empty, out var properties, out error))");
+        source.AppendLine("        { result = default; return false; }");
+        source.Append("        var dto = new ").Append(contract.TypeName).AppendLine("();");
+        foreach (MemberInfo member in contract.Members)
+        {
+            EmitReadMember(source, member);
+        }
+        source.AppendLine("        result = dto;");
+        source.AppendLine("        error = null;");
+        source.AppendLine("        return true;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.Append("    public static ").Append(contract.TypeName).AppendLine(" Read(global::Devolutions.PowerShell.Ffi.PowerShellValue value)");
+        source.AppendLine("    {");
+        source.AppendLine("        if (!TryRead(value, out var result, out var error)) throw global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.CreateException(error!);");
+        source.AppendLine("        return result!;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.Append("    public static global::Devolutions.PowerShell.Ffi.PowerShellValue Write(").Append(contract.TypeName).AppendLine(" value)");
+        source.AppendLine("    {");
+        source.AppendLine("        global::System.ArgumentNullException.ThrowIfNull(value);");
+        foreach (MemberInfo member in contract.Members)
+        {
+            if (ReferenceEquals(member.Kind, ProjectionKind.String))
+            {
+                source.Append("        if (value.").Append(member.PropertyName).Append(".Length > ")
+                    .Append(member.MaximumStringLength.ToString(CultureInfo.InvariantCulture))
+                    .AppendLine(") throw global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.CreateException(global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.ValueTooLarge(" + Literal(member.WireName) + ", \"The DTO string member exceeds its declared bound.\"));");
+            }
+            else if (member.Kind.IsArray)
+            {
+                source.Append("        if (value.").Append(member.PropertyName).Append(".Length > ")
+                    .Append(member.MaximumCollectionCount.ToString(CultureInfo.InvariantCulture))
+                    .AppendLine(") throw global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.CreateException(global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.ValueTooLarge(" + Literal(member.WireName) + ", \"The DTO array exceeds its declared bound.\"));");
+            }
+        }
+        source.AppendLine("        return global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.CreatePropertyBag(" + contract.Version.ToString(CultureInfo.InvariantCulture) + ", new global::System.Collections.Generic.KeyValuePair<string, global::Devolutions.PowerShell.Ffi.PowerShellValue>[]");
+        source.AppendLine("        {");
+        foreach (MemberInfo member in contract.Members)
+        {
+            source.Append("            new(").Append(Literal(member.WireName)).Append(", ")
+                .Append(WriteExpression("value." + member.PropertyName, member)).AppendLine("),");
+        }
+        source.AppendLine("        });");
+        source.AppendLine("    }");
+        source.AppendLine("}");
+        return source.ToString();
+    }
+
+    private static void EmitReadMember(StringBuilder source, MemberInfo member)
+    {
+        string path = "global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.JoinPath(string.Empty, " + Literal(member.WireName) + ")";
+        source.Append("        if (!global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.TryGetMember(properties!, ")
+            .Append(Literal(member.WireName)).Append(", ").Append(member.Required ? "true" : "false")
+            .Append(", string.Empty, out var ").Append(member.PropertyName).Append("Value, out error))")
+            .AppendLine(" { result = default; return false; }");
+        source.Append("        if (").Append(member.PropertyName).Append("Value is not null)").AppendLine();
+        source.AppendLine("        {");
+        if (member.Kind.IsArray)
+        {
+            string element = member.Kind.ElementName!;
+            source.Append("            if (!global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.TryReadArray(")
+                .Append(member.PropertyName).Append("Value, ").Append(member.MaximumCollectionCount.ToString(CultureInfo.InvariantCulture))
+                .Append(", ").Append(path).Append(", out var values, out error)) { result = default; return false; }").AppendLine();
+            source.Append("            var converted = new ").Append(element).Append("[values!.Count];").AppendLine();
+            source.AppendLine("            for (var index = 0; index < values.Count; index++)");
+            source.AppendLine("            {");
+            EmitScalarRead(source, member.Kind.Element!, "values[index]", "converted[index]", path, member.MaximumStringLength, "                ");
+            source.AppendLine("            }");
+            source.Append("            dto.").Append(member.PropertyName).AppendLine(" = converted;");
+        }
+        else
+        {
+            EmitScalarRead(source, member.Kind, member.PropertyName + "Value", "dto." + member.PropertyName, path, member.MaximumStringLength, "            ");
+        }
+        source.AppendLine("        }");
+    }
+
+    private static void EmitScalarRead(StringBuilder source, ProjectionKind kind, string input, string output, string path, int maximumStringLength, string indent)
+    {
+        if (kind == ProjectionKind.String)
+        {
+            source.Append(indent).Append("if (!global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.TryReadString(")
+                .Append(input).Append(", ").Append(maximumStringLength.ToString(CultureInfo.InvariantCulture))
+                .Append(", ").Append(path).Append(", out var scalar, out error)) { result = default; return false; }").AppendLine();
+            source.Append(indent).Append(output).AppendLine(" = scalar!;");
+            return;
+        }
+
+        string method = ReferenceEquals(kind, ProjectionKind.Boolean) ? "TryGetBoolean"
+            : ReferenceEquals(kind, ProjectionKind.SignedInteger) ? "TryGetSignedInteger"
+            : ReferenceEquals(kind, ProjectionKind.UnsignedInteger) ? "TryGetUnsignedInteger"
+            : ReferenceEquals(kind, ProjectionKind.Double) ? "TryGetDouble"
+            : ReferenceEquals(kind, ProjectionKind.Decimal) ? "TryGetDecimal"
+            : ReferenceEquals(kind, ProjectionKind.DateTime) ? "TryGetDateTime"
+            : ReferenceEquals(kind, ProjectionKind.DateTimeOffset) ? "TryGetDateTimeOffset"
+            : ReferenceEquals(kind, ProjectionKind.Guid) ? "TryGetGuid"
+            : ReferenceEquals(kind, ProjectionKind.Uri) ? "TryGetUri"
+            : throw new InvalidOperationException();
+        source.Append(indent).Append("if (!").Append(input).Append(".").Append(method)
+            .Append("(out var scalar)) { error = global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.InvalidValue(")
+            .Append(path).Append(", \"The DTO member has an invalid tagged value kind.\"); result = default; return false; }").AppendLine();
+        source.Append(indent).Append(output).AppendLine(" = scalar!;");
+    }
+
+    private static string WriteExpression(string value, MemberInfo member)
+    {
+        if (member.Kind.IsArray)
+        {
+            return "global::Devolutions.PowerShell.Ffi.PowerShellValue.Array(global::System.Linq.Enumerable.Select(" + value + ", static item => " +
+                   WriteScalarExpression("item", member.Kind.Element!, member.MaximumStringLength) + "))";
+        }
+
+        return WriteScalarExpression(value, member.Kind, member.MaximumStringLength);
+    }
+
+    private static string WriteScalarExpression(string value, ProjectionKind kind, int maximumStringLength)
+    {
+        string method = ReferenceEquals(kind, ProjectionKind.String) ? "String"
+            : ReferenceEquals(kind, ProjectionKind.Boolean) ? "Boolean"
+            : ReferenceEquals(kind, ProjectionKind.SignedInteger) ? "SignedInteger"
+            : ReferenceEquals(kind, ProjectionKind.UnsignedInteger) ? "UnsignedInteger"
+            : ReferenceEquals(kind, ProjectionKind.Double) ? "Double"
+            : ReferenceEquals(kind, ProjectionKind.Decimal) ? "Decimal"
+            : ReferenceEquals(kind, ProjectionKind.DateTime) ? "DateTime"
+            : ReferenceEquals(kind, ProjectionKind.DateTimeOffset) ? "DateTimeOffset"
+            : ReferenceEquals(kind, ProjectionKind.Guid) ? "Guid"
+            : ReferenceEquals(kind, ProjectionKind.Uri) ? "Uri"
+            : throw new InvalidOperationException();
+        return "global::Devolutions.PowerShell.Ffi.PowerShellValue." + method + "(" + value + ")";
+    }
+
+    private static ProjectionKind GetProjectionKind(ITypeSymbol type)
+    {
+        if (type is IArrayTypeSymbol { Rank: 1 } array)
+        {
+            ProjectionKind element = GetProjectionKind(array.ElementType);
+            return element.IsArray || element == ProjectionKind.Unsupported
+                ? ProjectionKind.Unsupported
+                : ProjectionKind.Array(element);
+        }
+
+        return type.SpecialType switch
+        {
+            SpecialType.System_String => ProjectionKind.String,
+            SpecialType.System_Boolean => ProjectionKind.Boolean,
+            SpecialType.System_Int64 => ProjectionKind.SignedInteger,
+            SpecialType.System_UInt64 => ProjectionKind.UnsignedInteger,
+            SpecialType.System_Double => ProjectionKind.Double,
+            SpecialType.System_Decimal => ProjectionKind.Decimal,
+            _ => type.ToDisplayString() switch
+            {
+                "System.DateTime" => ProjectionKind.DateTime,
+                "System.DateTimeOffset" => ProjectionKind.DateTimeOffset,
+                "System.Guid" => ProjectionKind.Guid,
+                "System.Uri" => ProjectionKind.Uri,
+                _ => ProjectionKind.Unsupported,
+            },
+        };
+    }
+
+    private static bool HasAttribute(ISymbol symbol, string metadataName) => GetAttribute(symbol, metadataName) is not null;
+
+    private static AttributeData? GetAttribute(ISymbol symbol, string metadataName) =>
+        symbol.GetAttributes().FirstOrDefault(attribute =>
+            attribute.AttributeClass?.ToDisplayString() == metadataName);
+
+    private static int GetNamedInt(AttributeData attribute, string name, int defaultValue) =>
+        attribute.NamedArguments.FirstOrDefault(pair => pair.Key == name).Value.Value is int value ? value : defaultValue;
+
+    private static bool GetNamedBoolean(AttributeData attribute, string name, bool defaultValue) =>
+        attribute.NamedArguments.FirstOrDefault(pair => pair.Key == name).Value.Value is bool value ? value : defaultValue;
+
+    private static Location Location(ISymbol symbol) =>
+        symbol.Locations.FirstOrDefault() ?? Microsoft.CodeAnalysis.Location.None;
+
+    private static string Literal(string value) => Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(value, quote: true);
+
+    private sealed class ContractInfo
+    {
+        public ContractInfo(string @namespace, string typeName, string name, int version, bool rejectUnknown, List<MemberInfo> members)
+        {
+            Namespace = @namespace;
+            TypeName = typeName;
+            Name = name;
+            Version = version;
+            RejectUnknown = rejectUnknown;
+            Members = members;
+        }
+
+        public string Namespace { get; }
+        public string TypeName { get; }
+        public string Name { get; }
+        public int Version { get; }
+        public bool RejectUnknown { get; }
+        public List<MemberInfo> Members { get; }
+    }
+
+    private sealed class MemberInfo
+    {
+        public MemberInfo(string propertyName, string wireName, string typeName, ProjectionKind kind, bool required, int maximumStringLength, int maximumCollectionCount)
+        {
+            PropertyName = propertyName;
+            WireName = wireName;
+            TypeName = typeName;
+            Kind = kind;
+            Required = required;
+            MaximumStringLength = maximumStringLength;
+            MaximumCollectionCount = maximumCollectionCount;
+        }
+
+        public string PropertyName { get; }
+        public string WireName { get; }
+        public string TypeName { get; }
+        public ProjectionKind Kind { get; }
+        public bool Required { get; }
+        public int MaximumStringLength { get; }
+        public int MaximumCollectionCount { get; }
+    }
+
+    private sealed class ProjectionKind
+    {
+        private ProjectionKind(string name, ProjectionKind? element = null)
+        {
+            Name = name;
+            Element = element;
+        }
+
+        public static ProjectionKind Unsupported { get; } = new("Unsupported");
+        public static ProjectionKind String { get; } = new("String");
+        public static ProjectionKind Boolean { get; } = new("Boolean");
+        public static ProjectionKind SignedInteger { get; } = new("SignedInteger");
+        public static ProjectionKind UnsignedInteger { get; } = new("UnsignedInteger");
+        public static ProjectionKind Double { get; } = new("Double");
+        public static ProjectionKind Decimal { get; } = new("Decimal");
+        public static ProjectionKind DateTime { get; } = new("DateTime");
+        public static ProjectionKind DateTimeOffset { get; } = new("DateTimeOffset");
+        public static ProjectionKind Guid { get; } = new("Guid");
+        public static ProjectionKind Uri { get; } = new("Uri");
+
+        public string Name { get; }
+        public ProjectionKind? Element { get; }
+        public bool IsArray => Element is not null;
+        public string? ElementName => Element?.Name switch
+        {
+            "String" => "string",
+            "Boolean" => "bool",
+            "SignedInteger" => "long",
+            "UnsignedInteger" => "ulong",
+            "Double" => "double",
+            "Decimal" => "decimal",
+            "DateTime" => "global::System.DateTime",
+            "DateTimeOffset" => "global::System.DateTimeOffset",
+            "Guid" => "global::System.Guid",
+            "Uri" => "global::System.Uri",
+            _ => null,
+        };
+
+        public static ProjectionKind Array(ProjectionKind element) => new("Array", element);
+    }
+}

--- a/dotnet/dto-contract-generator/DtoContractGenerator.cs
+++ b/dotnet/dto-contract-generator/DtoContractGenerator.cs
@@ -54,7 +54,7 @@ public sealed class DtoContractGenerator : IIncrementalGenerator
                 if (contract is not null)
                 {
                     production.AddSource(
-                        $"{type.Name}.PowerShellDtoProjection.g.cs",
+                        GetHintName(type),
                         SourceText.From(Emit(contract), Encoding.UTF8));
                 }
             }
@@ -67,14 +67,15 @@ public sealed class DtoContractGenerator : IIncrementalGenerator
         if (type.DeclaredAccessibility != Accessibility.Public ||
             type.ContainingType is not null ||
             type.TypeParameters.Length != 0 ||
-            type.TypeKind is not (TypeKind.Class or TypeKind.Struct) ||
+            type.TypeKind != TypeKind.Class ||
+            type.IsAbstract ||
             attribute is null ||
             attribute.ConstructorArguments.Length != 1 ||
             attribute.ConstructorArguments[0].Value is not int version ||
             version < 1)
         {
             production.ReportDiagnostic(Diagnostic.Create(InvalidContract, Location(type), type.Name,
-                "must be a public, non-generic top-level class or struct with a positive version"));
+                "must be a public, non-abstract, non-generic top-level class with a positive version"));
             return null;
         }
 
@@ -98,12 +99,13 @@ public sealed class DtoContractGenerator : IIncrementalGenerator
                 continue;
             }
 
-            if (property.IsStatic || property.SetMethod is null ||
+            if (property.IsStatic || property.IsIndexer || property.IsRequired || property.SetMethod is null ||
+                property.SetMethod.IsInitOnly ||
                 property.SetMethod.DeclaredAccessibility != Accessibility.Public ||
                 property.GetMethod is null || property.GetMethod.DeclaredAccessibility != Accessibility.Public)
             {
                 production.ReportDiagnostic(Diagnostic.Create(UnsupportedMember, Location(property), property.Name,
-                    "must have public instance getter and setter"));
+                    "must have public instance getter and non-init setter and cannot be required or an indexer"));
                 continue;
             }
 
@@ -114,7 +116,8 @@ public sealed class DtoContractGenerator : IIncrementalGenerator
                 : property.Name;
             int maxString = GetNamedInt(memberAttribute, "MaximumStringLength", 4096);
             int maxCollection = GetNamedInt(memberAttribute, "MaximumCollectionCount", 64);
-            if (wireName == "$version" || wireName.Length > 128 || wireName.IndexOf('\0') >= 0 ||
+            if (string.Equals(wireName, "$version", StringComparison.OrdinalIgnoreCase) ||
+                wireName.Length > 128 || wireName.IndexOf('\0') >= 0 ||
                 !names.Add(wireName) || maxString < 0 || maxString > 64 * 1024 ||
                 maxCollection < 0 || maxCollection > 64)
             {
@@ -145,6 +148,13 @@ public sealed class DtoContractGenerator : IIncrementalGenerator
         {
             production.ReportDiagnostic(Diagnostic.Create(InvalidContract, Location(type), type.Name,
                 "must declare at least one [PowerShellDtoMember] property"));
+            return null;
+        }
+
+        if (members.Count > 63)
+        {
+            production.ReportDiagnostic(Diagnostic.Create(InvalidContract, Location(type), type.Name,
+                "must declare no more than 63 [PowerShellDtoMember] properties because $version uses one of the 64 property bag entries"));
             return null;
         }
 
@@ -210,15 +220,22 @@ public sealed class DtoContractGenerator : IIncrementalGenerator
         {
             if (ReferenceEquals(member.Kind, ProjectionKind.String))
             {
-                source.Append("        if (value.").Append(member.PropertyName).Append(".Length > ")
+                source.Append("        if (value.@").Append(member.PropertyName).Append(".Length > ")
                     .Append(member.MaximumStringLength.ToString(CultureInfo.InvariantCulture))
                     .AppendLine(") throw global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.CreateException(global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.ValueTooLarge(" + Literal(member.WireName) + ", \"The DTO string member exceeds its declared bound.\"));");
             }
             else if (member.Kind.IsArray)
             {
-                source.Append("        if (value.").Append(member.PropertyName).Append(".Length > ")
+                source.Append("        if (value.@").Append(member.PropertyName).Append(".Length > ")
                     .Append(member.MaximumCollectionCount.ToString(CultureInfo.InvariantCulture))
                     .AppendLine(") throw global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.CreateException(global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.ValueTooLarge(" + Literal(member.WireName) + ", \"The DTO array exceeds its declared bound.\"));");
+                if (ReferenceEquals(member.Kind.Element, ProjectionKind.String))
+                {
+                    source.Append("        if (global::System.Linq.Enumerable.Any(value.@").Append(member.PropertyName)
+                        .Append(", static item => item.Length > ")
+                        .Append(member.MaximumStringLength.ToString(CultureInfo.InvariantCulture))
+                        .AppendLine(")) throw global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.CreateException(global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.ValueTooLarge(" + Literal(member.WireName) + ", \"A DTO string array member contains an item that exceeds its declared bound.\"));");
+                }
             }
         }
         source.AppendLine("        return global::Devolutions.PowerShell.Ffi.PowerShellDtoProjection.CreatePropertyBag(" + contract.Version.ToString(CultureInfo.InvariantCulture) + ", new global::System.Collections.Generic.KeyValuePair<string, global::Devolutions.PowerShell.Ffi.PowerShellValue>[]");
@@ -226,7 +243,7 @@ public sealed class DtoContractGenerator : IIncrementalGenerator
         foreach (MemberInfo member in contract.Members)
         {
             source.Append("            new(").Append(Literal(member.WireName)).Append(", ")
-                .Append(WriteExpression("value." + member.PropertyName, member)).AppendLine("),");
+                .Append(WriteExpression("value.@" + member.PropertyName, member)).AppendLine("),");
         }
         source.AppendLine("        });");
         source.AppendLine("    }");
@@ -254,11 +271,11 @@ public sealed class DtoContractGenerator : IIncrementalGenerator
             source.AppendLine("            {");
             EmitScalarRead(source, member.Kind.Element!, "values[index]", "converted[index]", path, member.MaximumStringLength, "                ");
             source.AppendLine("            }");
-            source.Append("            dto.").Append(member.PropertyName).AppendLine(" = converted;");
+            source.Append("            dto.@").Append(member.PropertyName).AppendLine(" = converted;");
         }
         else
         {
-            EmitScalarRead(source, member.Kind, member.PropertyName + "Value", "dto." + member.PropertyName, path, member.MaximumStringLength, "            ");
+            EmitScalarRead(source, member.Kind, member.PropertyName + "Value", "dto.@" + member.PropertyName, path, member.MaximumStringLength, "            ");
         }
         source.AppendLine("        }");
     }
@@ -360,6 +377,28 @@ public sealed class DtoContractGenerator : IIncrementalGenerator
 
     private static Location Location(ISymbol symbol) =>
         symbol.Locations.FirstOrDefault() ?? Microsoft.CodeAnalysis.Location.None;
+
+    private static string GetHintName(INamedTypeSymbol type)
+    {
+        var hintName = new StringBuilder();
+        foreach (char character in type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+        {
+            if ((character >= 'a' && character <= 'z') ||
+                (character >= 'A' && character <= 'Z') ||
+                (character >= '0' && character <= '9'))
+            {
+                hintName.Append(character);
+            }
+            else
+            {
+                hintName.Append('_')
+                    .Append(((int)character).ToString("X4", CultureInfo.InvariantCulture))
+                    .Append('_');
+            }
+        }
+
+        return hintName.Append(".PowerShellDtoProjection.g.cs").ToString();
+    }
 
     private static string Literal(string value) => Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(value, quote: true);
 

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -33,6 +33,8 @@
                       PrivateAssets="all" />
     <ProjectReference Include="..\live-contract-generator\Devolutions.MultiPwsh.LiveContract.Generator.csproj"
                       ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\dto-contract-generator\Devolutions.MultiPwsh.DtoContract.Generator.csproj"
+                      ReferenceOutputAssembly="false" />
     <Compile Include="..\interop\PowerShellLiveObjectProbeContract.cs"
              Link="PowerShellLiveObjectProbeContract.cs" />
     <Compile Include="..\interop\PowerShellLiveObjectContract.cs"
@@ -54,6 +56,10 @@
           PackagePath="buildTransitive\Devolutions.MultiPwsh.LiveContracts\"
           Visible="false" />
     <None Include="..\live-contract-generator\bin\$(Configuration)\netstandard2.0\Devolutions.MultiPwsh.LiveContract.Generator.dll"
+          Pack="true"
+          PackagePath="analyzers\dotnet\cs\"
+          Visible="false" />
+    <None Include="..\dto-contract-generator\bin\$(Configuration)\netstandard2.0\Devolutions.MultiPwsh.DtoContract.Generator.dll"
           Pack="true"
           PackagePath="analyzers\dotnet\cs\"
           Visible="false" />

--- a/dotnet/sdk-ffi/NativeMethods.cs
+++ b/dotnet/sdk-ffi/NativeMethods.cs
@@ -127,6 +127,21 @@ internal struct NativeOperationStreamBatchInfo
     internal uint Reserved;
 }
 
+[StructLayout(LayoutKind.Sequential)]
+internal struct NativeTypedResultPageInfo
+{
+    internal uint Size;
+    internal uint Flags;
+    internal int TerminalStatus;
+    internal uint Reserved;
+    internal ulong AcknowledgedSequence;
+    internal ulong NextSequence;
+    internal ulong TotalRecordCount;
+    internal ulong DroppedRecordCount;
+    internal uint RecordCount;
+    internal uint Reserved2;
+}
+
 internal static unsafe partial class NativeMethods
 {
     internal const string LibraryName = "multi-pwsh-sdk";
@@ -495,6 +510,63 @@ internal static unsafe partial class NativeMethods
     [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_operation_stream_batch_release")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial int ReleaseOperationStreamBatch(ulong batchHandle, NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_begin_typed_result_invocation")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int BeginTypedResultInvocation(
+        ulong handle,
+        uint maximumBufferedRecords,
+        uint maximumPageRecords,
+        ulong* typedResultHandle,
+        NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_typed_result_invocation_read_page")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int ReadTypedResultPage(
+        ulong typedResultHandle,
+        ulong acknowledgedThrough,
+        uint maximumRecords,
+        ulong* pageHandle,
+        NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_typed_result_invocation_stop")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int StopTypedResultInvocation(ulong typedResultHandle, NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_typed_result_invocation_release")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int ReleaseTypedResultInvocation(ulong typedResultHandle, NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_typed_result_page_get_info")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int GetTypedResultPageInfo(
+        ulong pageHandle,
+        NativeTypedResultPageInfo* info,
+        NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_typed_result_page_get_record_info")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int GetTypedResultPageRecordInfo(
+        ulong pageHandle,
+        uint recordIndex,
+        ulong* sequence,
+        uint* kind,
+        NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_typed_result_page_copy_record_value")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int CopyTypedResultPageRecordValue(
+        ulong pageHandle,
+        uint recordIndex,
+        uint* kind,
+        byte* buffer,
+        nuint bufferLength,
+        nuint* requiredLength,
+        NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_typed_result_page_release")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int ReleaseTypedResultPage(ulong pageHandle, NativeCallResult* result);
 
     [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_session_create")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/dotnet/sdk-ffi/PowerShell.cs
+++ b/dotnet/sdk-ffi/PowerShell.cs
@@ -31,6 +31,7 @@ public sealed unsafe class PowerShell : IDisposable
     private const ulong LiveSessionObjectProbeFeature = 1UL << 18;
     private const ulong LiveObjectContractsFeature = 1UL << 19;
     private const ulong LiveStreamPollingFeature = 1UL << 20;
+    private const ulong TypedResultPagingFeature = 1UL << 21;
     private const ulong RequiredFeatures =
         StructuredInvocationErrorsFeature | PerCallDiagnosticsFeature | Utf8SpansFeature |
         ImmutableResultsFeature | TaggedValuesFeature | CommandOptionsFeature | BoundedInputFeature |
@@ -544,6 +545,36 @@ public sealed unsafe class PowerShell : IDisposable
         return new PowerShellInvocationOperation(new PowerShellOperationHandle(nativeOperationHandle));
     }
 
+    /// <summary>
+    /// Starts a bounded invocation whose output can be read as copied tagged
+    /// values with an explicit acknowledgement cursor.
+    /// </summary>
+    public PowerShellTypedResultInvocation BeginTypedResultInvocation(
+        PowerShellValuePagerOptions? options = null)
+    {
+        EnsureTypedResultPagingSupported();
+        options ??= new PowerShellValuePagerOptions();
+        using PowerShellHandle.HandleLease lease = handle.Borrow();
+        byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+        NativeCallResult result = NativeCall.CreateResult(diagnostic);
+        ulong nativeTypedResultHandle = 0;
+        int status = NativeMethods.BeginTypedResultInvocation(
+            lease.Value,
+            checked((uint)options.MaximumBufferedRecords),
+            checked((uint)options.MaximumPageRecords),
+            &nativeTypedResultHandle,
+            &result);
+        NativeCall.ThrowIfFailed(status, result, diagnostic);
+        if (nativeTypedResultHandle == 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned an invalid typed result invocation handle.");
+        }
+
+        return new PowerShellTypedResultInvocation(nativeTypedResultHandle, options);
+    }
+
     public Task<PowerShellInvocationResult> InvokeAsync(CancellationToken cancellationToken = default)
     {
         return PowerShellAsyncOperationAwaiter.GetResultAsync(BeginInvoke(), cancellationToken, releaseWhenComplete: true);
@@ -641,6 +672,22 @@ public sealed unsafe class PowerShell : IDisposable
             throw new PowerShellFfiException(
                 PowerShellFfiStatus.UnsupportedCapability,
                 "The selected PowerShell native asset does not support live stream polling.");
+        }
+    }
+
+    internal static void EnsureTypedResultPagingSupported()
+    {
+        EnsureTypedResultPagingSupported(GetAbiInfo());
+    }
+
+    internal static void EnsureTypedResultPagingSupported(NativeAbiInfo info)
+    {
+        EnsureSupportedAbi(info);
+        if ((info.FeatureFlags & TypedResultPagingFeature) == 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.UnsupportedCapability,
+                "The selected PowerShell native asset does not support typed result paging.");
         }
     }
 

--- a/dotnet/sdk-ffi/PowerShellDtoContractAttribute.cs
+++ b/dotnet/sdk-ffi/PowerShellDtoContractAttribute.cs
@@ -1,0 +1,46 @@
+namespace Devolutions.PowerShell.Ffi;
+
+/// <summary>
+/// Marks a public DTO for compile-time generation of a strict copied
+/// <see cref="PowerShellValue"/> property-bag projection.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+public sealed class PowerShellDtoContractAttribute : Attribute
+{
+    public PowerShellDtoContractAttribute(int version = 1)
+    {
+        if (version < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(version));
+        }
+
+        Version = version;
+    }
+
+    public int Version { get; }
+
+    /// <summary>
+    /// Rejects properties that are not declared by the DTO contract.
+    /// </summary>
+    public bool RejectUnknownMembers { get; set; } = true;
+}
+
+/// <summary>
+/// Configures the wire name and bounds for a DTO property.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class PowerShellDtoMemberAttribute : Attribute
+{
+    public PowerShellDtoMemberAttribute(string? name = null)
+    {
+        Name = name;
+    }
+
+    public string? Name { get; }
+
+    public bool Required { get; set; } = true;
+
+    public int MaximumStringLength { get; set; } = 4096;
+
+    public int MaximumCollectionCount { get; set; } = PowerShellValue.MaximumContainerEntries;
+}

--- a/dotnet/sdk-ffi/PowerShellDtoProjection.cs
+++ b/dotnet/sdk-ffi/PowerShellDtoProjection.cs
@@ -1,0 +1,217 @@
+using System.Collections.ObjectModel;
+
+namespace Devolutions.PowerShell.Ffi;
+
+public enum PowerShellDtoProjectionFailure
+{
+    InvalidRoot,
+    UnknownMember,
+    MissingMember,
+    InvalidVersion,
+    InvalidValue,
+    ValueTooLarge,
+}
+
+public sealed class PowerShellDtoProjectionException : InvalidOperationException
+{
+    internal PowerShellDtoProjectionException(PowerShellDtoProjectionError error)
+        : base(error.Message)
+    {
+        Error = error;
+    }
+
+    public PowerShellDtoProjectionError Error { get; }
+}
+
+public sealed class PowerShellDtoProjectionError
+{
+    internal PowerShellDtoProjectionError(
+        PowerShellDtoProjectionFailure failure,
+        string path,
+        string message)
+    {
+        Failure = failure;
+        Path = path;
+        Message = message;
+    }
+
+    public PowerShellDtoProjectionFailure Failure { get; }
+
+    public string Path { get; }
+
+    public string Message { get; }
+}
+
+/// <summary>
+/// Shared bounded primitives used by source-generated DTO projections.
+/// </summary>
+public static class PowerShellDtoProjection
+{
+    public const string VersionMemberName = "$version";
+
+    public static PowerShellDtoProjectionException CreateException(PowerShellDtoProjectionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new PowerShellDtoProjectionException(error);
+    }
+
+    public static bool TryGetPropertyBag(
+        PowerShellValue value,
+        int version,
+        bool rejectUnknownMembers,
+        IReadOnlySet<string> declaredMembers,
+        string path,
+        out IReadOnlyDictionary<string, PowerShellValue>? properties,
+        out PowerShellDtoProjectionError? error)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(declaredMembers);
+        if (version < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(version));
+        }
+
+        if (value.Kind != PowerShellValueKind.PropertyBag)
+        {
+            properties = null;
+            error = Failure(PowerShellDtoProjectionFailure.InvalidRoot, path, "Expected a copied property bag.");
+            return false;
+        }
+
+        properties = value.GetPropertyBag();
+        if (!properties.TryGetValue(VersionMemberName, out PowerShellValue? versionValue) ||
+            !versionValue.TryGetUnsignedInteger(out ulong encodedVersion) ||
+            encodedVersion != (ulong)version)
+        {
+            properties = null;
+            error = Failure(PowerShellDtoProjectionFailure.InvalidVersion, path, "The DTO version is missing or incompatible.");
+            return false;
+        }
+
+        if (rejectUnknownMembers &&
+            properties.Keys.Any(name => !string.Equals(name, VersionMemberName, StringComparison.Ordinal) &&
+                                        !declaredMembers.Contains(name)))
+        {
+            properties = null;
+            error = Failure(PowerShellDtoProjectionFailure.UnknownMember, path, "The DTO contains an undeclared member.");
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    public static bool TryGetMember(
+        IReadOnlyDictionary<string, PowerShellValue> properties,
+        string name,
+        bool required,
+        string path,
+        out PowerShellValue? value,
+        out PowerShellDtoProjectionError? error)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (properties.TryGetValue(name, out value))
+        {
+            error = null;
+            return true;
+        }
+
+        error = required
+            ? Failure(PowerShellDtoProjectionFailure.MissingMember, JoinPath(path, name), "The required DTO member is missing.")
+            : null;
+        return !required;
+    }
+
+    public static bool TryReadString(
+        PowerShellValue value,
+        int maximumLength,
+        string path,
+        out string? result,
+        out PowerShellDtoProjectionError? error)
+    {
+        if (maximumLength < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumLength));
+        }
+
+        if (!value.TryGetString(out result) || result is null || result.Length > maximumLength)
+        {
+            result = null;
+            error = Failure(
+                value.Kind == PowerShellValueKind.String
+                    ? PowerShellDtoProjectionFailure.ValueTooLarge
+                    : PowerShellDtoProjectionFailure.InvalidValue,
+                path,
+                "The DTO string member has an invalid kind or exceeds its bound.");
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    public static bool TryReadArray(
+        PowerShellValue value,
+        int maximumCount,
+        string path,
+        out IReadOnlyList<PowerShellValue>? values,
+        out PowerShellDtoProjectionError? error)
+    {
+        if (maximumCount < 0 || maximumCount > PowerShellValue.MaximumContainerEntries)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumCount));
+        }
+
+        if (value.Kind != PowerShellValueKind.Array)
+        {
+            values = null;
+            error = Failure(PowerShellDtoProjectionFailure.InvalidValue, path, "Expected a copied tagged array.");
+            return false;
+        }
+
+        values = value.GetArray();
+        if (values.Count > maximumCount)
+        {
+            values = null;
+            error = Failure(PowerShellDtoProjectionFailure.ValueTooLarge, path, "The DTO array exceeds its declared bound.");
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    public static PowerShellValue CreatePropertyBag(
+        int version,
+        IEnumerable<KeyValuePair<string, PowerShellValue>> members)
+    {
+        ArgumentNullException.ThrowIfNull(members);
+        if (version < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(version));
+        }
+
+        return PowerShellValue.PropertyBag(
+            new[] { new KeyValuePair<string, PowerShellValue>(VersionMemberName, PowerShellValue.UnsignedInteger((ulong)version)) }
+                .Concat(members));
+    }
+
+    public static string JoinPath(string path, string member)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(member);
+        return string.IsNullOrEmpty(path) ? member : string.Concat(path, ".", member);
+    }
+
+    public static PowerShellDtoProjectionError InvalidValue(string path, string message) =>
+        Failure(PowerShellDtoProjectionFailure.InvalidValue, path, message);
+
+    public static PowerShellDtoProjectionError ValueTooLarge(string path, string message) =>
+        Failure(PowerShellDtoProjectionFailure.ValueTooLarge, path, message);
+
+    private static PowerShellDtoProjectionError Failure(
+        PowerShellDtoProjectionFailure failure,
+        string path,
+        string message) =>
+        new(failure, path, message);
+}

--- a/dotnet/sdk-ffi/PowerShellTypedResultInvocation.cs
+++ b/dotnet/sdk-ffi/PowerShellTypedResultInvocation.cs
@@ -1,0 +1,205 @@
+namespace Devolutions.PowerShell.Ffi;
+
+/// <summary>
+/// A native-backed, bounded acknowledgement reader for copied PowerShell values.
+/// </summary>
+public sealed unsafe class PowerShellTypedResultInvocation : IDisposable
+{
+    private const uint Terminal = 1;
+    private const uint Truncated = 1 << 1;
+    private const uint Complete = 1 << 2;
+    private readonly PowerShellTypedResultInvocationHandle handle;
+    private readonly int maximumPageRecords;
+
+    internal PowerShellTypedResultInvocation(ulong nativeHandle, PowerShellValuePagerOptions options)
+    {
+        handle = new PowerShellTypedResultInvocationHandle(nativeHandle);
+        maximumPageRecords = options.MaximumPageRecords;
+    }
+
+    /// <summary>
+    /// Acknowledges <paramref name="acknowledgedThrough"/> from the prior page and
+    /// returns the next ordered page of copied tagged values.
+    /// </summary>
+    public PowerShellValuePage Read(ulong acknowledgedThrough, int? maximumRecords = null)
+    {
+        PowerShell.EnsureTypedResultPagingSupported();
+        int limit = maximumRecords ?? maximumPageRecords;
+        if (limit < 1 || limit > maximumPageRecords)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumRecords));
+        }
+
+        using PowerShellTypedResultInvocationHandle.HandleLease lease = handle.Borrow();
+        byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+        NativeCallResult result = NativeCall.CreateResult(diagnostic);
+        ulong nativePageHandle = 0;
+        int status = NativeMethods.ReadTypedResultPage(
+            lease.Value,
+            acknowledgedThrough,
+            checked((uint)limit),
+            &nativePageHandle,
+            &result);
+        NativeCall.ThrowIfFailed(status, result, diagnostic);
+        if (nativePageHandle == 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned an invalid typed result page handle.");
+        }
+
+        using var pageHandle = new PowerShellTypedResultPageHandle(nativePageHandle);
+        NativeTypedResultPageInfo info = new()
+        {
+            Size = checked((uint)sizeof(NativeTypedResultPageInfo)),
+        };
+        result = NativeCall.CreateResult(diagnostic);
+        status = NativeMethods.GetTypedResultPageInfo(pageHandle.Value, &info, &result);
+        NativeCall.ThrowIfFailed(status, result, diagnostic);
+
+        if (!Enum.IsDefined((PowerShellFfiStatus)info.TerminalStatus) ||
+            info.AcknowledgedSequence != acknowledgedThrough ||
+            info.NextSequence < info.AcknowledgedSequence ||
+            info.NextSequence > info.TotalRecordCount ||
+            info.DroppedRecordCount > info.TotalRecordCount ||
+            info.RecordCount > (uint)limit ||
+            (info.Flags & ~(Terminal | Truncated | Complete)) != 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned invalid typed result page metadata.");
+        }
+
+        bool isTerminal = (info.Flags & Terminal) != 0;
+        bool isTruncated = (info.Flags & Truncated) != 0;
+        bool isComplete = (info.Flags & Complete) != 0;
+        if ((!isTerminal && info.TerminalStatus != (int)PowerShellFfiStatus.Success) ||
+            (isComplete && (!isTerminal ||
+                            info.TerminalStatus != (int)PowerShellFfiStatus.Success ||
+                            isTruncated ||
+                            info.DroppedRecordCount != 0 ||
+                            info.TotalRecordCount != info.AcknowledgedSequence)))
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned inconsistent typed result terminal metadata.");
+        }
+
+        var records = new PowerShellValuePageRecord[checked((int)info.RecordCount)];
+        ulong previousSequence = info.AcknowledgedSequence;
+        for (uint index = 0; index < info.RecordCount; index++)
+        {
+            ulong sequence = 0;
+            uint kind = 0;
+            result = NativeCall.CreateResult(diagnostic);
+            status = NativeMethods.GetTypedResultPageRecordInfo(
+                pageHandle.Value,
+                index,
+                &sequence,
+                &kind,
+                &result);
+            NativeCall.ThrowIfFailed(status, result, diagnostic);
+            if (!Enum.IsDefined((PowerShellValueKind)kind) ||
+                sequence <= previousSequence ||
+                sequence > info.NextSequence)
+            {
+                throw new PowerShellFfiException(
+                    PowerShellFfiStatus.ManagedFailure,
+                    "Native PowerShell FFI returned unordered typed result records.");
+            }
+
+            records[checked((int)index)] = new PowerShellValuePageRecord(
+                sequence,
+                ReadValue(pageHandle.Value, index, kind, diagnostic));
+            previousSequence = sequence;
+        }
+
+        if (records.Length == 0 ? info.NextSequence != info.AcknowledgedSequence : info.NextSequence != previousSequence)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned an inconsistent typed result cursor.");
+        }
+
+        return new PowerShellValuePage(
+            Array.AsReadOnly(records),
+            info.AcknowledgedSequence,
+            info.NextSequence,
+            info.TotalRecordCount,
+            (PowerShellFfiStatus)info.TerminalStatus,
+            isTerminal,
+            info.DroppedRecordCount,
+            isTruncated,
+            isComplete);
+    }
+
+    public void Stop()
+    {
+        PowerShell.EnsureTypedResultPagingSupported();
+        using PowerShellTypedResultInvocationHandle.HandleLease lease = handle.Borrow();
+        byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+        NativeCallResult result = NativeCall.CreateResult(diagnostic);
+        int status = NativeMethods.StopTypedResultInvocation(lease.Value, &result);
+        NativeCall.ThrowIfFailed(status, result, diagnostic);
+    }
+
+    public void Dispose()
+    {
+        handle.Dispose();
+    }
+
+    private static PowerShellValue ReadValue(
+        ulong pageHandle,
+        uint recordIndex,
+        uint expectedKind,
+        byte* diagnostic)
+    {
+        NativeCallResult result = NativeCall.CreateResult(diagnostic);
+        uint kind = 0;
+        nuint requiredLength = 0;
+        int status = NativeMethods.CopyTypedResultPageRecordValue(
+            pageHandle,
+            recordIndex,
+            &kind,
+            null,
+            0,
+            &requiredLength,
+            &result);
+        if (status != (int)PowerShellFfiStatus.Success &&
+            status != (int)PowerShellFfiStatus.BufferTooSmall)
+        {
+            NativeCall.ThrowIfFailed(status, result, diagnostic);
+        }
+
+        if (kind != expectedKind || requiredLength > PowerShellValue.MaximumPayloadLength)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned an invalid typed result value.");
+        }
+
+        byte[] payload = new byte[checked((int)requiredLength)];
+        fixed (byte* payloadPointer = payload)
+        {
+            result = NativeCall.CreateResult(diagnostic);
+            status = NativeMethods.CopyTypedResultPageRecordValue(
+                pageHandle,
+                recordIndex,
+                &kind,
+                payloadPointer,
+                (nuint)payload.Length,
+                &requiredLength,
+                &result);
+            NativeCall.ThrowIfFailed(status, result, diagnostic);
+        }
+
+        if (kind != expectedKind || requiredLength != (nuint)payload.Length)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI changed a typed result value during copy.");
+        }
+
+        return PowerShellValue.FromNative(kind, payload);
+    }
+}

--- a/dotnet/sdk-ffi/PowerShellTypedResultInvocationHandle.cs
+++ b/dotnet/sdk-ffi/PowerShellTypedResultInvocationHandle.cs
@@ -1,0 +1,72 @@
+using Microsoft.Win32.SafeHandles;
+
+namespace Devolutions.PowerShell.Ffi;
+
+internal sealed unsafe class PowerShellTypedResultInvocationHandle : SafeHandleZeroOrMinusOneIsInvalid
+{
+    private readonly ulong nativeValue;
+
+    internal PowerShellTypedResultInvocationHandle(ulong value)
+        : base(ownsHandle: true)
+    {
+        if (value == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value));
+        }
+
+        nativeValue = value;
+        SetHandle((nint)1);
+    }
+
+    internal HandleLease Borrow()
+    {
+        bool addedRef = false;
+        try
+        {
+            DangerousAddRef(ref addedRef);
+            if (IsInvalid)
+            {
+                throw new ObjectDisposedException(nameof(PowerShellTypedResultInvocation));
+            }
+
+            return new HandleLease(this);
+        }
+        catch
+        {
+            if (addedRef)
+            {
+                DangerousRelease();
+            }
+
+            throw;
+        }
+    }
+
+    protected override bool ReleaseHandle()
+    {
+        byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+        NativeCallResult result = NativeCall.CreateResult(diagnostic);
+        int status = NativeMethods.ReleaseTypedResultInvocation(nativeValue, &result);
+        return status == (int)PowerShellFfiStatus.Success &&
+            result.Status == (int)PowerShellFfiStatus.Success;
+    }
+
+    internal sealed class HandleLease : IDisposable
+    {
+        private PowerShellTypedResultInvocationHandle? owner;
+
+        internal HandleLease(PowerShellTypedResultInvocationHandle owner)
+        {
+            this.owner = owner;
+            Value = owner.nativeValue;
+        }
+
+        internal ulong Value { get; }
+
+        public void Dispose()
+        {
+            PowerShellTypedResultInvocationHandle? current = Interlocked.Exchange(ref owner, null);
+            current?.DangerousRelease();
+        }
+    }
+}

--- a/dotnet/sdk-ffi/PowerShellTypedResultPageHandle.cs
+++ b/dotnet/sdk-ffi/PowerShellTypedResultPageHandle.cs
@@ -1,0 +1,42 @@
+using Microsoft.Win32.SafeHandles;
+
+namespace Devolutions.PowerShell.Ffi;
+
+internal sealed unsafe class PowerShellTypedResultPageHandle : SafeHandleZeroOrMinusOneIsInvalid
+{
+    private readonly ulong nativeValue;
+
+    internal PowerShellTypedResultPageHandle(ulong value)
+        : base(ownsHandle: true)
+    {
+        if (value == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value));
+        }
+
+        nativeValue = value;
+        SetHandle((nint)1);
+    }
+
+    internal ulong Value
+    {
+        get
+        {
+            if (IsInvalid)
+            {
+                throw new ObjectDisposedException(nameof(PowerShellTypedResultPageHandle));
+            }
+
+            return nativeValue;
+        }
+    }
+
+    protected override bool ReleaseHandle()
+    {
+        byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+        NativeCallResult result = NativeCall.CreateResult(diagnostic);
+        int status = NativeMethods.ReleaseTypedResultPage(nativeValue, &result);
+        return status == (int)PowerShellFfiStatus.Success &&
+            result.Status == (int)PowerShellFfiStatus.Success;
+    }
+}

--- a/dotnet/sdk-ffi/PowerShellValue.cs
+++ b/dotnet/sdk-ffi/PowerShellValue.cs
@@ -8,9 +8,9 @@ namespace Devolutions.PowerShell.Ffi;
 
 public sealed class PowerShellValue
 {
-    internal const int MaximumPayloadLength = 64 * 1024;
-    internal const int MaximumContainerEntries = 64;
-    internal const int MaximumDepth = 8;
+    public const int MaximumPayloadLength = 64 * 1024;
+    public const int MaximumContainerEntries = 64;
+    public const int MaximumDepth = 8;
     private readonly byte[] payload;
 
     private PowerShellValue(PowerShellValueKind kind, byte[] payload)

--- a/dotnet/sdk-ffi/PowerShellValuePager.cs
+++ b/dotnet/sdk-ffi/PowerShellValuePager.cs
@@ -49,7 +49,10 @@ public sealed class PowerShellValuePage
         ulong nextSequence,
         ulong totalRecordCount,
         PowerShellFfiStatus terminalStatus,
-        bool isTerminal)
+        bool isTerminal,
+        ulong droppedRecordCount = 0,
+        bool isTruncated = false,
+        bool isComplete = false)
     {
         Records = records;
         AcknowledgedSequence = acknowledgedSequence;
@@ -57,6 +60,9 @@ public sealed class PowerShellValuePage
         TotalRecordCount = totalRecordCount;
         TerminalStatus = terminalStatus;
         IsTerminal = isTerminal;
+        DroppedRecordCount = droppedRecordCount;
+        IsTruncated = isTruncated;
+        IsComplete = isComplete;
     }
 
     public IReadOnlyList<PowerShellValuePageRecord> Records { get; }
@@ -73,9 +79,15 @@ public sealed class PowerShellValuePage
 
     public ulong TotalRecordCount { get; }
 
+    public ulong DroppedRecordCount { get; }
+
     public PowerShellFfiStatus TerminalStatus { get; }
 
     public bool IsTerminal { get; }
+
+    public bool IsTruncated { get; }
+
+    public bool IsComplete { get; }
 }
 
 public sealed class PowerShellValuePagerCompletion
@@ -84,12 +96,16 @@ public sealed class PowerShellValuePagerCompletion
         PowerShellFfiStatus terminalStatus,
         string diagnostic,
         ulong totalRecordCount,
-        ulong acknowledgedRecordCount)
+        ulong acknowledgedRecordCount,
+        ulong droppedRecordCount = 0,
+        bool isTruncated = false)
     {
         TerminalStatus = terminalStatus;
         Diagnostic = diagnostic;
         TotalRecordCount = totalRecordCount;
         AcknowledgedRecordCount = acknowledgedRecordCount;
+        DroppedRecordCount = droppedRecordCount;
+        IsTruncated = isTruncated;
     }
 
     public PowerShellFfiStatus TerminalStatus { get; }
@@ -100,8 +116,14 @@ public sealed class PowerShellValuePagerCompletion
 
     public ulong AcknowledgedRecordCount { get; }
 
+    public ulong DroppedRecordCount { get; }
+
+    public bool IsTruncated { get; }
+
     public bool IsComplete =>
         TerminalStatus == PowerShellFfiStatus.Success &&
+        !IsTruncated &&
+        DroppedRecordCount == 0 &&
         TotalRecordCount == AcknowledgedRecordCount;
 }
 
@@ -175,13 +197,17 @@ public sealed class PowerShellValuePager : IDisposable
             PowerShellValuePageRecord[] page = records.Take(limit).ToArray();
             ulong next = page.Length == 0 ? acknowledgedSequence : page[^1].Sequence;
             maximumAcknowledgableSequence = next;
+            bool isComplete = terminal &&
+                terminalStatus == PowerShellFfiStatus.Success &&
+                totalRecordCount == acknowledgedSequence;
             return new PowerShellValuePage(
                 Array.AsReadOnly(page),
                 acknowledgedSequence,
                 next,
                 totalRecordCount,
                 terminalStatus,
-                terminal);
+                terminal,
+                isComplete: isComplete);
         }
     }
 

--- a/dotnet/sdk-ffi/PowerShellValuePager.cs
+++ b/dotnet/sdk-ffi/PowerShellValuePager.cs
@@ -1,0 +1,280 @@
+using System.Collections.Generic;
+
+namespace Devolutions.PowerShell.Ffi;
+
+/// <summary>
+/// Caller-configured bounds for a lossless copied-value result pager.
+/// </summary>
+public sealed class PowerShellValuePagerOptions
+{
+    public PowerShellValuePagerOptions(int maximumBufferedRecords = 32, int maximumPageRecords = 32)
+    {
+        if (maximumBufferedRecords < 1 || maximumBufferedRecords > PowerShellValue.MaximumContainerEntries)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumBufferedRecords));
+        }
+
+        if (maximumPageRecords < 1 || maximumPageRecords > maximumBufferedRecords)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumPageRecords));
+        }
+
+        MaximumBufferedRecords = maximumBufferedRecords;
+        MaximumPageRecords = maximumPageRecords;
+    }
+
+    public int MaximumBufferedRecords { get; }
+
+    public int MaximumPageRecords { get; }
+}
+
+public sealed class PowerShellValuePageRecord
+{
+    internal PowerShellValuePageRecord(ulong sequence, PowerShellValue value)
+    {
+        Sequence = sequence;
+        Value = value;
+    }
+
+    public ulong Sequence { get; }
+
+    public PowerShellValue Value { get; }
+}
+
+public sealed class PowerShellValuePage
+{
+    internal PowerShellValuePage(
+        IReadOnlyList<PowerShellValuePageRecord> records,
+        ulong acknowledgedSequence,
+        ulong nextSequence,
+        ulong totalRecordCount,
+        PowerShellFfiStatus terminalStatus,
+        bool isTerminal)
+    {
+        Records = records;
+        AcknowledgedSequence = acknowledgedSequence;
+        NextSequence = nextSequence;
+        TotalRecordCount = totalRecordCount;
+        TerminalStatus = terminalStatus;
+        IsTerminal = isTerminal;
+    }
+
+    public IReadOnlyList<PowerShellValuePageRecord> Records { get; }
+
+    /// <summary>
+    /// The sequence the reader supplied to this page request.
+    /// </summary>
+    public ulong AcknowledgedSequence { get; }
+
+    /// <summary>
+    /// Acknowledgement cursor for the records returned by this page.
+    /// </summary>
+    public ulong NextSequence { get; }
+
+    public ulong TotalRecordCount { get; }
+
+    public PowerShellFfiStatus TerminalStatus { get; }
+
+    public bool IsTerminal { get; }
+}
+
+public sealed class PowerShellValuePagerCompletion
+{
+    internal PowerShellValuePagerCompletion(
+        PowerShellFfiStatus terminalStatus,
+        string diagnostic,
+        ulong totalRecordCount,
+        ulong acknowledgedRecordCount)
+    {
+        TerminalStatus = terminalStatus;
+        Diagnostic = diagnostic;
+        TotalRecordCount = totalRecordCount;
+        AcknowledgedRecordCount = acknowledgedRecordCount;
+    }
+
+    public PowerShellFfiStatus TerminalStatus { get; }
+
+    public string Diagnostic { get; }
+
+    public ulong TotalRecordCount { get; }
+
+    public ulong AcknowledgedRecordCount { get; }
+
+    public bool IsComplete =>
+        TerminalStatus == PowerShellFfiStatus.Success &&
+        TotalRecordCount == AcknowledgedRecordCount;
+}
+
+/// <summary>
+/// A bounded, lossless acknowledgement pager for copied <see cref="PowerShellValue"/> records.
+/// </summary>
+/// <remarks>
+/// Producers block when the configured buffer is full. Records are retained only
+/// until the consumer explicitly acknowledges their sequence. A terminal success
+/// cannot be reported complete until every record has been acknowledged.
+/// </remarks>
+public sealed class PowerShellValuePager : IDisposable
+{
+    private readonly object gate = new();
+    private readonly Queue<PowerShellValuePageRecord> records;
+    private readonly int maximumPageRecords;
+    private readonly int maximumBufferedRecords;
+    private ulong nextSequence = 1;
+    private ulong acknowledgedSequence;
+    private ulong maximumAcknowledgableSequence;
+    private ulong totalRecordCount;
+    private PowerShellFfiStatus terminalStatus = PowerShellFfiStatus.Success;
+    private string diagnostic = string.Empty;
+    private bool terminal;
+    private bool disposed;
+
+    public PowerShellValuePager(PowerShellValuePagerOptions? options = null)
+    {
+        options ??= new PowerShellValuePagerOptions();
+        maximumBufferedRecords = options.MaximumBufferedRecords;
+        maximumPageRecords = options.MaximumPageRecords;
+        records = new Queue<PowerShellValuePageRecord>(maximumBufferedRecords);
+    }
+
+    public void Write(PowerShellValue value, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        lock (gate)
+        {
+            while (!terminal && !disposed && records.Count == maximumBufferedRecords)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Monitor.Wait(gate, TimeSpan.FromMilliseconds(50));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfClosed();
+            records.Enqueue(new PowerShellValuePageRecord(nextSequence, value));
+            nextSequence = checked(nextSequence + 1);
+            totalRecordCount = checked(totalRecordCount + 1);
+            Monitor.PulseAll(gate);
+        }
+    }
+
+    public PowerShellValuePage Read(ulong acknowledgedThrough, int? maximumRecords = null)
+    {
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            int limit = maximumRecords ?? maximumPageRecords;
+            if (limit < 1 || limit > maximumPageRecords)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumRecords));
+            }
+
+            if (acknowledgedThrough != acknowledgedSequence)
+            {
+                throw new InvalidOperationException("Result pages must be read from the last acknowledged cursor.");
+            }
+
+            PowerShellValuePageRecord[] page = records.Take(limit).ToArray();
+            ulong next = page.Length == 0 ? acknowledgedSequence : page[^1].Sequence;
+            maximumAcknowledgableSequence = next;
+            return new PowerShellValuePage(
+                Array.AsReadOnly(page),
+                acknowledgedSequence,
+                next,
+                totalRecordCount,
+                terminalStatus,
+                terminal);
+        }
+    }
+
+    public void Acknowledge(ulong sequence)
+    {
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            if (sequence < acknowledgedSequence || sequence > maximumAcknowledgableSequence)
+            {
+                throw new InvalidOperationException("Result acknowledgement is outside the most recently returned page.");
+            }
+
+            while (records.Count != 0 && records.Peek().Sequence <= sequence)
+            {
+                records.Dequeue();
+            }
+
+            acknowledgedSequence = sequence;
+            maximumAcknowledgableSequence = acknowledgedSequence;
+            Monitor.PulseAll(gate);
+        }
+    }
+
+    public void Complete(PowerShellFfiStatus status = PowerShellFfiStatus.Success, string? terminalDiagnostic = null)
+    {
+        if (!Enum.IsDefined(status))
+        {
+            throw new ArgumentOutOfRangeException(nameof(status));
+        }
+
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            if (terminal)
+            {
+                throw new InvalidOperationException("The result pager is already terminal.");
+            }
+
+            terminal = true;
+            terminalStatus = status;
+            diagnostic = terminalDiagnostic ?? string.Empty;
+            Monitor.PulseAll(gate);
+        }
+    }
+
+    public PowerShellValuePagerCompletion GetCompletion()
+    {
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            if (!terminal)
+            {
+                throw new InvalidOperationException("The result pager has not reached a terminal state.");
+            }
+
+            return new PowerShellValuePagerCompletion(
+                terminalStatus,
+                diagnostic,
+                totalRecordCount,
+                acknowledgedSequence);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            terminal = true;
+            terminalStatus = PowerShellFfiStatus.OperationCancelled;
+            diagnostic = "The result pager was disposed before final acknowledgement.";
+            records.Clear();
+            Monitor.PulseAll(gate);
+        }
+    }
+
+    private void ThrowIfClosed()
+    {
+        ThrowIfDisposed();
+        if (terminal)
+        {
+            throw new InvalidOperationException("The result pager is terminal and cannot accept additional records.");
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+    }
+}

--- a/dotnet/sdk-ffi/README.md
+++ b/dotnet/sdk-ffi/README.md
@@ -140,6 +140,33 @@ This is neither a live console, `PSHost`, callback/event API, nor a stream of
 SMA objects, credentials, or other CLR references. Cancellation can expose
 already-captured records, but still never produces a successful final result.
 
+## DTO projections and bounded paging
+
+`PowerShellDtoContractAttribute` and `PowerShellDtoMemberAttribute` opt an
+application DTO into the package's separate incremental source generator. The
+generator emits direct `Read`, `TryRead`, and `Write` methods for a versioned
+`PowerShellValue` property bag; no reflection or runtime type discovery is
+used. Contracts require public settable properties and a public parameterless
+constructor, and support only the documented copied scalar kinds plus bounded
+one-dimensional arrays of those scalars. Every property bag carries an exact
+`$version` value. By default unknown properties, missing required properties,
+incorrect scalar kinds, and string/array limit violations return a structured
+`PowerShellDtoProjectionError`; `Read` raises the corresponding typed
+exception. This is an application DTO mapper, not a serializer for arbitrary
+CLR graphs, PowerShell objects, credentials, callbacks, or live-object
+contracts.
+
+`PowerShellValuePager` is the reusable bounded acknowledgement state machine
+for copied result values. Its caller-configured record and page bounds apply
+backpressure to writers, and its pages expose ordered sequences plus an
+acknowledgement cursor. Records remain retained only until
+`Acknowledge(sequence)` removes them. `GetCompletion().IsComplete` is true
+only after a successful terminal state and acknowledgement of every produced
+record; cancellation, disposal, a terminal error, or unacknowledged records
+are never silently complete. This primitive is deliberately distinct from
+`ReadStreamBatch`: it does not turn the existing lossy display stream into a
+typed data feed, and it never exposes SMA values or unbounded retention.
+
 `PowerShellRuntime.CreateSession(PowerShellSessionOptions)` creates a separate,
 reusable local-runspace session. `PowerShellSessionConfiguration` supplies
 copied tagged initial variables, module imports/paths, a working directory,

--- a/dotnet/sdk-ffi/README.md
+++ b/dotnet/sdk-ffi/README.md
@@ -167,6 +167,19 @@ are never silently complete. This primitive is deliberately distinct from
 `ReadStreamBatch`: it does not turn the existing lossy display stream into a
 typed data feed, and it never exposes SMA values or unbounded retention.
 
+`BeginTypedResultInvocation(options)` connects that acknowledgement model to
+an invocation's output through the additive `TYPED_RESULT_PAGING` native
+feature. `Read(acknowledgedThrough, maximumRecords)` acknowledges the prior
+page and returns only copied `PowerShellValue` records (including bounded
+arrays and property bags), never SMA objects, `PSObject`, or display text.
+The configured buffer is a hard producer backpressure limit; values are not
+dropped to make room. Each page reports total, dropped, truncation, terminal,
+and completeness metadata. Outputs that cannot be represented losslessly as a
+documented tagged value terminate the typed operation with `UnsupportedValue`
+rather than being converted to text or silently omitted. Older native assets
+are rejected with `UnsupportedCapability` before the additive exports are
+called.
+
 `PowerShellRuntime.CreateSession(PowerShellSessionOptions)` creates a separate,
 reusable local-runspace session. `PowerShellSessionConfiguration` supplies
 copied tagged initial variables, module imports/paths, a working directory,

--- a/tests/PwshFfiApiBaseline.txt
+++ b/tests/PwshFfiApiBaseline.txt
@@ -1,4 +1,6 @@
 bindings:Bindings_GetFfiApiV2
+bindings:Bindings_GetFfiApiV3
+bindings:Bindings_GetFfiApiV4
 bindings:FfiInvocationResult_CopyStreamRecordFieldToUtf8
 bindings:FfiInvocationResult_CopyStreamRecordValue
 bindings:FfiInvocationResult_GetInfo
@@ -9,6 +11,21 @@ bindings:FfiInvocationResult_GetStreamRecordInfo
 bindings:FfiInvocationResult_GetStreamRecordProjectionInfo
 bindings:FfiInvocationResult_GetStreamTotals
 bindings:FfiInvocationResult_Release
+bindings:FfiLiveInvocation_Complete
+bindings:FfiLiveInvocation_Poll
+bindings:FfiLiveInvocation_ReadBatch
+bindings:FfiLiveInvocation_Release
+bindings:FfiLiveInvocation_Stop
+bindings:FfiLiveInvocationBatch_CopyRecordTextToUtf8
+bindings:FfiLiveInvocationBatch_GetInfo
+bindings:FfiLiveInvocationBatch_GetRecordInfo
+bindings:FfiLiveInvocationBatch_Release
+bindings:FfiLiveObjectContractPack_Register
+bindings:FfiLiveObjectContractPack_RegisterMany
+bindings:FfiLiveObjectProbe_Create
+bindings:FfiLiveObjectProbe_Release
+bindings:FfiLiveObjectProbe_Unregister
+bindings:FfiPowerShell_AddArgumentLiveObject
 bindings:FfiPowerShell_AddArgumentUtf8
 bindings:FfiPowerShell_AddArgumentValue
 bindings:FfiPowerShell_AddCommandUtf8
@@ -21,6 +38,8 @@ bindings:FfiPowerShell_AddParameterValue
 bindings:FfiPowerShell_AddScriptUtf8
 bindings:FfiPowerShell_AddScriptUtf8Local
 bindings:FfiPowerShell_AddStatement
+bindings:FfiPowerShell_BeginLiveInvocation
+bindings:FfiPowerShell_BeginTypedResultInvocation
 bindings:FfiPowerShell_Clear
 bindings:FfiPowerShell_CompleteInput
 bindings:FfiPowerShell_CopyInvocationErrorFieldToUtf8
@@ -30,135 +49,76 @@ bindings:FfiPowerShell_InvokeToResult
 bindings:FfiPowerShell_InvokeToUtf8
 bindings:FfiPowerShell_Release
 bindings:FfiPowerShell_ResetInput
+bindings:FfiPowerShell_SetCapabilityContext
 bindings:FfiPowerShell_Stop
 bindings:FfiPowerShellSession_Create
-bindings:FfiPowerShellSession_CreateConfigured
 bindings:FfiPowerShellSession_CreateBuilder
+bindings:FfiPowerShellSession_CreateConfigured
 bindings:FfiPowerShellSession_GetEventInfo
 bindings:FfiPowerShellSession_GetSnapshot
 bindings:FfiPowerShellSession_GetVariableSnapshot
-bindings:FfiPowerShell_SetCapabilityContext
+bindings:FfiPowerShellSession_Release
+bindings:FfiPowerShellSession_RemoveVariable
+bindings:FfiPowerShellSession_SetLiveObjectContractVariable
+bindings:FfiPowerShellSession_SetLiveObjectVariable
+bindings:FfiPowerShellSession_SetVariable
+bindings:FfiTypedResultInvocation_Complete
+bindings:FfiTypedResultInvocation_Poll
+bindings:FfiTypedResultInvocation_ReadPage
+bindings:FfiTypedResultInvocation_Release
+bindings:FfiTypedResultInvocation_Stop
+bindings:FfiTypedResultPage_CopyRecordValue
+bindings:FfiTypedResultPage_GetInfo
+bindings:FfiTypedResultPage_GetRecordInfo
+bindings:FfiTypedResultPage_Release
+facade:ctor:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Void .ctor(System.Guid, UInt16, UInt16, Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection)
 facade:ctor:Devolutions.PowerShell.Ffi.PowerShellCapabilityArgumentSchema::Void .ctor(System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellValueKind])
 facade:ctor:Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding::Void .ctor(Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition, Devolutions.PowerShell.Ffi.IPowerShellCapabilityHandler)
 facade:ctor:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::Void .ctor(System.String, System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellCapabilityArgumentSchema], System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellValueKind], Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission, Int32, Int32, System.TimeSpan)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy::Void .ctor(System.Collections.Generic.IEnumerable`1[System.String], Boolean, Int32, Int32)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe::Void .ctor(System.String, System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue]], Devolutions.PowerShell.Ffi.PowerShellResultSchema, System.Nullable`1[System.TimeSpan])
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellDtoContractAttribute::Void .ctor(Int32)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellDtoMemberAttribute::Void .ctor(System.String)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1::Void .ctor(Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract, TContract)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack::Void .ctor(System.String, System.String)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Void .ctor(Int32, Int32, System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellValueKind], System.Collections.Generic.IEnumerable`1[System.String], Boolean, Boolean)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellScriptRecipe::Void .ctor(System.String, Devolutions.PowerShell.Ffi.PowerShellResultSchema, System.Nullable`1[System.TimeSpan])
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::Void .ctor(System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue]], System.Collections.Generic.IEnumerable`1[System.String], System.Collections.Generic.IEnumerable`1[System.String], System.String, System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,System.String]], Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Void .ctor(Int64)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Void .ctor(Devolutions.PowerShell.Ffi.PowerShellRunspaceMode, Devolutions.PowerShell.Ffi.PowerShellSessionInitialConfiguration, Devolutions.PowerShell.Ffi.PowerShellSessionHistoryMode, Devolutions.PowerShell.Ffi.PowerShellSessionPreference, Devolutions.PowerShell.Ffi.PowerShellSessionPreference, Devolutions.PowerShell.Ffi.PowerShellSessionPreference, Devolutions.PowerShell.Ffi.PowerShellSessionPreference, Devolutions.PowerShell.Ffi.PowerShellSessionPreference, System.String, Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellSessionPoolOptions::Void .ctor(UInt32, UInt32)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellValuePager::Void .ctor(Devolutions.PowerShell.Ffi.PowerShellValuePagerOptions)
+facade:ctor:Devolutions.PowerShell.Ffi.PowerShellValuePagerOptions::Void .ctor(Int32, Int32)
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt16 MajorVersion
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt16 MinorVersion
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt32 Directions
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt32 Reserved
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt32 Size
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt64 InterfaceIdHigh
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt64 InterfaceIdLow
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor* Contracts
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::IntPtr CreatePayloadProxy
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::IntPtr ReleasePayloadProxy
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::UInt32 AbiVersion
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::UInt32 ContractCount
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::UIntPtr Size
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection ConsumerToSession
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection None
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection PayloadToConsumer
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectTestContracts::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract Count
+facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectTestContracts::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract SessionCreatorBroker
 facade:field:Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission::Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission HostInteraction
 facade:field:Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission::Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission None
 facade:field:Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission::Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission Read
 facade:field:Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission::Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission Report
 facade:field:Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission::Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission Write
-facade:method:Devolutions.PowerShell.Ffi.IPowerShellCapabilityHandler::Devolutions.PowerShell.Ffi.PowerShellValue Invoke(Devolutions.PowerShell.Ffi.PowerShellCapabilityInvocation, System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValue])
-facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell WithCapabilities(Devolutions.PowerShell.Ffi.PowerShellCapabilitySet)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellCapabilitySet::Devolutions.PowerShell.Ffi.PowerShellCapabilitySet Register(System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding])
-facade:method:Devolutions.PowerShell.Ffi.PowerShellCapabilitySet::Void Dispose()
-facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellCapabilitySet RegisterCapabilities(System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding])
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityArgumentSchema::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValueKind] AllowedKinds
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding::Devolutions.PowerShell.Ffi.IPowerShellCapabilityHandler Handler
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition Definition
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission Permissions
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::Int32 MaximumInputBytes
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::Int32 MaximumOutputBytes
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellCapabilityArgumentSchema] Arguments
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValueKind] ResponseKinds
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::System.String Name
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::System.TimeSpan Deadline
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityInvocation::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition Definition
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityInvocation::System.Threading.CancellationToken CancellationToken
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityInvocation::UInt64 InvocationId
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilitySet::System.Collections.Generic.IReadOnlyCollection`1[Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition] Definitions
-facade:property:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition PromptChoice
-facade:property:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition PromptMultipleChoice
-facade:property:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition ReadLine
-facade:property:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition ReportProgress
-facade:property:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition WriteText
-facade:type:Devolutions.PowerShell.Ffi.IPowerShellCapabilityHandler
-facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilityArgumentSchema
-facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding
-facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition
-facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilityInvocation
-facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission
-facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilitySet
-facade:type:Devolutions.PowerShell.Ffi.PowerShellHostInteraction
-native:multi_pwsh_capability_register
-native:multi_pwsh_capability_release
-native:multi_pwsh_set_capabilities
-bindings:FfiPowerShellSession_RemoveVariable
-bindings:FfiPowerShellSession_Release
-bindings:FfiPowerShellSession_SetVariable
-facade:type:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy
-facade:ctor:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy::Void .ctor(System.Collections.Generic.IEnumerable`1[System.String], Boolean, Int32, Int32)
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy::System.Collections.Generic.IReadOnlyList`1[System.String] AllowedCommands
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy::Boolean AllowsScripts
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy::Int32 MaximumParameters
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy::Int32 MaximumScriptBytes
-facade:type:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe
-facade:ctor:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe::Void .ctor(System.String, System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue]], Devolutions.PowerShell.Ffi.PowerShellResultSchema, System.Nullable`1[System.TimeSpan])
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe::System.String Command
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe::System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue] Parameters
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe::Devolutions.PowerShell.Ffi.PowerShellResultSchema ResultSchema
-facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe::System.Nullable`1[System.TimeSpan] Timeout
-facade:type:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot
-facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Debug
-facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Errors
-facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Information
-facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::Boolean IsComplete
-facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Output
-facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.String OutputText
-facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Progress
-facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Verbose
-facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Warnings
-facade:method:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellProgressUpdate ParseProgressUpdate(Devolutions.PowerShell.Ffi.PowerShellValue)
-facade:type:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate
-facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::System.String Activity
-facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::Int64 ActivityId
-facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::System.String CurrentOperation
-facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::Boolean IsCompleted
-facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::Int64 ParentActivityId
-facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::Int32 PercentComplete
-facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::Int64 SecondsRemaining
-facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::System.String StatusDescription
-facade:type:Devolutions.PowerShell.Ffi.PowerShellResultSchema
-facade:ctor:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Void .ctor(Int32, Int32, System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellValueKind], System.Collections.Generic.IEnumerable`1[System.String], Boolean, Boolean)
-facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValueKind] AllowedScalarKinds
-facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Int32 MaximumOutputRecords
-facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Int32 MinimumOutputRecords
-facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Boolean RequireCompleteSnapshots
-facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::System.Collections.Generic.IReadOnlyList`1[System.String] RequiredPropertyNames
-facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Boolean RequireNoErrors
-facade:method:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Void Validate(Devolutions.PowerShell.Ffi.PowerShellInvocationResult)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellInvocationResult Invoke(Devolutions.PowerShell.Ffi.PowerShellCommandRecipe, Devolutions.PowerShell.Ffi.PowerShellCommandPolicy)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellInvocationResult Invoke(Devolutions.PowerShell.Ffi.PowerShellScriptRecipe, Devolutions.PowerShell.Ffi.PowerShellCommandPolicy)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::System.Threading.Tasks.Task`1[Devolutions.PowerShell.Ffi.PowerShellInvocationResult] InvokeAsync(Devolutions.PowerShell.Ffi.PowerShellCommandRecipe, Devolutions.PowerShell.Ffi.PowerShellCommandPolicy, System.Threading.CancellationToken)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::System.Threading.Tasks.Task`1[Devolutions.PowerShell.Ffi.PowerShellInvocationResult] InvokeAsync(Devolutions.PowerShell.Ffi.PowerShellScriptRecipe, Devolutions.PowerShell.Ffi.PowerShellCommandPolicy, System.Threading.CancellationToken)
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.Collections.Generic.IReadOnlyList`1[System.String] Aliases
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata] ParameterSets
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellScriptValidationMetadata] Validations
-facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata::System.String Name
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata::System.Nullable`1[System.Int64] Position
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata::Boolean ValueFromPipeline
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata::Boolean ValueFromPipelineByPropertyName
-facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptRecipe
-facade:ctor:Devolutions.PowerShell.Ffi.PowerShellScriptRecipe::Void .ctor(System.String, Devolutions.PowerShell.Ffi.PowerShellResultSchema, System.Nullable`1[System.TimeSpan])
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptRecipe::Devolutions.PowerShell.Ffi.PowerShellResultSchema ResultSchema
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptRecipe::System.String Script
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptRecipe::System.Nullable`1[System.TimeSpan] Timeout
-facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptValidationMetadata
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptValidationMetadata::System.Collections.Generic.IReadOnlyList`1[System.String] Arguments
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptValidationMetadata::System.String Name
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void SetPropertyBag(System.String, System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue]])
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Boolean TryGetPropertyBag(System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue] ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Devolutions.PowerShell.Ffi.PowerShellSessionScriptResult InvokeAndReadVariable(Devolutions.PowerShell.Ffi.PowerShellScriptRecipe, System.String, Devolutions.PowerShell.Ffi.PowerShellCommandPolicy)
-facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionScriptResult
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionScriptResult::Boolean HasValue
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionScriptResult::Devolutions.PowerShell.Ffi.PowerShellInvocationResult Invocation
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionScriptResult::Devolutions.PowerShell.Ffi.PowerShellValue Value
-facade:type:Devolutions.PowerShell.Ffi.PowerShellSnapshotReader
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSnapshotReader::System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue] GetCompleteProperties(Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSnapshotReader::Boolean TryGetProperty(Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot, System.String, Devolutions.PowerShell.Ffi.PowerShellValue ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSnapshotReader::Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot CreateDisplaySnapshot(Devolutions.PowerShell.Ffi.PowerShellInvocationResult)
-facade:ctor:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::Void .ctor(System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue]], System.Collections.Generic.IEnumerable`1[System.String], System.Collections.Generic.IEnumerable`1[System.String], System.String, System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,System.String]], Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy)
-facade:ctor:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Void .ctor(Devolutions.PowerShell.Ffi.PowerShellRunspaceMode, Devolutions.PowerShell.Ffi.PowerShellSessionInitialConfiguration, Devolutions.PowerShell.Ffi.PowerShellSessionHistoryMode, Devolutions.PowerShell.Ffi.PowerShellSessionPreference, Devolutions.PowerShell.Ffi.PowerShellSessionPreference, Devolutions.PowerShell.Ffi.PowerShellSessionPreference, Devolutions.PowerShell.Ffi.PowerShellSessionPreference, Devolutions.PowerShell.Ffi.PowerShellSessionPreference, System.String, Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration)
-facade:ctor:Devolutions.PowerShell.Ffi.PowerShellSessionPoolOptions::Void .ctor(UInt32, UInt32)
+facade:field:Devolutions.PowerShell.Ffi.PowerShellDtoProjection::System.String VersionMemberName
+facade:field:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure InvalidRoot
+facade:field:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure InvalidValue
+facade:field:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure InvalidVersion
+facade:field:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure MissingMember
+facade:field:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure UnknownMember
+facade:field:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure ValueTooLarge
 facade:field:Devolutions.PowerShell.Ffi.PowerShellFfiStatus::Devolutions.PowerShell.Ffi.PowerShellFfiStatus Backpressure
 facade:field:Devolutions.PowerShell.Ffi.PowerShellFfiStatus::Devolutions.PowerShell.Ffi.PowerShellFfiStatus BufferTooSmall
 facade:field:Devolutions.PowerShell.Ffi.PowerShellFfiStatus::Devolutions.PowerShell.Ffi.PowerShellFfiStatus HostFailure
@@ -172,9 +132,6 @@ facade:field:Devolutions.PowerShell.Ffi.PowerShellFfiStatus::Devolutions.PowerSh
 facade:field:Devolutions.PowerShell.Ffi.PowerShellFfiStatus::Devolutions.PowerShell.Ffi.PowerShellFfiStatus OperationNotTerminal
 facade:field:Devolutions.PowerShell.Ffi.PowerShellFfiStatus::Devolutions.PowerShell.Ffi.PowerShellFfiStatus Panic
 facade:field:Devolutions.PowerShell.Ffi.PowerShellFfiStatus::Devolutions.PowerShell.Ffi.PowerShellFfiStatus Success
-facade:field:Devolutions.PowerShell.Ffi.PowerShellSecretTransferPolicy::Devolutions.PowerShell.Ffi.PowerShellSecretTransferPolicy Rejected
-facade:field:Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy::Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy Default
-facade:field:Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy::Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy Restricted
 facade:field:Devolutions.PowerShell.Ffi.PowerShellFfiStatus::Devolutions.PowerShell.Ffi.PowerShellFfiStatus UnsupportedCapability
 facade:field:Devolutions.PowerShell.Ffi.PowerShellFfiStatus::Devolutions.PowerShell.Ffi.PowerShellFfiStatus UnsupportedValue
 facade:field:Devolutions.PowerShell.Ffi.PowerShellInvocationState::Devolutions.PowerShell.Ffi.PowerShellInvocationState Completed
@@ -186,6 +143,9 @@ facade:field:Devolutions.PowerShell.Ffi.PowerShellOperationState::Devolutions.Po
 facade:field:Devolutions.PowerShell.Ffi.PowerShellOperationState::Devolutions.PowerShell.Ffi.PowerShellOperationState Running
 facade:field:Devolutions.PowerShell.Ffi.PowerShellRunspaceMode::Devolutions.PowerShell.Ffi.PowerShellRunspaceMode CurrentRunspace
 facade:field:Devolutions.PowerShell.Ffi.PowerShellRunspaceMode::Devolutions.PowerShell.Ffi.PowerShellRunspaceMode NewRunspace
+facade:field:Devolutions.PowerShell.Ffi.PowerShellSecretTransferPolicy::Devolutions.PowerShell.Ffi.PowerShellSecretTransferPolicy Rejected
+facade:field:Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy::Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy Default
+facade:field:Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy::Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy Restricted
 facade:field:Devolutions.PowerShell.Ffi.PowerShellSessionHistoryMode::Devolutions.PowerShell.Ffi.PowerShellSessionHistoryMode Disabled
 facade:field:Devolutions.PowerShell.Ffi.PowerShellSessionHistoryMode::Devolutions.PowerShell.Ffi.PowerShellSessionHistoryMode Enabled
 facade:field:Devolutions.PowerShell.Ffi.PowerShellSessionInitialConfiguration::Devolutions.PowerShell.Ffi.PowerShellSessionInitialConfiguration ConstrainedLanguage
@@ -207,6 +167,9 @@ facade:field:Devolutions.PowerShell.Ffi.PowerShellStreamKind::Devolutions.PowerS
 facade:field:Devolutions.PowerShell.Ffi.PowerShellStreamKind::Devolutions.PowerShell.Ffi.PowerShellStreamKind Progress
 facade:field:Devolutions.PowerShell.Ffi.PowerShellStreamKind::Devolutions.PowerShell.Ffi.PowerShellStreamKind Verbose
 facade:field:Devolutions.PowerShell.Ffi.PowerShellStreamKind::Devolutions.PowerShell.Ffi.PowerShellStreamKind Warning
+facade:field:Devolutions.PowerShell.Ffi.PowerShellValue::Int32 MaximumContainerEntries
+facade:field:Devolutions.PowerShell.Ffi.PowerShellValue::Int32 MaximumDepth
+facade:field:Devolutions.PowerShell.Ffi.PowerShellValue::Int32 MaximumPayloadLength
 facade:field:Devolutions.PowerShell.Ffi.PowerShellValueKind::Devolutions.PowerShell.Ffi.PowerShellValueKind Array
 facade:field:Devolutions.PowerShell.Ffi.PowerShellValueKind::Devolutions.PowerShell.Ffi.PowerShellValueKind Boolean
 facade:field:Devolutions.PowerShell.Ffi.PowerShellValueKind::Devolutions.PowerShell.Ffi.PowerShellValueKind Bytes
@@ -222,6 +185,29 @@ facade:field:Devolutions.PowerShell.Ffi.PowerShellValueKind::Devolutions.PowerSh
 facade:field:Devolutions.PowerShell.Ffi.PowerShellValueKind::Devolutions.PowerShell.Ffi.PowerShellValueKind Switch
 facade:field:Devolutions.PowerShell.Ffi.PowerShellValueKind::Devolutions.PowerShell.Ffi.PowerShellValueKind UnsignedInteger
 facade:field:Devolutions.PowerShell.Ffi.PowerShellValueKind::Devolutions.PowerShell.Ffi.PowerShellValueKind Uri
+facade:method:Devolutions.PowerShell.Ffi.IPowerShellCapabilityHandler::Devolutions.PowerShell.Ffi.PowerShellValue Invoke(Devolutions.PowerShell.Ffi.PowerShellCapabilityInvocation, System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValue])
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetDescription(System.String ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetGroup(System.String ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetHost(System.String ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetIdentity(Int64 ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetName(System.String ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetValue(Int64 ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 SetDescription(System.String)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 SetGroup(System.String)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 SetHost(System.String)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 SetName(System.String)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 SetValue(Int64)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChildCollection::Int32 GetAt(Int32, Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChildCollection::Int32 GetCount(Int32 ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 Add(System.String, Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 GetChildren(Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChildCollection ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 GetCount(Int64 ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 GetPrimary(Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 Increment(Int64 ByRef)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Boolean Equals(Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Boolean Equals(System.Object)
+facade:method:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Int32 GetHashCode()
+facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell AddArgument(Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe)
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell AddArgument(Devolutions.PowerShell.Ffi.PowerShellValue)
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell AddArgument(System.String)
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell AddArguments(System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellValue])
@@ -241,37 +227,94 @@ facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell CompleteInput()
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell Create()
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell ResetInput()
+facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell WithCapabilities(Devolutions.PowerShell.Ffi.PowerShellCapabilitySet)
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShellInvocationOperation BeginInvoke()
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShellInvocationResult Invoke()
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShellInvocationResult InvokeWithDiagnostics()
+facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShellTypedResultInvocation BeginTypedResultInvocation(Devolutions.PowerShell.Ffi.PowerShellValuePagerOptions)
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::System.String InvokeText()
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::System.Threading.Tasks.Task`1[Devolutions.PowerShell.Ffi.PowerShellInvocationResult] InvokeAsync(System.Threading.CancellationToken)
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Void Dispose()
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Void Initialize()
+facade:method:Devolutions.PowerShell.Ffi.PowerShell::Void Initialize(System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
+facade:method:Devolutions.PowerShell.Ffi.PowerShell::Void Initialize(System.String, System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Void Initialize(System.String)
 facade:method:Devolutions.PowerShell.Ffi.PowerShell::Void Stop()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellCapabilitySet::Devolutions.PowerShell.Ffi.PowerShellCapabilitySet Register(System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellCapabilitySet::Void Dispose()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellDtoProjection::Boolean TryGetMember(System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue], System.String, Boolean, System.String, Devolutions.PowerShell.Ffi.PowerShellValue ByRef, Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellDtoProjection::Boolean TryGetPropertyBag(Devolutions.PowerShell.Ffi.PowerShellValue, Int32, Boolean, System.Collections.Generic.IReadOnlySet`1[System.String], System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue] ByRef, Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellDtoProjection::Boolean TryReadArray(Devolutions.PowerShell.Ffi.PowerShellValue, Int32, System.String, System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValue] ByRef, Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellDtoProjection::Boolean TryReadString(Devolutions.PowerShell.Ffi.PowerShellValue, Int32, System.String, System.String ByRef, Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellDtoProjection::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError InvalidValue(System.String, System.String)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellDtoProjection::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError ValueTooLarge(System.String, System.String)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellDtoProjection::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionException CreateException(Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellDtoProjection::Devolutions.PowerShell.Ffi.PowerShellValue CreatePropertyBag(Int32, System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue]])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellDtoProjection::System.String JoinPath(System.String, System.String)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellProgressUpdate ParseProgressUpdate(Devolutions.PowerShell.Ffi.PowerShellValue)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellInvocationOperation::Devolutions.PowerShell.Ffi.PowerShellInvocationOperationStatus Poll()
 facade:method:Devolutions.PowerShell.Ffi.PowerShellInvocationOperation::Devolutions.PowerShell.Ffi.PowerShellInvocationOperationStatus Wait(System.TimeSpan)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellInvocationOperation::Devolutions.PowerShell.Ffi.PowerShellInvocationResult GetResult()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellInvocationOperation::Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch ReadStreamBatch(UInt64, Int32)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellInvocationOperation::System.Threading.Tasks.Task`1[Devolutions.PowerShell.Ffi.PowerShellInvocationResult] GetResultAsync(System.Threading.CancellationToken)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellInvocationOperation::Void Dispose()
 facade:method:Devolutions.PowerShell.Ffi.PowerShellInvocationOperation::Void Stop()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1::Void Dispose()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe::Int64 Increment()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe::Void Dispose()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Void Validate(Devolutions.PowerShell.Ffi.PowerShellInvocationResult)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShell Create()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellCapabilitySet RegisterCapabilities(System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellInvocationResult Invoke(Devolutions.PowerShell.Ffi.PowerShellCommandRecipe, Devolutions.PowerShell.Ffi.PowerShellCommandPolicy)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellInvocationResult Invoke(Devolutions.PowerShell.Ffi.PowerShellScriptRecipe, Devolutions.PowerShell.Ffi.PowerShellCommandPolicy)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe CreateLiveObjectProbe(Int64)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellRuntime Activate()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellRuntime Activate(System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellRuntime Activate(System.String, System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
 facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellRuntime Activate(System.String)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellScriptParseResult ParseScriptParameters(System.String)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellSession CreateSession(Devolutions.PowerShell.Ffi.PowerShellSessionOptions)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellSessionPool CreateSessionPool(Devolutions.PowerShell.Ffi.PowerShellSessionPoolOptions)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::System.Threading.Tasks.Task`1[Devolutions.PowerShell.Ffi.PowerShellInvocationResult] InvokeAsync(Devolutions.PowerShell.Ffi.PowerShellCommandRecipe, Devolutions.PowerShell.Ffi.PowerShellCommandPolicy, System.Threading.CancellationToken)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::System.Threading.Tasks.Task`1[Devolutions.PowerShell.Ffi.PowerShellInvocationResult] InvokeAsync(Devolutions.PowerShell.Ffi.PowerShellScriptRecipe, Devolutions.PowerShell.Ffi.PowerShellCommandPolicy, System.Threading.CancellationToken)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellScriptParser::Devolutions.PowerShell.Ffi.PowerShellScriptParseResult Parse(Devolutions.PowerShell.Ffi.PowerShellRuntime, System.String)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSecretTransfer::Void ThrowNotSupported()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Boolean RemoveVariable(System.String)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Boolean TryGetPropertyBag(System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue] ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Boolean TryGetVariable(System.String, Devolutions.PowerShell.Ffi.PowerShellValue ByRef)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Devolutions.PowerShell.Ffi.PowerShell CreatePowerShell()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Devolutions.PowerShell.Ffi.PowerShellSessionScriptResult InvokeAndReadVariable(Devolutions.PowerShell.Ffi.PowerShellScriptRecipe, System.String, Devolutions.PowerShell.Ffi.PowerShellCommandPolicy)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Devolutions.PowerShell.Ffi.PowerShellSessionSnapshot GetSnapshot()
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellSessionEvent] GetEvents()
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Boolean RemoveVariable(System.String)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Boolean TryGetVariable(System.String, Devolutions.PowerShell.Ffi.PowerShellValue ByRef)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void Dispose()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void SetLiveObjectVariable(System.String, Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void SetLiveObjectVariable[TContract](System.String, Devolutions.PowerShell.Ffi.PowerShellLiveObject`1[TContract])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void SetPropertyBag(System.String, System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue]])
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void SetVariable(System.String, Devolutions.PowerShell.Ffi.PowerShellValue)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Int64 Increment()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Void Dispose()
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSessionPool::Void Dispose()
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSecretTransfer::Void ThrowNotSupported()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSnapshotReader::Boolean TryGetProperty(Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot, System.String, Devolutions.PowerShell.Ffi.PowerShellValue ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSnapshotReader::Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot CreateDisplaySnapshot(Devolutions.PowerShell.Ffi.PowerShellInvocationResult)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSnapshotReader::System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue] GetCompleteProperties(Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSnapshotSerializer::Byte[] Serialize(Devolutions.PowerShell.Ffi.PowerShellInvocationResult)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSnapshotSerializer::Devolutions.PowerShell.Ffi.PowerShellInvocationResult Deserialize(System.ReadOnlySpan`1[System.Byte])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellTypedResultInvocation::Devolutions.PowerShell.Ffi.PowerShellValuePage Read(UInt64, System.Nullable`1[System.Int32])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellTypedResultInvocation::Void Dispose()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellTypedResultInvocation::Void Stop()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetBoolean(Boolean ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetBytes(Byte[] ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetDateTime(System.DateTime ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetDateTimeOffset(System.DateTimeOffset ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetDecimal(System.Decimal ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetDouble(Double ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetGuid(System.Guid ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetProperty(System.String, Devolutions.PowerShell.Ffi.PowerShellValue ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetSignedInteger(Int64 ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetString(System.String ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetSwitch(Boolean ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetUnsignedInteger(UInt64 ByRef)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetUri(System.Uri ByRef)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Devolutions.PowerShell.Ffi.PowerShellValue Array(System.Collections.Generic.IEnumerable`1[Devolutions.PowerShell.Ffi.PowerShellValue])
 facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Devolutions.PowerShell.Ffi.PowerShellValue Boolean(Boolean)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Devolutions.PowerShell.Ffi.PowerShellValue Bytes(Byte[])
@@ -287,24 +330,67 @@ facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Devolutions.PowerShell
 facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Devolutions.PowerShell.Ffi.PowerShellValue Switch(Boolean)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Devolutions.PowerShell.Ffi.PowerShellValue UnsignedInteger(UInt64)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Devolutions.PowerShell.Ffi.PowerShellValue Uri(System.Uri)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetBoolean(Boolean ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetBytes(Byte[] ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetDateTime(System.DateTime ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetDateTimeOffset(System.DateTimeOffset ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetDecimal(System.Decimal ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetDouble(Double ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetGuid(System.Guid ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetProperty(System.String, Devolutions.PowerShell.Ffi.PowerShellValue ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetSignedInteger(Int64 ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetString(System.String ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetSwitch(Boolean ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetUnsignedInteger(UInt64 ByRef)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean TryGetUri(System.Uri ByRef)
 facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue] GetPropertyBag()
 facade:method:Devolutions.PowerShell.Ffi.PowerShellValue::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValue] GetArray()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValuePager::Devolutions.PowerShell.Ffi.PowerShellValuePage Read(UInt64, System.Nullable`1[System.Int32])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValuePager::Devolutions.PowerShell.Ffi.PowerShellValuePagerCompletion GetCompletion()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValuePager::Void Acknowledge(UInt64)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValuePager::Void Complete(Devolutions.PowerShell.Ffi.PowerShellFfiStatus, System.String)
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValuePager::Void Dispose()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellValuePager::Void Write(Devolutions.PowerShell.Ffi.PowerShellValue, System.Threading.CancellationToken)
+facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection Directions
+facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::System.Guid InterfaceId
+facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::UInt16 MajorVersion
+facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::UInt16 MinorVersion
 facade:property:Devolutions.PowerShell.Ffi.PowerShell::UInt32 AbiVersion
 facade:property:Devolutions.PowerShell.Ffi.PowerShell::UInt64 FeatureFlags
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityArgumentSchema::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValueKind] AllowedKinds
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding::Devolutions.PowerShell.Ffi.IPowerShellCapabilityHandler Handler
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition Definition
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission Permissions
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::Int32 MaximumInputBytes
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::Int32 MaximumOutputBytes
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellCapabilityArgumentSchema] Arguments
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValueKind] ResponseKinds
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::System.String Name
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition::System.TimeSpan Deadline
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityInvocation::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition Definition
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityInvocation::System.Threading.CancellationToken CancellationToken
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilityInvocation::UInt64 InvocationId
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCapabilitySet::System.Collections.Generic.IReadOnlyCollection`1[Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition] Definitions
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy::Boolean AllowsScripts
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy::Int32 MaximumParameters
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy::Int32 MaximumScriptBytes
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy::System.Collections.Generic.IReadOnlyList`1[System.String] AllowedCommands
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe::Devolutions.PowerShell.Ffi.PowerShellResultSchema ResultSchema
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe::System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue] Parameters
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe::System.Nullable`1[System.TimeSpan] Timeout
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe::System.String Command
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::Boolean IsComplete
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Debug
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Errors
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Information
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Output
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Progress
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Verbose
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.Collections.Generic.IReadOnlyList`1[System.String] Warnings
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot::System.String OutputText
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDtoContractAttribute::Boolean RejectUnknownMembers
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDtoContractAttribute::Int32 Version
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDtoMemberAttribute::Boolean Required
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDtoMemberAttribute::Int32 MaximumCollectionCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDtoMemberAttribute::Int32 MaximumStringLength
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDtoMemberAttribute::System.String Name
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure Failure
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError::System.String Message
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError::System.String Path
+facade:property:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionException::Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError Error
 facade:property:Devolutions.PowerShell.Ffi.PowerShellFfiException::Devolutions.PowerShell.Ffi.PowerShellFfiStatus Status
+facade:property:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition PromptChoice
+facade:property:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition PromptMultipleChoice
+facade:property:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition ReadLine
+facade:property:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition ReportProgress
+facade:property:Devolutions.PowerShell.Ffi.PowerShellHostInteraction::Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition WriteText
 facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationError::Boolean IsTruncated
 facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationError::Devolutions.PowerShell.Ffi.PowerShellValue TargetValue
 facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationError::System.String Category
@@ -346,6 +432,25 @@ facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationResult::Devolutio
 facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationResult::Devolutions.PowerShell.Ffi.PowerShellStreamSnapshot`1[Devolutions.PowerShell.Ffi.PowerShellStreamRecord] Warnings
 facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationResult::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellStreamSequenceRecord] Sequence
 facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationResult::UInt64 InvocationId
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::Boolean IsCursorLost
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::Boolean IsTerminal
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::Boolean IsTruncated
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::Devolutions.PowerShell.Ffi.PowerShellFfiStatus TerminalStatus
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::Devolutions.PowerShell.Ffi.PowerShellOperationState State
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord] Records
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::UInt64 DroppedRecordCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::UInt64 LostRecordCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::UInt64 NextSequence
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::UInt64 SourceDroppedRecordCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::UInt64 TotalRecordCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord::Boolean IsTruncated
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord::Devolutions.PowerShell.Ffi.PowerShellStreamKind Stream
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord::System.String DisplayText
+facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord::UInt64 Sequence
+facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract Contract
+facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack::System.String PayloadAdapterAssemblyPath
+facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack::System.String PayloadAdapterTypeName
+facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe::Int64 Count
 facade:property:Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot::Boolean IsPropertyBagTruncated
 facade:property:Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot::Boolean IsTruncated
 facade:property:Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot::Devolutions.PowerShell.Ffi.PowerShellValue PropertyBag
@@ -357,13 +462,62 @@ facade:property:Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot::UInt32 Drop
 facade:property:Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot::UInt32 PropertyEntryCount
 facade:property:Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot::UInt32 TypeNameCount
 facade:property:Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot::UInt64 Sequence
+facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::Boolean IsCompleted
+facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::Int32 PercentComplete
+facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::Int64 ActivityId
+facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::Int64 ParentActivityId
+facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::Int64 SecondsRemaining
+facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::System.String Activity
+facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::System.String CurrentOperation
+facade:property:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate::System.String StatusDescription
+facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Boolean RequireCompleteSnapshots
+facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Boolean RequireNoErrors
+facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Int32 MaximumOutputRecords
+facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::Int32 MinimumOutputRecords
+facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValueKind] AllowedScalarKinds
+facade:property:Devolutions.PowerShell.Ffi.PowerShellResultSchema::System.Collections.Generic.IReadOnlyList`1[System.String] RequiredPropertyNames
 facade:property:Devolutions.PowerShell.Ffi.PowerShellRuntime::System.String PayloadDirectory
 facade:property:Devolutions.PowerShell.Ffi.PowerShellRuntime::UInt32 AbiVersion
 facade:property:Devolutions.PowerShell.Ffi.PowerShellRuntime::UInt64 FeatureFlags
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::Boolean IsMandatory
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata] ParameterSets
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellScriptValidationMetadata] Validations
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.Collections.Generic.IReadOnlyList`1[System.String] Aliases
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.Collections.Generic.IReadOnlyList`1[System.String] ValidateSetValues
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.String DefaultValueExpression
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.String Description
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.String HelpMessage
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.String Name
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.String TypeName
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata::Boolean ValueFromPipeline
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata::Boolean ValueFromPipelineByPropertyName
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata::System.Nullable`1[System.Int64] Position
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata::System.String Name
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseError::Int64 EndOffset
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseError::Int64 StartOffset
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseError::System.String ErrorId
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseError::System.String Message
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseResult::Boolean HasErrors
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseResult::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata] Parameters
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseResult::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellScriptParseError] Errors
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptRecipe::Devolutions.PowerShell.Ffi.PowerShellResultSchema ResultSchema
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptRecipe::System.Nullable`1[System.TimeSpan] Timeout
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptRecipe::System.String Script
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptValidationMetadata::System.Collections.Generic.IReadOnlyList`1[System.String] Arguments
+facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptValidationMetadata::System.String Name
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSecretTransfer::Devolutions.PowerShell.Ffi.PowerShellSecretTransferPolicy Policy
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy ExecutionPolicy
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue] InitialVariables
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.String] Environment
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::System.Collections.Generic.IReadOnlyList`1[System.String] AllowedModulePaths
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::System.Collections.Generic.IReadOnlyList`1[System.String] ModuleImports
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::System.String WorkingDirectory
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionEvent::Boolean IsTruncated
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionEvent::Devolutions.PowerShell.Ffi.PowerShellSessionState State
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionEvent::UInt64 Sequence
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Int64 Count
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Devolutions.PowerShell.Ffi.PowerShellRunspaceMode RunspaceMode
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration Configuration
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Devolutions.PowerShell.Ffi.PowerShellSessionHistoryMode HistoryMode
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Devolutions.PowerShell.Ffi.PowerShellSessionInitialConfiguration InitialConfiguration
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Devolutions.PowerShell.Ffi.PowerShellSessionPreference DebugPreference
@@ -372,16 +526,11 @@ facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Devolutions
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Devolutions.PowerShell.Ffi.PowerShellSessionPreference VerbosePreference
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Devolutions.PowerShell.Ffi.PowerShellSessionPreference WarningPreference
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::System.String AllowedModulePath
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionOptions::Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration Configuration
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSecretTransfer::Devolutions.PowerShell.Ffi.PowerShellSecretTransferPolicy Policy
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::System.Collections.Generic.IReadOnlyList`1[System.String] AllowedModulePaths
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.String] Environment
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy ExecutionPolicy
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::System.Collections.Generic.IReadOnlyDictionary`2[System.String,Devolutions.PowerShell.Ffi.PowerShellValue] InitialVariables
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::System.Collections.Generic.IReadOnlyList`1[System.String] ModuleImports
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration::System.String WorkingDirectory
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionPoolOptions::UInt32 MaximumSessions
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionPoolOptions::UInt32 MinimumSessions
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionScriptResult::Boolean HasValue
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionScriptResult::Devolutions.PowerShell.Ffi.PowerShellInvocationResult Invocation
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionScriptResult::Devolutions.PowerShell.Ffi.PowerShellValue Value
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionSnapshot::Boolean AreEventsTruncated
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionSnapshot::Devolutions.PowerShell.Ffi.PowerShellSessionState RunspaceState
 facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionSnapshot::Devolutions.PowerShell.Ffi.PowerShellSessionState State
@@ -399,48 +548,116 @@ facade:property:Devolutions.PowerShell.Ffi.PowerShellStreamSnapshot`1::Devolutio
 facade:property:Devolutions.PowerShell.Ffi.PowerShellStreamSnapshot`1::System.Collections.Generic.IReadOnlyList`1[T] Records
 facade:property:Devolutions.PowerShell.Ffi.PowerShellStreamSnapshot`1::UInt64 DroppedRecordCount
 facade:property:Devolutions.PowerShell.Ffi.PowerShellStreamSnapshot`1::UInt64 TotalRecordCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean IsNull
 facade:property:Devolutions.PowerShell.Ffi.PowerShellValue::Devolutions.PowerShell.Ffi.PowerShellValue Null
 facade:property:Devolutions.PowerShell.Ffi.PowerShellValue::Devolutions.PowerShell.Ffi.PowerShellValueKind Kind
-facade:property:Devolutions.PowerShell.Ffi.PowerShellValue::Boolean IsNull
 facade:property:Devolutions.PowerShell.Ffi.PowerShellValueConversionException::System.Type SourceType
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePage::Boolean IsComplete
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePage::Boolean IsTerminal
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePage::Boolean IsTruncated
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePage::Devolutions.PowerShell.Ffi.PowerShellFfiStatus TerminalStatus
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePage::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellValuePageRecord] Records
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePage::UInt64 AcknowledgedSequence
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePage::UInt64 DroppedRecordCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePage::UInt64 NextSequence
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePage::UInt64 TotalRecordCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePagerCompletion::Boolean IsComplete
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePagerCompletion::Boolean IsTruncated
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePagerCompletion::Devolutions.PowerShell.Ffi.PowerShellFfiStatus TerminalStatus
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePagerCompletion::System.String Diagnostic
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePagerCompletion::UInt64 AcknowledgedRecordCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePagerCompletion::UInt64 DroppedRecordCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePagerCompletion::UInt64 TotalRecordCount
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePageRecord::Devolutions.PowerShell.Ffi.PowerShellValue Value
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePageRecord::UInt64 Sequence
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePagerOptions::Int32 MaximumBufferedRecords
+facade:property:Devolutions.PowerShell.Ffi.PowerShellValuePagerOptions::Int32 MaximumPageRecords
+facade:type:Devolutions.PowerShell.Ffi.IPowerShellCapabilityHandler
+facade:type:Devolutions.PowerShell.Ffi.IPowerShellLiveObjectBroker
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChildCollection
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection
+facade:type:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectTestContracts
 facade:type:Devolutions.PowerShell.Ffi.PowerShell
+facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilityArgumentSchema
+facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilityBinding
+facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilityDefinition
+facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilityInvocation
+facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilityPermission
+facade:type:Devolutions.PowerShell.Ffi.PowerShellCapabilitySet
+facade:type:Devolutions.PowerShell.Ffi.PowerShellCommandPolicy
+facade:type:Devolutions.PowerShell.Ffi.PowerShellCommandRecipe
+facade:type:Devolutions.PowerShell.Ffi.PowerShellDisplaySnapshot
+facade:type:Devolutions.PowerShell.Ffi.PowerShellDtoContractAttribute
+facade:type:Devolutions.PowerShell.Ffi.PowerShellDtoMemberAttribute
+facade:type:Devolutions.PowerShell.Ffi.PowerShellDtoProjection
+facade:type:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionError
+facade:type:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionException
+facade:type:Devolutions.PowerShell.Ffi.PowerShellDtoProjectionFailure
 facade:type:Devolutions.PowerShell.Ffi.PowerShellFfiException
 facade:type:Devolutions.PowerShell.Ffi.PowerShellFfiStatus
+facade:type:Devolutions.PowerShell.Ffi.PowerShellHostInteraction
 facade:type:Devolutions.PowerShell.Ffi.PowerShellInvocationError
 facade:type:Devolutions.PowerShell.Ffi.PowerShellInvocationException
 facade:type:Devolutions.PowerShell.Ffi.PowerShellInvocationOperation
 facade:type:Devolutions.PowerShell.Ffi.PowerShellInvocationOperationStatus
 facade:type:Devolutions.PowerShell.Ffi.PowerShellInvocationResult
 facade:type:Devolutions.PowerShell.Ffi.PowerShellInvocationState
+facade:type:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch
+facade:type:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord
+facade:type:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1
+facade:type:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack
+facade:type:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe
 facade:type:Devolutions.PowerShell.Ffi.PowerShellObjectSnapshot
 facade:type:Devolutions.PowerShell.Ffi.PowerShellOperationState
+facade:type:Devolutions.PowerShell.Ffi.PowerShellProgressUpdate
+facade:type:Devolutions.PowerShell.Ffi.PowerShellResultSchema
 facade:type:Devolutions.PowerShell.Ffi.PowerShellRunspaceMode
 facade:type:Devolutions.PowerShell.Ffi.PowerShellRuntime
-facade:type:Devolutions.PowerShell.Ffi.PowerShellSession
+facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata
+facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParameterSetMetadata
+facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParseError
+facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParser
+facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParseResult
+facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptRecipe
+facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptValidationMetadata
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSecretTransfer
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSecretTransferNotSupportedException
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSecretTransferPolicy
+facade:type:Devolutions.PowerShell.Ffi.PowerShellSession
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionConfiguration
-facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionEvent
+facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionExecutionPolicy
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionHistoryMode
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionInitialConfiguration
+facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionOptions
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionPool
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionPoolOptions
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionPreference
+facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionScriptResult
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionSnapshot
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionState
+facade:type:Devolutions.PowerShell.Ffi.PowerShellSnapshotReader
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSnapshotSerializer
 facade:type:Devolutions.PowerShell.Ffi.PowerShellStreamKind
 facade:type:Devolutions.PowerShell.Ffi.PowerShellStreamRecord
 facade:type:Devolutions.PowerShell.Ffi.PowerShellStreamSequenceRecord
 facade:type:Devolutions.PowerShell.Ffi.PowerShellStreamSnapshot`1
+facade:type:Devolutions.PowerShell.Ffi.PowerShellTypedResultInvocation
 facade:type:Devolutions.PowerShell.Ffi.PowerShellValue
 facade:type:Devolutions.PowerShell.Ffi.PowerShellValueConversionException
 facade:type:Devolutions.PowerShell.Ffi.PowerShellValueKind
-native:multi_pwsh_get_abi_info
-native:multi_pwsh_get_payload_path_utf8
+facade:type:Devolutions.PowerShell.Ffi.PowerShellValuePage
+facade:type:Devolutions.PowerShell.Ffi.PowerShellValuePager
+facade:type:Devolutions.PowerShell.Ffi.PowerShellValuePagerCompletion
+facade:type:Devolutions.PowerShell.Ffi.PowerShellValuePageRecord
+facade:type:Devolutions.PowerShell.Ffi.PowerShellValuePagerOptions
+native:multi_pwsh_add_argument_live_object
 native:multi_pwsh_add_argument_utf8
 native:multi_pwsh_add_argument_value
 native:multi_pwsh_add_command_utf8
@@ -453,20 +670,35 @@ native:multi_pwsh_add_parameter_value
 native:multi_pwsh_add_script_utf8
 native:multi_pwsh_add_script_utf8_local
 native:multi_pwsh_add_statement
+native:multi_pwsh_begin_typed_result_invocation
+native:multi_pwsh_capability_register
+native:multi_pwsh_capability_release
 native:multi_pwsh_clear
 native:multi_pwsh_complete_input
 native:multi_pwsh_copy_invocation_error_field_utf8
 native:multi_pwsh_create
+native:multi_pwsh_get_abi_info
 native:multi_pwsh_get_invocation_error_count
+native:multi_pwsh_get_payload_path_utf8
 native:multi_pwsh_initialize_from_path
+native:multi_pwsh_initialize_from_path_with_contract_packs
 native:multi_pwsh_initialize_utf8
+native:multi_pwsh_initialize_with_contract_packs_utf8
 native:multi_pwsh_invoke
 native:multi_pwsh_invoke_async
 native:multi_pwsh_invoke_utf8
+native:multi_pwsh_live_object_probe_create
+native:multi_pwsh_live_object_probe_release
+native:multi_pwsh_live_object_probe_unregister
 native:multi_pwsh_operation_get_result
 native:multi_pwsh_operation_poll
+native:multi_pwsh_operation_read_stream_batch
 native:multi_pwsh_operation_release
 native:multi_pwsh_operation_stop
+native:multi_pwsh_operation_stream_batch_copy_record_text_utf8
+native:multi_pwsh_operation_stream_batch_get_info
+native:multi_pwsh_operation_stream_batch_get_record_info
+native:multi_pwsh_operation_stream_batch_release
 native:multi_pwsh_operation_wait
 native:multi_pwsh_release
 native:multi_pwsh_reset_input
@@ -485,156 +717,18 @@ native:multi_pwsh_session_create_builder
 native:multi_pwsh_session_get_event_info
 native:multi_pwsh_session_get_snapshot
 native:multi_pwsh_session_get_variable_snapshot
-native:multi_pwsh_session_remove_variable
 native:multi_pwsh_session_pool_create
 native:multi_pwsh_session_release
-native:multi_pwsh_session_set_variable
-native:multi_pwsh_stop
-facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellScriptParseResult ParseScriptParameters(System.String)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellScriptParser::Devolutions.PowerShell.Ffi.PowerShellScriptParseResult Parse(Devolutions.PowerShell.Ffi.PowerShellRuntime, System.String)
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::Boolean IsMandatory
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.Collections.Generic.IReadOnlyList`1[System.String] ValidateSetValues
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.String DefaultValueExpression
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.String Description
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.String HelpMessage
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.String Name
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata::System.String TypeName
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseError::Int64 EndOffset
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseError::Int64 StartOffset
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseError::System.String ErrorId
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseError::System.String Message
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseResult::Boolean HasErrors
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseResult::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata] Parameters
-facade:property:Devolutions.PowerShell.Ffi.PowerShellScriptParseResult::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellScriptParseError] Errors
-facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParameterMetadata
-facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParseError
-facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParser
-facade:type:Devolutions.PowerShell.Ffi.PowerShellScriptParseResult
-bindings:FfiLiveObjectContractPack_Register
-bindings:FfiLiveObjectContractPack_RegisterMany
-bindings:FfiLiveObjectProbe_Create
-bindings:FfiLiveObjectProbe_Release
-bindings:FfiLiveObjectProbe_Unregister
-bindings:FfiPowerShell_AddArgumentLiveObject
-bindings:FfiPowerShellSession_SetLiveObjectContractVariable
-bindings:FfiPowerShellSession_SetLiveObjectVariable
-facade:ctor:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Void .ctor(System.Guid, UInt16, UInt16, Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection)
-facade:ctor:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1::Void .ctor(Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract, TContract)
-facade:ctor:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack::Void .ctor(System.String, System.String)
-facade:ctor:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Void .ctor(Int64)
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt16 MajorVersion
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt16 MinorVersion
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt32 Directions
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt32 Reserved
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt32 Size
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt64 InterfaceIdHigh
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor::UInt64 InterfaceIdLow
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor* Contracts
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::IntPtr CreatePayloadProxy
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::IntPtr ReleasePayloadProxy
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::UInt32 AbiVersion
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::UInt32 ContractCount
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi::UIntPtr Size
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection ConsumerToSession
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection None
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection PayloadToConsumer
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectTestContracts::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract Count
-facade:field:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectTestContracts::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract SessionCreatorBroker
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetDescription(System.String ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetGroup(System.String ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetHost(System.String ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetIdentity(Int64 ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetName(System.String ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 GetValue(Int64 ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 SetDescription(System.String)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 SetGroup(System.String)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 SetHost(System.String)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 SetName(System.String)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild::Int32 SetValue(Int64)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChildCollection::Int32 GetAt(Int32, Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChildCollection::Int32 GetCount(Int32 ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 Add(System.String, Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 GetCount(Int64 ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 GetChildren(Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChildCollection ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 GetPrimary(Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount::Int32 Increment(Int64 ByRef)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Boolean Equals(Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Boolean Equals(System.Object)
-facade:method:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Int32 GetHashCode()
-facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShell AddArgument(Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe)
-facade:method:Devolutions.PowerShell.Ffi.PowerShell::Void Initialize(System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
-facade:method:Devolutions.PowerShell.Ffi.PowerShell::Void Initialize(System.String, System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
-facade:method:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1::Void Dispose()
-facade:method:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe::Int64 Increment()
-facade:method:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe::Void Dispose()
-facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe CreateLiveObjectProbe(Int64)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellRuntime Activate(System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
-facade:method:Devolutions.PowerShell.Ffi.PowerShellRuntime::Devolutions.PowerShell.Ffi.PowerShellRuntime Activate(System.String, System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack])
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void SetLiveObjectVariable(System.String, Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe)
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void SetLiveObjectVariable[TContract](System.String, Devolutions.PowerShell.Ffi.PowerShellLiveObject`1[TContract])
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Int64 Increment()
-facade:method:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Void Dispose()
-facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection Directions
-facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::System.Guid InterfaceId
-facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::UInt16 MajorVersion
-facade:property:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract::UInt16 MinorVersion
-facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1::Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract Contract
-facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack::System.String PayloadAdapterAssemblyPath
-facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack::System.String PayloadAdapterTypeName
-facade:property:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe::Int64 Count
-facade:property:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe::Int64 Count
-facade:type:Devolutions.PowerShell.Ffi.IPowerShellLiveObjectBroker
-facade:type:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChild
-facade:type:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestChildCollection
-facade:type:Devolutions.PowerShell.Ffi.LiveObjects.IPowerShellLiveObjectTestCount
-facade:type:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor
-facade:type:Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractPackApi
-facade:type:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectContract
-facade:type:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectDirection
-facade:type:Devolutions.PowerShell.Ffi.LiveObjects.PowerShellLiveObjectTestContracts
-facade:type:Devolutions.PowerShell.Ffi.PowerShellLiveObject`1
-facade:type:Devolutions.PowerShell.Ffi.PowerShellLiveObjectContractPack
-facade:type:Devolutions.PowerShell.Ffi.PowerShellLiveObjectProbe
-facade:type:Devolutions.PowerShell.Ffi.PowerShellSessionObjectProbe
-native:multi_pwsh_add_argument_live_object
-native:multi_pwsh_initialize_from_path_with_contract_packs
-native:multi_pwsh_initialize_with_contract_packs_utf8
-native:multi_pwsh_live_object_probe_create
-native:multi_pwsh_live_object_probe_release
-native:multi_pwsh_live_object_probe_unregister
+native:multi_pwsh_session_remove_variable
 native:multi_pwsh_session_set_live_object_contract_variable
 native:multi_pwsh_session_set_live_object_variable
-bindings:Bindings_GetFfiApiV3
-bindings:FfiLiveInvocationBatch_CopyRecordTextToUtf8
-bindings:FfiLiveInvocationBatch_GetInfo
-bindings:FfiLiveInvocationBatch_GetRecordInfo
-bindings:FfiLiveInvocationBatch_Release
-bindings:FfiLiveInvocation_Complete
-bindings:FfiLiveInvocation_Poll
-bindings:FfiLiveInvocation_ReadBatch
-bindings:FfiLiveInvocation_Release
-bindings:FfiLiveInvocation_Stop
-bindings:FfiPowerShell_BeginLiveInvocation
-facade:method:Devolutions.PowerShell.Ffi.PowerShellInvocationOperation::Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch ReadStreamBatch(UInt64, Int32)
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::Boolean IsCursorLost
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::Boolean IsTerminal
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::Boolean IsTruncated
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::Devolutions.PowerShell.Ffi.PowerShellFfiStatus TerminalStatus
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::Devolutions.PowerShell.Ffi.PowerShellOperationState State
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::System.Collections.Generic.IReadOnlyList`1[Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord] Records
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::UInt64 DroppedRecordCount
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::UInt64 LostRecordCount
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::UInt64 NextSequence
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::UInt64 SourceDroppedRecordCount
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch::UInt64 TotalRecordCount
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord::Boolean IsTruncated
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord::Devolutions.PowerShell.Ffi.PowerShellStreamKind Stream
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord::System.String DisplayText
-facade:property:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord::UInt64 Sequence
-facade:type:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamBatch
-facade:type:Devolutions.PowerShell.Ffi.PowerShellInvocationStreamRecord
-native:multi_pwsh_operation_read_stream_batch
-native:multi_pwsh_operation_stream_batch_copy_record_text_utf8
-native:multi_pwsh_operation_stream_batch_get_info
-native:multi_pwsh_operation_stream_batch_get_record_info
-native:multi_pwsh_operation_stream_batch_release
+native:multi_pwsh_session_set_variable
+native:multi_pwsh_set_capabilities
+native:multi_pwsh_stop
+native:multi_pwsh_typed_result_invocation_read_page
+native:multi_pwsh_typed_result_invocation_release
+native:multi_pwsh_typed_result_invocation_stop
+native:multi_pwsh_typed_result_page_copy_record_value
+native:multi_pwsh_typed_result_page_get_info
+native:multi_pwsh_typed_result_page_get_record_info
+native:multi_pwsh_typed_result_page_release

--- a/tests/PwshFfiApiBaselineInspector/Program.cs
+++ b/tests/PwshFfiApiBaselineInspector/Program.cs
@@ -76,6 +76,7 @@ NativeImportInspection[] nativeImports = nativeMethodsType.GetMethods(StaticNonP
     .ToArray();
 
 ValidateAbiCompatibility(facadeAssembly, StaticNonPublic);
+ValidatePowerShellValuePager();
 
 var inspection = new FacadeInspection(
     facadeAssembly.GetReferencedAssemblies().Select(reference => reference.Name!).OrderBy(name => name, StringComparer.Ordinal).ToArray(),
@@ -142,6 +143,32 @@ static void ValidateAbiCompatibility(Assembly facadeAssembly, BindingFlags stati
     {
         throw new InvalidOperationException("Facade ABI validation accepted an incompatible minimum ABI version.");
     }
+
+    MethodInfo? ensureTypedResultPagingSupported = powerShellType.GetMethod(
+        "EnsureTypedResultPagingSupported",
+        staticNonPublic,
+        binder: null,
+        types: [abiInfoType],
+        modifiers: null);
+    if (ensureTypedResultPagingSupported is null)
+    {
+        throw new InvalidOperationException("The facade must retain a typed result paging feature gate.");
+    }
+
+    const ulong typedResultPagingFeature = 1UL << 21;
+    ensureTypedResultPagingSupported.Invoke(
+        null,
+        [CreateAbiInfo(
+            abiInfoType,
+            allRequiredFeatures | typedResultPagingFeature,
+            abiVersion: 2,
+            minimumCompatibleAbiVersion: 2)]);
+    if (!IsUnsupportedCapability(
+            ensureTypedResultPagingSupported,
+            CreateAbiInfo(abiInfoType, allRequiredFeatures, abiVersion: 2, minimumCompatibleAbiVersion: 2)))
+    {
+        throw new InvalidOperationException("Facade typed result paging feature gate accepted an absent feature bit.");
+    }
 }
 
 static object CreateAbiInfo(Type abiInfoType, ulong featureFlags, uint abiVersion, uint minimumCompatibleAbiVersion)
@@ -166,6 +193,41 @@ static bool IsRejected(MethodInfo ensureSupportedAbi, object abiInfo)
     catch (TargetInvocationException exception) when (exception.InnerException is NotSupportedException)
     {
         return true;
+    }
+}
+
+static bool IsUnsupportedCapability(MethodInfo featureGate, object abiInfo)
+{
+    try
+    {
+        featureGate.Invoke(null, [abiInfo]);
+        return false;
+    }
+    catch (TargetInvocationException exception)
+        when (exception.InnerException is PowerShellFfiException ffiException &&
+              ffiException.Status == PowerShellFfiStatus.UnsupportedCapability)
+    {
+        return true;
+    }
+}
+
+static void ValidatePowerShellValuePager()
+{
+    using var pager = new PowerShellValuePager(new PowerShellValuePagerOptions(1, 1));
+    pager.Write(PowerShellValue.String("value"));
+    pager.Complete();
+
+    PowerShellValuePage page = pager.Read(0);
+    if (!page.IsTerminal || page.IsComplete || page.NextSequence != 1 || page.Records.Count != 1)
+    {
+        throw new InvalidOperationException("PowerShellValuePager did not return the expected terminal page.");
+    }
+
+    pager.Acknowledge(page.NextSequence);
+    page = pager.Read(page.NextSequence);
+    if (!page.IsComplete || page.Records.Count != 0 || !pager.GetCompletion().IsComplete)
+    {
+        throw new InvalidOperationException("PowerShellValuePager did not require acknowledgement before completion.");
     }
 }
 

--- a/tests/Verify-PwshFfiApiBaseline.ps1
+++ b/tests/Verify-PwshFfiApiBaseline.ps1
@@ -154,6 +154,7 @@ $expectedManagedStructs = [ordered]@{
     'NativeSessionSnapshot' = @{ Size = 40; Fields = @('Size|0|System.UInt32', 'State|4|System.UInt32', 'RunspaceState|8|System.UInt32', 'Flags|12|System.UInt32', 'ActivePipelineCount|16|System.UInt32', 'EventCount|20|System.UInt32', 'InvocationCount|24|System.UInt64', 'HistoryCount|32|System.UInt64') }
     'NativeSessionPoolOptions' = @{ Size = 20; Fields = @('Size|0|System.UInt32', 'MinimumSessions|4|System.UInt32', 'MaximumSessions|8|System.UInt32', 'Flags|12|System.UInt32', 'Reserved|16|System.UInt32') }
     'NativeOperationStreamBatchInfo' = @{ Size = 64; Fields = @('Size|0|System.UInt32', 'OperationState|4|System.UInt32', 'TerminalStatus|8|System.Int32', 'Flags|12|System.UInt32', 'NextSequence|16|System.UInt64', 'TotalRecordCount|24|System.UInt64', 'DroppedRecordCount|32|System.UInt64', 'SourceDroppedRecordCount|40|System.UInt64', 'LostRecordCount|48|System.UInt64', 'RecordCount|56|System.UInt32', 'Reserved|60|System.UInt32') }
+    'NativeTypedResultPageInfo' = @{ Size = 56; Fields = @('Size|0|System.UInt32', 'Flags|4|System.UInt32', 'TerminalStatus|8|System.Int32', 'Reserved|12|System.UInt32', 'AcknowledgedSequence|16|System.UInt64', 'NextSequence|24|System.UInt64', 'TotalRecordCount|32|System.UInt64', 'DroppedRecordCount|40|System.UInt64', 'RecordCount|48|System.UInt32', 'Reserved2|52|System.UInt32') }
     'NativeLiveObjectContractDescriptor' = @{ Size = 32; Fields = @('Size|0|System.UInt32', 'Directions|4|System.UInt32', 'InterfaceIdLow|8|System.UInt64', 'InterfaceIdHigh|16|System.UInt64', 'MajorVersion|24|System.UInt16', 'MinorVersion|26|System.UInt16', 'Reserved|28|System.UInt32') }
     'NativeLiveObjectContractPackApi' = @{ Size = 40; Fields = @('Size|0|System.UIntPtr', 'AbiVersion|8|System.UInt32', 'ContractCount|12|System.UInt32', 'Contracts|16|Devolutions.PowerShell.Ffi.LiveObjects.NativeLiveObjectContractDescriptor*', 'CreatePayloadProxy|24|System.IntPtr', 'ReleasePayloadProxy|32|System.IntPtr') }
 }
@@ -320,6 +321,18 @@ $expectedLiveTableSlots = @(
     @{ Field = 'LiveInvocation_Stop'; Method = 'FfiLiveInvocation_Stop'; Signature = 'IntPtr,FfiCallResult*,int' }
     @{ Field = 'LiveInvocation_Release'; Method = 'FfiLiveInvocation_Release'; Signature = 'IntPtr,FfiCallResult*,int' }
 )
+$expectedTypedResultTableSlots = @(
+    @{ Field = 'PowerShell_BeginTypedResultInvocation'; Rust = 'power_shell_begin_typed_result_invocation_fn'; Alias = 'FnFfiPowerShellBeginTypedResultInvocation'; Method = 'FfiPowerShell_BeginTypedResultInvocation'; Signature = 'IntPtr,int,int,IntPtr*,FfiCallResult*,int' }
+    @{ Field = 'TypedResultInvocation_Poll'; Rust = 'typed_result_invocation_poll_fn'; Alias = 'FnFfiTypedResultInvocationPoll'; Method = 'FfiTypedResultInvocation_Poll'; Signature = 'IntPtr,int*,FfiCallResult*,int' }
+    @{ Field = 'TypedResultInvocation_ReadPage'; Rust = 'typed_result_invocation_read_page_fn'; Alias = 'FnFfiTypedResultInvocationReadPage'; Method = 'FfiTypedResultInvocation_ReadPage'; Signature = 'IntPtr,long,int,IntPtr*,FfiCallResult*,int' }
+    @{ Field = 'TypedResultInvocation_Complete'; Rust = 'typed_result_invocation_complete_fn'; Alias = 'FnFfiTypedResultInvocationComplete'; Method = 'FfiTypedResultInvocation_Complete'; Signature = 'IntPtr,FfiCallResult*,int' }
+    @{ Field = 'TypedResultInvocation_Stop'; Rust = 'typed_result_invocation_stop_fn'; Alias = 'FnFfiTypedResultInvocationComplete'; Method = 'FfiTypedResultInvocation_Stop'; Signature = 'IntPtr,FfiCallResult*,int' }
+    @{ Field = 'TypedResultInvocation_Release'; Rust = 'typed_result_invocation_release_fn'; Alias = 'FnFfiTypedResultInvocationComplete'; Method = 'FfiTypedResultInvocation_Release'; Signature = 'IntPtr,FfiCallResult*,int' }
+    @{ Field = 'TypedResultPage_GetInfo'; Rust = 'typed_result_page_get_info_fn'; Alias = 'FnFfiTypedResultPageGetInfo'; Method = 'FfiTypedResultPage_GetInfo'; Signature = 'IntPtr,long*,long*,long*,long*,int*,uint*,int*,FfiCallResult*,int' }
+    @{ Field = 'TypedResultPage_GetRecordInfo'; Rust = 'typed_result_page_get_record_info_fn'; Alias = 'FnFfiTypedResultPageGetRecordInfo'; Method = 'FfiTypedResultPage_GetRecordInfo'; Signature = 'IntPtr,int,long*,uint*,FfiCallResult*,int' }
+    @{ Field = 'TypedResultPage_CopyRecordValue'; Rust = 'typed_result_page_copy_record_value_fn'; Alias = 'FnFfiTypedResultPageCopyRecordValue'; Method = 'FfiTypedResultPage_CopyRecordValue'; Signature = 'IntPtr,int,uint*,byte*,int,int*,FfiCallResult*,int' }
+    @{ Field = 'TypedResultPage_Release'; Rust = 'typed_result_page_release_fn'; Alias = 'FnFfiTypedResultInvocationComplete'; Method = 'FfiTypedResultPage_Release'; Signature = 'IntPtr,FfiCallResult*,int' }
+)
 $ffiApiV3Type = $bindingsAssemblyObject.GetType('NativeHost.Bindings+FfiApiV3', $true)
 Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiV3Type)) -Expected 104 -Description 'Managed FfiApiV3 size'
 $ffiApiV3Fields = @($ffiApiV3Type.GetFields($instanceFields) | Sort-Object MetadataToken)
@@ -331,6 +344,19 @@ for ($index = 0; $index -lt $ffiApiV3Fields.Count; $index++) {
     $expectedType = if ($index -eq 0) { 'System.UIntPtr' } elseif ($index -eq 1) { 'System.UInt32' } elseif ($index -eq 2) { 'System.UInt64' } else { 'System.IntPtr' }
     Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::OffsetOf($ffiApiV3Type, $field.Name).ToInt64()) -Expected ([Int64]$expectedOffset) -Description "Managed FfiApiV3 '$($field.Name)' offset"
     Assert-Equal -Actual (Get-ManagedTypeName $field.FieldType) -Expected $expectedType -Description "Managed FfiApiV3 '$($field.Name)' type"
+}
+
+$ffiApiV4Type = $bindingsAssemblyObject.GetType('NativeHost.Bindings+FfiApiV4', $true)
+Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiV4Type)) -Expected 104 -Description 'Managed FfiApiV4 size'
+$ffiApiV4Fields = @($ffiApiV4Type.GetFields($instanceFields) | Sort-Object MetadataToken)
+$expectedFfiApiV4FieldNames = @('Size', 'AbiVersion', 'FeatureFlags') + @($expectedTypedResultTableSlots | ForEach-Object { $_.Field })
+Assert-Sequence -Actual @($ffiApiV4Fields | ForEach-Object Name) -Expected $expectedFfiApiV4FieldNames -Description 'Managed FfiApiV4 slot order'
+for ($index = 0; $index -lt $ffiApiV4Fields.Count; $index++) {
+    $field = $ffiApiV4Fields[$index]
+    $expectedOffset = if ($index -eq 0) { 0 } elseif ($index -eq 1) { 8 } elseif ($index -eq 2) { 16 } else { 24 + (($index - 3) * 8) }
+    $expectedType = if ($index -eq 0) { 'System.UIntPtr' } elseif ($index -eq 1) { 'System.UInt32' } elseif ($index -eq 2) { 'System.UInt64' } else { 'System.IntPtr' }
+    Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::OffsetOf($ffiApiV4Type, $field.Name).ToInt64()) -Expected ([Int64]$expectedOffset) -Description "Managed FfiApiV4 '$($field.Name)' offset"
+    Assert-Equal -Actual (Get-ManagedTypeName $field.FieldType) -Expected $expectedType -Description "Managed FfiApiV4 '$($field.Name)' type"
 }
 
 $compactFfiBindingsSource = $ffiBindingsSource -replace '\s+', ''
@@ -351,6 +377,15 @@ foreach ($slot in $expectedLiveTableSlots) {
     $assignment = "$($slot.Field)=(IntPtr)(delegate*unmanaged<$($slot.Signature)>)&$($slot.Method)"
     if ($compactFfiBindingsSource.IndexOf($assignment, [StringComparison]::Ordinal) -lt 0) {
         throw "Managed FfiApiV3 slot '$($slot.Field)' does not have its checked target and signature '$($slot.Signature)'."
+    }
+}
+if (-not $compactFfiBindingsSource.Contains('FeatureFlags=FfiFeatureTypedResultPaging')) {
+    throw 'Managed FfiApiV4 does not advertise typed result paging.'
+}
+foreach ($slot in $expectedTypedResultTableSlots) {
+    $assignment = "$($slot.Field)=(IntPtr)(delegate*unmanaged<$($slot.Signature)>)&$($slot.Method)"
+    if ($compactFfiBindingsSource.IndexOf($assignment, [StringComparison]::Ordinal) -lt 0) {
+        throw "Managed FfiApiV4 slot '$($slot.Field)' does not have its checked target and signature '$($slot.Signature)'."
     }
 }
 
@@ -388,8 +423,22 @@ Assert-Sequence -Actual $rustLiveApiTableFields -Expected @(
     'live_invocation_stop_fn',
     'live_invocation_release_fn'
 ) -Description 'Rust FfiApiV3 slot order'
-if (-not $rustBindingsSource.Contains('Err(_) => None')) {
-    throw 'Rust bindings must treat the live-stream managed table as optional for payload compatibility.'
+
+$rustTypedResultApiTableMatch = [regex]::Match($rustBindingsSource, '(?s)struct\s+FfiApiV4\s*\{(?<body>.*?)\n\s*\}')
+if (-not $rustTypedResultApiTableMatch.Success) {
+    throw 'Rust FfiApiV4 table declaration is missing.'
+}
+$rustTypedResultApiTableFields = @(
+    [regex]::Matches($rustTypedResultApiTableMatch.Groups['body'].Value, '(?m)^\s*(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*[^,]+,') |
+        ForEach-Object { $_.Groups['name'].Value }
+)
+Assert-Sequence -Actual $rustTypedResultApiTableFields -Expected (@(
+        'size',
+        'abi_version',
+        'feature_flags'
+    ) + @($expectedTypedResultTableSlots | ForEach-Object Rust)) -Description 'Rust FfiApiV4 slot order'
+if (-not [regex]::IsMatch($rustBindingsSource, '(?s)Bindings_GetFfiApiV4.*?Err\(_\)\s*=>\s*None')) {
+    throw 'Rust bindings must treat the typed result paging managed table as optional for payload compatibility.'
 }
 
 $rustBindingsTableMatch = [regex]::Match($rustBindingsSource, '(?s)pub\(crate\)\s+struct\s+FfiBindings\s*\{(?<body>.*?)\n\s*\}')
@@ -401,6 +450,15 @@ $rustBindingsFields = @(
         ForEach-Object { "$($_.Groups['name'].Value)|$($_.Groups['type'].Value)" }
 )
 Assert-Sequence -Actual $rustBindingsFields -Expected @($expectedTableSlots | ForEach-Object { "$($_.Rust)|$($_.Alias)" }) -Description 'Rust FfiBindings slot order and aliases'
+if (-not [regex]::IsMatch(
+        $rustBindingsTableMatch.Groups['body'].Value,
+        '(?m)^\s*typed_result_paging\s*:\s*Option<FfiTypedResultPagingBindings>,'
+    )) {
+    throw 'Rust FfiBindings must retain an optional typed result paging binding table.'
+}
+if (-not $rustFfiSource.Contains('const FEATURE_TYPED_RESULT_PAGING: u64 = 1 << 21;')) {
+    throw 'Rust native ABI must advertise typed result paging feature bit 21.'
+}
 
 $expectedRustFunctionAliases = @'
 FnBindingsGetFfiApiV2|unsafeextern"system"fn()->*constFfiApiV2

--- a/tests/Verify-PwshFfiApiBaseline.ps1
+++ b/tests/Verify-PwshFfiApiBaseline.ps1
@@ -440,6 +440,9 @@ Assert-Sequence -Actual $rustTypedResultApiTableFields -Expected (@(
 if (-not [regex]::IsMatch($rustBindingsSource, '(?s)Bindings_GetFfiApiV4.*?Err\(_\)\s*=>\s*None')) {
     throw 'Rust bindings must treat the typed result paging managed table as optional for payload compatibility.'
 }
+if (-not [regex]::IsMatch($rustBindingsSource, '(?s)Bindings_GetFfiApiV3.*?Err\(_\)\s*=>\s*None')) {
+    throw 'Rust bindings must retain V3 managed table optionality for payload compatibility.'
+}
 
 $rustBindingsTableMatch = [regex]::Match($rustBindingsSource, '(?s)pub\(crate\)\s+struct\s+FfiBindings\s*\{(?<body>.*?)\n\s*\}')
 if (-not $rustBindingsTableMatch.Success) {


### PR DESCRIPTION
## Summary

- add a strict source-generated DTO projection surface for versioned, bounded `PowerShellValue` property bags
- add typed, lossless bounded result paging with explicit cursor acknowledgement and completion metadata
- wire paging through an additive feature-gated native ABI while preserving legacy ABI tables and predictable `UnsupportedCapability` behavior for older native assets

## Safety and compatibility

- transports only copied tagged values, property bags, and arrays; no SMA objects, `PSObject`, arbitrary CLR graphs, or callbacks cross the typed page boundary
- applies caller-configured record/page bounds with producer backpressure and explicit terminal, truncation, dropped-record, and completeness state
- stores full native `ulong` IDs independently of pointer-sized `SafeHandle` sentinels, including 32-bit native targets

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj`
- `dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj --no-build`
- DTO projection and pager smoke project

Payload-dependent integration tests remain skipped when `PWSH_FFI_PAYLOAD` is not configured.