### PR TITLE
feat(ffi): qualify unified payload bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,10 @@ jobs:
           dotnet publish dotnet/nativeaot-sample/NativeAotFfiSample.csproj -c Release
           & dotnet/nativeaot-sample/bin/Release/net10.0/win-x64/publish/NativeAotFfiSample.exe
           if ($LASTEXITCODE -ne 0) { throw "The PATH-resolved NativeAOT SDK sample failed with exit code $LASTEXITCODE." }
+          & dotnet/nativeaot-sample/bin/Release/net10.0/win-x64/publish/NativeAotFfiSample.exe `
+            $payloadDirectory `
+            --expect-incompatible-contract-pack
+          if ($LASTEXITCODE -ne 0) { throw "The incompatible contract-pack NativeAOT sample failed with exit code $LASTEXITCODE." }
 
       - name: Dry-run pack NativeAOT SDK
         shell: pwsh

--- a/crates/pwsh-host/build.rs
+++ b/crates/pwsh-host/build.rs
@@ -42,7 +42,12 @@ fn main() {
     let managed_common_props = dotnet_dir.join("Managed.Common.props");
     let bindings_sources = [
         dotnet_dir.join("bindings").join("Bindings.cs"),
+        dotnet_dir.join("bindings").join("FfiBindings.cs"),
+        dotnet_dir.join("bindings").join("LiveObjectContractPackRegistry.cs"),
         dotnet_dir.join("bindings").join("Bindings.Generated.cs"),
+        dotnet_dir.join("interop").join("PowerShellLiveObjectContract.cs"),
+        dotnet_dir.join("interop").join("PowerShellLiveObjectProbeContract.cs"),
+        dotnet_dir.join("interop").join("PowerShellLiveObjectTestContract.cs"),
     ];
     let startup_hook_project = dotnet_dir
         .join("startup-hook")

--- a/crates/pwsh-host/src/bindings/ffi.rs
+++ b/crates/pwsh-host/src/bindings/ffi.rs
@@ -11,9 +11,7 @@ use crate::pdcstring::{PdCStr, PdCString};
 
 use super::bindings_generated::PowerShellHandle;
 
-const FFI_BINDINGS_ABI_VERSION: u32 = 2;
-const FFI_BINDINGS_LIVE_STREAM_ABI_VERSION: u32 = 3;
-const FFI_BINDINGS_TYPED_RESULT_PAGING_ABI_VERSION: u32 = 4;
+const FFI_BINDINGS_ABI_VERSION: u32 = 1;
 const FFI_CALL_DIAGNOSTIC_CAPACITY: usize = 4096;
 const FFI_FEATURE_ASYNC_OPERATION_PRIMITIVES: u64 = 1 << 8;
 const FFI_FEATURE_SESSION_PRIMITIVES: u64 = 1 << 10;
@@ -55,7 +53,7 @@ pub struct FfiLiveObjectContractDescriptor {
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-struct FfiApiV2 {
+struct FfiApiV1 {
     size: usize,
     abi_version: u32,
     feature_flags: u64,
@@ -109,14 +107,6 @@ struct FfiApiV2 {
     live_object_contract_pack_register_fn: *const libc::c_void,
     power_shell_session_set_live_object_contract_variable_fn: *const libc::c_void,
     live_object_contract_pack_register_many_fn: *const libc::c_void,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct FfiApiV3 {
-    size: usize,
-    abi_version: u32,
-    feature_flags: u64,
     power_shell_begin_live_invocation_fn: *const libc::c_void,
     live_invocation_poll_fn: *const libc::c_void,
     live_invocation_read_batch_fn: *const libc::c_void,
@@ -127,14 +117,6 @@ struct FfiApiV3 {
     live_invocation_complete_fn: *const libc::c_void,
     live_invocation_stop_fn: *const libc::c_void,
     live_invocation_release_fn: *const libc::c_void,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct FfiApiV4 {
-    size: usize,
-    abi_version: u32,
-    feature_flags: u64,
     power_shell_begin_typed_result_invocation_fn: *const libc::c_void,
     typed_result_invocation_poll_fn: *const libc::c_void,
     typed_result_invocation_read_page_fn: *const libc::c_void,
@@ -147,9 +129,7 @@ struct FfiApiV4 {
     typed_result_page_release_fn: *const libc::c_void,
 }
 
-type FnBindingsGetFfiApiV2 = unsafe extern "system" fn() -> *const FfiApiV2;
-type FnBindingsGetFfiApiV3 = unsafe extern "system" fn() -> *const FfiApiV3;
-type FnBindingsGetFfiApiV4 = unsafe extern "system" fn() -> *const FfiApiV4;
+type FnBindingsGetFfiApiV1 = unsafe extern "system" fn() -> *const FfiApiV1;
 type FnFfiPowerShellCreate = unsafe extern "system" fn(*mut PowerShellHandle, *mut FfiCallResult) -> i32;
 type FnFfiPowerShellRelease = unsafe extern "system" fn(PowerShellHandle, *mut FfiCallResult) -> i32;
 type FnFfiPowerShellAddUtf8 = unsafe extern "system" fn(PowerShellHandle, *const u8, i32, *mut FfiCallResult) -> i32;
@@ -387,8 +367,8 @@ pub(crate) struct FfiBindings {
     live_object_contract_pack_register_fn: FnFfiLiveObjectContractPackRegister,
     power_shell_session_set_live_object_contract_variable_fn: FnFfiPowerShellSessionSetLiveObjectContractVariable,
     live_object_contract_pack_register_many_fn: FnFfiLiveObjectContractPackRegisterMany,
-    live_stream: Option<FfiLiveStreamBindings>,
-    typed_result_paging: Option<FfiTypedResultPagingBindings>,
+    live_stream: FfiLiveStreamBindings,
+    typed_result_paging: FfiTypedResultPagingBindings,
 }
 
 #[derive(Clone, Copy)]
@@ -457,11 +437,11 @@ impl FfiBindings {
             fn_loader.get_function_pointer_for_unmanaged_callers_only_method(type_name, method_name)
         }
 
-        let get_api_fn: FnBindingsGetFfiApiV2 = {
+        let get_api_fn: FnBindingsGetFfiApiV1 = {
             let fn_ptr = get_function_pointer(
                 fn_loader,
                 pdcstr!("NativeHost.Bindings, Devolutions.PowerShell.SDK.Bindings"),
-                pdcstr!("Bindings_GetFfiApiV2"),
+                pdcstr!("Bindings_GetFfiApiV1"),
             )?;
             unsafe { mem::transmute(fn_ptr) }
         };
@@ -479,7 +459,7 @@ impl FfiBindings {
         };
 
         if api.abi_version != FFI_BINDINGS_ABI_VERSION
-            || api.size < mem::size_of::<FfiApiV2>()
+            || api.size < mem::size_of::<FfiApiV1>()
             || api.feature_flags
                 & (FFI_FEATURE_ASYNC_OPERATION_PRIMITIVES
                     | FFI_FEATURE_SESSION_PRIMITIVES
@@ -490,7 +470,9 @@ impl FfiBindings {
                     | FFI_FEATURE_CAPABILITY_RPC
                     | FFI_FEATURE_LIVE_OBJECT_PROBE
                     | FFI_FEATURE_LIVE_SESSION_OBJECT_PROBE
-                    | FFI_FEATURE_LIVE_OBJECT_CONTRACTS)
+                    | FFI_FEATURE_LIVE_OBJECT_CONTRACTS
+                    | FFI_FEATURE_LIVE_STREAM_POLLING
+                    | FFI_FEATURE_TYPED_RESULT_PAGING)
                 != (FFI_FEATURE_ASYNC_OPERATION_PRIMITIVES
                     | FFI_FEATURE_SESSION_PRIMITIVES
                     | FFI_FEATURE_SESSION_POLLING
@@ -500,7 +482,9 @@ impl FfiBindings {
                     | FFI_FEATURE_CAPABILITY_RPC
                     | FFI_FEATURE_LIVE_OBJECT_PROBE
                     | FFI_FEATURE_LIVE_SESSION_OBJECT_PROBE
-                    | FFI_FEATURE_LIVE_OBJECT_CONTRACTS)
+                    | FFI_FEATURE_LIVE_OBJECT_CONTRACTS
+                    | FFI_FEATURE_LIVE_STREAM_POLLING
+                    | FFI_FEATURE_TYPED_RESULT_PAGING)
         {
             return Err(Error::IO(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -559,6 +543,26 @@ impl FfiBindings {
             api.live_object_contract_pack_register_fn,
             api.power_shell_session_set_live_object_contract_variable_fn,
             api.live_object_contract_pack_register_many_fn,
+            api.power_shell_begin_live_invocation_fn,
+            api.live_invocation_poll_fn,
+            api.live_invocation_read_batch_fn,
+            api.live_invocation_batch_get_info_fn,
+            api.live_invocation_batch_get_record_info_fn,
+            api.live_invocation_batch_copy_record_text_to_utf8_fn,
+            api.live_invocation_batch_release_fn,
+            api.live_invocation_complete_fn,
+            api.live_invocation_stop_fn,
+            api.live_invocation_release_fn,
+            api.power_shell_begin_typed_result_invocation_fn,
+            api.typed_result_invocation_poll_fn,
+            api.typed_result_invocation_read_page_fn,
+            api.typed_result_invocation_complete_fn,
+            api.typed_result_invocation_stop_fn,
+            api.typed_result_invocation_release_fn,
+            api.typed_result_page_get_info_fn,
+            api.typed_result_page_get_record_info_fn,
+            api.typed_result_page_copy_record_value_fn,
+            api.typed_result_page_release_fn,
         ];
         if fields.iter().any(|field| field.is_null()) {
             return Err(Error::IO(std::io::Error::new(
@@ -567,188 +571,95 @@ impl FfiBindings {
             )));
         }
 
-        let live_stream = match get_function_pointer(
-            fn_loader,
-            pdcstr!("NativeHost.Bindings, Devolutions.PowerShell.SDK.Bindings"),
-            pdcstr!("Bindings_GetFfiApiV3"),
-        ) {
-            Ok(pointer) => {
-                let get_api_fn: FnBindingsGetFfiApiV3 = unsafe { mem::transmute(pointer) };
-                let api_ptr = unsafe { get_api_fn() };
-                if api_ptr.is_null() {
-                    return Err(Error::IO(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "managed live stream binding table is null",
-                    )));
-                }
-                let api = unsafe { *api_ptr };
-                let fields = [
+        let live_stream = FfiLiveStreamBindings {
+            power_shell_begin_live_invocation_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiPowerShellBeginLiveInvocation>(
                     api.power_shell_begin_live_invocation_fn,
-                    api.live_invocation_poll_fn,
-                    api.live_invocation_read_batch_fn,
+                )
+            },
+            live_invocation_poll_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveInvocationPoll>(api.live_invocation_poll_fn)
+            },
+            live_invocation_read_batch_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveInvocationReadBatch>(api.live_invocation_read_batch_fn)
+            },
+            live_invocation_batch_get_info_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveInvocationBatchGetInfo>(
                     api.live_invocation_batch_get_info_fn,
+                )
+            },
+            live_invocation_batch_get_record_info_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveInvocationBatchGetRecordInfo>(
                     api.live_invocation_batch_get_record_info_fn,
+                )
+            },
+            live_invocation_batch_copy_record_text_to_utf8_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveInvocationBatchCopyRecordTextToUtf8>(
                     api.live_invocation_batch_copy_record_text_to_utf8_fn,
-                    api.live_invocation_batch_release_fn,
-                    api.live_invocation_complete_fn,
-                    api.live_invocation_stop_fn,
-                    api.live_invocation_release_fn,
-                ];
-                if api.abi_version != FFI_BINDINGS_LIVE_STREAM_ABI_VERSION
-                    || api.size < mem::size_of::<FfiApiV3>()
-                    || api.feature_flags & FFI_FEATURE_LIVE_STREAM_POLLING == 0
-                    || fields.iter().any(|field| field.is_null())
-                {
-                    return Err(Error::IO(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "managed live stream bindings are incompatible",
-                    )));
-                }
-
-                Some(FfiLiveStreamBindings {
-                    power_shell_begin_live_invocation_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiPowerShellBeginLiveInvocation>(
-                            api.power_shell_begin_live_invocation_fn,
-                        )
-                    },
-                    live_invocation_poll_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiLiveInvocationPoll>(api.live_invocation_poll_fn)
-                    },
-                    live_invocation_read_batch_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiLiveInvocationReadBatch>(
-                            api.live_invocation_read_batch_fn,
-                        )
-                    },
-                    live_invocation_batch_get_info_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiLiveInvocationBatchGetInfo>(
-                            api.live_invocation_batch_get_info_fn,
-                        )
-                    },
-                    live_invocation_batch_get_record_info_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiLiveInvocationBatchGetRecordInfo>(
-                            api.live_invocation_batch_get_record_info_fn,
-                        )
-                    },
-                    live_invocation_batch_copy_record_text_to_utf8_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiLiveInvocationBatchCopyRecordTextToUtf8>(
-                            api.live_invocation_batch_copy_record_text_to_utf8_fn,
-                        )
-                    },
-                    live_invocation_batch_release_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiLiveInvocationRelease>(
-                            api.live_invocation_batch_release_fn,
-                        )
-                    },
-                    live_invocation_complete_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiLiveInvocationComplete>(
-                            api.live_invocation_complete_fn,
-                        )
-                    },
-                    live_invocation_stop_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiLiveInvocationRelease>(api.live_invocation_stop_fn)
-                    },
-                    live_invocation_release_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiLiveInvocationRelease>(
-                            api.live_invocation_release_fn,
-                        )
-                    },
-                })
-            }
-            Err(_) => None,
+                )
+            },
+            live_invocation_batch_release_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveInvocationRelease>(api.live_invocation_batch_release_fn)
+            },
+            live_invocation_complete_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveInvocationComplete>(api.live_invocation_complete_fn)
+            },
+            live_invocation_stop_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveInvocationRelease>(api.live_invocation_stop_fn)
+            },
+            live_invocation_release_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiLiveInvocationRelease>(api.live_invocation_release_fn)
+            },
         };
-
-        let typed_result_paging = match get_function_pointer(
-            fn_loader,
-            pdcstr!("NativeHost.Bindings, Devolutions.PowerShell.SDK.Bindings"),
-            pdcstr!("Bindings_GetFfiApiV4"),
-        ) {
-            Ok(pointer) => {
-                let get_api_fn: FnBindingsGetFfiApiV4 = unsafe { mem::transmute(pointer) };
-                let api_ptr = unsafe { get_api_fn() };
-                if api_ptr.is_null() {
-                    return Err(Error::IO(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "managed typed result paging binding table is null",
-                    )));
-                }
-                let api = unsafe { *api_ptr };
-                let fields = [
+        let typed_result_paging = FfiTypedResultPagingBindings {
+            power_shell_begin_typed_result_invocation_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiPowerShellBeginTypedResultInvocation>(
                     api.power_shell_begin_typed_result_invocation_fn,
+                )
+            },
+            typed_result_invocation_poll_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationPoll>(
                     api.typed_result_invocation_poll_fn,
+                )
+            },
+            typed_result_invocation_read_page_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationReadPage>(
                     api.typed_result_invocation_read_page_fn,
+                )
+            },
+            typed_result_invocation_complete_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
                     api.typed_result_invocation_complete_fn,
+                )
+            },
+            typed_result_invocation_stop_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
                     api.typed_result_invocation_stop_fn,
+                )
+            },
+            typed_result_invocation_release_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
                     api.typed_result_invocation_release_fn,
-                    api.typed_result_page_get_info_fn,
+                )
+            },
+            typed_result_page_get_info_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiTypedResultPageGetInfo>(api.typed_result_page_get_info_fn)
+            },
+            typed_result_page_get_record_info_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiTypedResultPageGetRecordInfo>(
                     api.typed_result_page_get_record_info_fn,
+                )
+            },
+            typed_result_page_copy_record_value_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiTypedResultPageCopyRecordValue>(
                     api.typed_result_page_copy_record_value_fn,
+                )
+            },
+            typed_result_page_release_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
                     api.typed_result_page_release_fn,
-                ];
-                if api.abi_version != FFI_BINDINGS_TYPED_RESULT_PAGING_ABI_VERSION
-                    || api.size < mem::size_of::<FfiApiV4>()
-                    || api.feature_flags & FFI_FEATURE_TYPED_RESULT_PAGING == 0
-                    || fields.iter().any(|field| field.is_null())
-                {
-                    return Err(Error::IO(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "managed typed result paging bindings are incompatible",
-                    )));
-                }
-
-                Some(FfiTypedResultPagingBindings {
-                    power_shell_begin_typed_result_invocation_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiPowerShellBeginTypedResultInvocation>(
-                            api.power_shell_begin_typed_result_invocation_fn,
-                        )
-                    },
-                    typed_result_invocation_poll_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationPoll>(
-                            api.typed_result_invocation_poll_fn,
-                        )
-                    },
-                    typed_result_invocation_read_page_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationReadPage>(
-                            api.typed_result_invocation_read_page_fn,
-                        )
-                    },
-                    typed_result_invocation_complete_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
-                            api.typed_result_invocation_complete_fn,
-                        )
-                    },
-                    typed_result_invocation_stop_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
-                            api.typed_result_invocation_stop_fn,
-                        )
-                    },
-                    typed_result_invocation_release_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
-                            api.typed_result_invocation_release_fn,
-                        )
-                    },
-                    typed_result_page_get_info_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiTypedResultPageGetInfo>(
-                            api.typed_result_page_get_info_fn,
-                        )
-                    },
-                    typed_result_page_get_record_info_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiTypedResultPageGetRecordInfo>(
-                            api.typed_result_page_get_record_info_fn,
-                        )
-                    },
-                    typed_result_page_copy_record_value_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiTypedResultPageCopyRecordValue>(
-                            api.typed_result_page_copy_record_value_fn,
-                        )
-                    },
-                    typed_result_page_release_fn: unsafe {
-                        mem::transmute::<*const libc::c_void, FnFfiTypedResultInvocationComplete>(
-                            api.typed_result_page_release_fn,
-                        )
-                    },
-                })
-            }
-            Err(_) => None,
+                )
+            },
         };
 
         Ok(Self {
@@ -1243,11 +1154,11 @@ impl FfiPowerShell {
     }
 
     pub fn supports_live_stream_polling(&self) -> bool {
-        self.bindings.live_stream.is_some()
+        true
     }
 
     pub fn supports_typed_result_paging(&self) -> bool {
-        self.bindings.typed_result_paging.is_some()
+        true
     }
 
     pub fn begin_typed_result_invocation(
@@ -1265,9 +1176,7 @@ impl FfiPowerShell {
                 "typed result invocation bounds are invalid".to_owned(),
             ));
         }
-        let typed_result_paging = self.bindings.typed_result_paging.ok_or_else(|| {
-            FfiBindingError::from_status(-17, "managed bindings do not support typed result paging".to_owned())
-        })?;
+        let typed_result_paging = self.bindings.typed_result_paging;
         let mut typed_result_handle = std::ptr::null_mut();
         self.call(|handle, result| unsafe {
             (typed_result_paging.power_shell_begin_typed_result_invocation_fn)(
@@ -1293,9 +1202,7 @@ impl FfiPowerShell {
     }
 
     pub fn begin_live_invocation(&self) -> Result<FfiLiveInvocation, FfiBindingError> {
-        let live_stream = self.bindings.live_stream.ok_or_else(|| {
-            FfiBindingError::from_status(-17, "managed bindings do not support live stream polling".to_owned())
-        })?;
+        let live_stream = self.bindings.live_stream;
         let mut live_handle = std::ptr::null_mut();
         self.call(|handle, result| unsafe {
             (live_stream.power_shell_begin_live_invocation_fn)(handle, &mut live_handle, result)
@@ -1468,7 +1375,7 @@ pub struct FfiLiveInvocation {
 
 impl FfiLiveInvocation {
     pub fn poll(&self) -> Result<bool, FfiBindingError> {
-        let live_stream = self.live_stream()?;
+        let live_stream = self.bindings.live_stream;
         let mut completed = 0_i32;
         self.call(|handle, result| unsafe { (live_stream.live_invocation_poll_fn)(handle, &mut completed, result) })?;
         match completed {
@@ -1493,7 +1400,7 @@ impl FfiLiveInvocation {
             ));
         }
 
-        let live_stream = self.live_stream()?;
+        let live_stream = self.bindings.live_stream;
         let mut batch_handle = std::ptr::null_mut();
         self.call(|handle, result| unsafe {
             (live_stream.live_invocation_read_batch_fn)(
@@ -1653,12 +1560,12 @@ impl FfiLiveInvocation {
     }
 
     pub fn stop(&self) -> Result<(), FfiBindingError> {
-        let live_stream = self.live_stream()?;
+        let live_stream = self.bindings.live_stream;
         self.call(|handle, result| unsafe { (live_stream.live_invocation_stop_fn)(handle, result) })
     }
 
     pub fn complete(&self) -> Result<FfiInvocationResult, FfiBindingError> {
-        let live_stream = self.live_stream()?;
+        let live_stream = self.bindings.live_stream;
         let mut result_handle = std::ptr::null_mut();
         self.call(|handle, result| unsafe {
             (live_stream.live_invocation_complete_fn)(handle, &mut result_handle, result)
@@ -1674,12 +1581,6 @@ impl FfiLiveInvocation {
             _runtime: Arc::clone(&self._runtime),
             bindings: self.bindings,
             handle: Some(result_handle),
-        })
-    }
-
-    fn live_stream(&self) -> Result<FfiLiveStreamBindings, FfiBindingError> {
-        self.bindings.live_stream.ok_or_else(|| {
-            FfiBindingError::from_status(-17, "managed bindings do not support live stream polling".to_owned())
         })
     }
 
@@ -1702,9 +1603,7 @@ impl Drop for FfiLiveInvocation {
         let Some(handle) = self.handle.take() else {
             return;
         };
-        let Some(live_stream) = self.bindings.live_stream else {
-            return;
-        };
+        let live_stream = self.bindings.live_stream;
         let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
         let mut call_result = new_call_result(&mut diagnostic);
         unsafe {
@@ -1741,7 +1640,7 @@ pub struct FfiTypedResultInvocation {
 
 impl FfiTypedResultInvocation {
     pub fn poll(&self) -> Result<bool, FfiBindingError> {
-        let typed_result_paging = self.typed_result_paging()?;
+        let typed_result_paging = self.bindings.typed_result_paging;
         let mut completed = 0_i32;
         self.call(|handle, result| unsafe {
             (typed_result_paging.typed_result_invocation_poll_fn)(handle, &mut completed, result)
@@ -1768,7 +1667,7 @@ impl FfiTypedResultInvocation {
             ));
         }
 
-        let typed_result_paging = self.typed_result_paging()?;
+        let typed_result_paging = self.bindings.typed_result_paging;
         let mut page_handle = std::ptr::null_mut();
         self.call(|handle, result| unsafe {
             (typed_result_paging.typed_result_invocation_read_page_fn)(
@@ -1961,19 +1860,13 @@ impl FfiTypedResultInvocation {
     }
 
     pub fn complete(&self) -> Result<(), FfiBindingError> {
-        let typed_result_paging = self.typed_result_paging()?;
+        let typed_result_paging = self.bindings.typed_result_paging;
         self.call(|handle, result| unsafe { (typed_result_paging.typed_result_invocation_complete_fn)(handle, result) })
     }
 
     pub fn stop(&self) -> Result<(), FfiBindingError> {
-        let typed_result_paging = self.typed_result_paging()?;
+        let typed_result_paging = self.bindings.typed_result_paging;
         self.call(|handle, result| unsafe { (typed_result_paging.typed_result_invocation_stop_fn)(handle, result) })
-    }
-
-    fn typed_result_paging(&self) -> Result<FfiTypedResultPagingBindings, FfiBindingError> {
-        self.bindings.typed_result_paging.ok_or_else(|| {
-            FfiBindingError::from_status(-17, "managed bindings do not support typed result paging".to_owned())
-        })
     }
 
     fn call<F>(&self, operation: F) -> Result<(), FfiBindingError>
@@ -1995,9 +1888,7 @@ impl Drop for FfiTypedResultInvocation {
         let Some(handle) = self.handle.take() else {
             return;
         };
-        let Some(typed_result_paging) = self.bindings.typed_result_paging else {
-            return;
-        };
+        let typed_result_paging = self.bindings.typed_result_paging;
         let mut diagnostic = [0_u8; FFI_CALL_DIAGNOSTIC_CAPACITY];
         let mut call_result = new_call_result(&mut diagnostic);
         unsafe {

--- a/crates/pwsh-host/src/bindings/ffi.rs
+++ b/crates/pwsh-host/src/bindings/ffi.rs
@@ -488,7 +488,7 @@ impl FfiBindings {
         {
             return Err(Error::IO(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                "managed FFI bindings do not support async operation and session primitives",
+                "managed FFI bindings report an incompatible ABI version, table size, or required feature set",
             )));
         }
 

--- a/docs/in-process-ffi.md
+++ b/docs/in-process-ffi.md
@@ -162,6 +162,9 @@ A session-affine dispatcher is required before supporting that category.
 - The public native ABI remains v2. `ReadStreamBatch` is enabled only when the
   `LIVE_STREAM_POLLING` feature bit is present, so consumers can reject a native
   asset that lacks polling before calling its additive export.
+- The managed payload and Rust host use one jointly shipped **V1 payload binding
+  table**. It includes the core, live-stream, and typed-result slots. This is
+  separate from the public native ABI, which remains v2.
 - The supported ABI uses sized, caller-owned `multi_pwsh_call_result` structures. Each operation
   returns its own bounded UTF-8 diagnostic and truncation metadata, so concurrent
   calls never read a process-global error slot. `multi_pwsh_utf8_span` permits
@@ -279,6 +282,25 @@ before completing the task as cancelled; it never abandons or prematurely
 releases the operation handle. The facade uses `LibraryImport` and
 `SafeHandle` leases only—no SMA objects, native callbacks, or collectible
 managed delegates cross the boundary.
+
+### Typed result paging
+
+`PowerShell.BeginTypedResultInvocation(options)` is the lossless result-data
+counterpart to live stream polling. It is part of the required V1 payload
+binding table; the public native ABI remains v2. The caller chooses bounded
+record and page limits (1 through 64), then calls
+`Read(acknowledgedThrough, maximumRecords)`. Supplying a newer cursor
+explicitly acknowledges the previous page and releases its records; re-reading
+an earlier cursor does not acknowledge or discard anything.
+
+The payload producer blocks when the bounded queue is full. It never drops
+values to make room, and it returns `UnsupportedValue` when output cannot be
+represented as a documented tagged value rather than converting it to display
+text. Terminal pages carry cancellation, truncation, dropped-record, and
+completion state. `IsComplete` is true only after successful completion and
+acknowledgement of every produced record. This remains copied data only:
+arrays and property bags are bounded `PowerShellValue` values, never `PSObject`
+or arbitrary CLR-object transfer.
 
 ### Sessions, bounded settings, and polling
 
@@ -795,7 +817,9 @@ PowerShell payload and any selected modules separately. The application must not
 transitive `System.Management.Automation`, `Microsoft.PowerShell.SDK`, or
 payload runtime asset to the NativeAOT facade path. Activation reports a
 deterministic incompatibility if another selected payload/runtime already owns
-the process.
+the process. Structural payload checks ensure only that required host files
+exist; they do not attest to payload provenance, integrity, module manifests,
+or application deployment policy. Those remain application responsibilities.
 
 `win-arm64`, Linux, and macOS have packaged native assets but remain unvalidated
 for payload activation and must not be advertised as supported until each has a
@@ -839,8 +863,15 @@ dotnet publish dotnet/nativeaot-sample/NativeAotFfiSample.csproj -c Release
 ./dotnet/nativeaot-sample/bin/Release/net10.0/win-x64/publish/NativeAotFfiSample.exe
 # Or select a payload explicitly:
 ./dotnet/nativeaot-sample/bin/Release/net10.0/win-x64/publish/NativeAotFfiSample.exe <payload>
+
+dotnet pack dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj -c Release -o artifacts/sdk-nuget
+pwsh -NoLogo -NoProfile -File tests/Test-PwshFfiPackage.ps1 `
+    -PackageSource artifacts/sdk-nuget `
+    -PowerShellPayloadDirectory $env:PWSH_FFI_PAYLOAD
 ```
 
 The ignored Rust test and NativeAOT sample require a real payload root containing
 `pwsh.dll`, `pwsh.runtimeconfig.json`, and
-`System.Management.Automation.dll`.
+`System.Management.Automation.dll`. The packaged Win-x64 consumer requires a
+PowerShell 7.4 payload and verifies typed-result paging through the managed
+facade, native host, and required V1 payload binding table.

--- a/dotnet/bindings/FfiBindings.cs
+++ b/dotnet/bindings/FfiBindings.cs
@@ -20,9 +20,7 @@ namespace NativeHost
 {
     public static partial class Bindings
     {
-        private const uint FfiBindingsAbiVersion = 2;
-        private const uint FfiBindingsLiveStreamAbiVersion = 3;
-        private const uint FfiBindingsTypedResultPagingAbiVersion = 4;
+        private const uint FfiBindingsAbiVersion = 1;
         private const uint FfiCallResultTruncatedDiagnostic = 1;
         private const int FfiStatusSuccess = 0;
         private const int FfiStatusInvalidArgument = -1;
@@ -110,7 +108,7 @@ namespace NativeHost
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        private struct FfiApiV2
+        private struct FfiApiV1
         {
             public nuint Size;
             public uint AbiVersion;
@@ -165,14 +163,6 @@ namespace NativeHost
             public IntPtr LiveObjectContractPack_Register;
             public IntPtr PowerShellSession_SetLiveObjectContractVariable;
             public IntPtr LiveObjectContractPack_RegisterMany;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct FfiApiV3
-        {
-            public nuint Size;
-            public uint AbiVersion;
-            public ulong FeatureFlags;
             public IntPtr PowerShell_BeginLiveInvocation;
             public IntPtr LiveInvocation_Poll;
             public IntPtr LiveInvocation_ReadBatch;
@@ -183,14 +173,6 @@ namespace NativeHost
             public IntPtr LiveInvocation_Complete;
             public IntPtr LiveInvocation_Stop;
             public IntPtr LiveInvocation_Release;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct FfiApiV4
-        {
-            public nuint Size;
-            public uint AbiVersion;
-            public ulong FeatureFlags;
             public IntPtr PowerShell_BeginTypedResultInvocation;
             public IntPtr TypedResultInvocation_Poll;
             public IntPtr TypedResultInvocation_ReadPage;
@@ -270,7 +252,7 @@ namespace NativeHost
             throw new InvalidOperationException("An approved module import could not be resolved beneath an approved module path.");
         }
 
-        private static readonly object FfiApiV2Lock = new object();
+        private static readonly object FfiApiV1Lock = new object();
         private static readonly ConcurrentDictionary<IntPtr, InvocationResult> FfiInvocationResults =
             new ConcurrentDictionary<IntPtr, InvocationResult>();
         private static readonly ConcurrentDictionary<IntPtr, FfiInputBuffer> FfiInputBuffers =
@@ -287,25 +269,23 @@ namespace NativeHost
             FfiLiveObjectProbeContract,
             static pointer => new FfiManagedLiveObjectLease(FfiLiveSessionObjectProbeProxy.Create(pointer)));
         private static long FfiNextInvocationId;
-        private static IntPtr FfiApiV2Ptr = IntPtr.Zero;
-        private static IntPtr FfiApiV3Ptr = IntPtr.Zero;
-        private static IntPtr FfiApiV4Ptr = IntPtr.Zero;
+        private static IntPtr FfiApiV1Ptr = IntPtr.Zero;
 
         [UnmanagedCallersOnly]
-        public static IntPtr Bindings_GetFfiApiV2()
+        public static IntPtr Bindings_GetFfiApiV1()
         {
             try
             {
-                lock (FfiApiV2Lock)
+                lock (FfiApiV1Lock)
                 {
-                    if (FfiApiV2Ptr == IntPtr.Zero)
+                    if (FfiApiV1Ptr == IntPtr.Zero)
                     {
-                        FfiApiV2 api = CreateFfiApiV2();
-                        FfiApiV2Ptr = Marshal.AllocCoTaskMem(Marshal.SizeOf<FfiApiV2>());
-                        Marshal.StructureToPtr(api, FfiApiV2Ptr, false);
+                        FfiApiV1 api = CreateFfiApiV1();
+                        FfiApiV1Ptr = Marshal.AllocCoTaskMem(Marshal.SizeOf<FfiApiV1>());
+                        Marshal.StructureToPtr(api, FfiApiV1Ptr, false);
                     }
 
-                    return FfiApiV2Ptr;
+                    return FfiApiV1Ptr;
                 }
             }
             catch
@@ -314,62 +294,17 @@ namespace NativeHost
             }
         }
 
-        [UnmanagedCallersOnly]
-        public static IntPtr Bindings_GetFfiApiV3()
+        private static unsafe FfiApiV1 CreateFfiApiV1()
         {
-            try
+            return new FfiApiV1
             {
-                lock (FfiApiV2Lock)
-                {
-                    if (FfiApiV3Ptr == IntPtr.Zero)
-                    {
-                        FfiApiV3 api = CreateFfiApiV3();
-                        FfiApiV3Ptr = Marshal.AllocCoTaskMem(Marshal.SizeOf<FfiApiV3>());
-                        Marshal.StructureToPtr(api, FfiApiV3Ptr, false);
-                    }
-
-                    return FfiApiV3Ptr;
-                }
-            }
-            catch
-            {
-                return IntPtr.Zero;
-            }
-        }
-
-        [UnmanagedCallersOnly]
-        public static IntPtr Bindings_GetFfiApiV4()
-        {
-            try
-            {
-                lock (FfiApiV2Lock)
-                {
-                    if (FfiApiV4Ptr == IntPtr.Zero)
-                    {
-                        FfiApiV4 api = CreateFfiApiV4();
-                        FfiApiV4Ptr = Marshal.AllocCoTaskMem(Marshal.SizeOf<FfiApiV4>());
-                        Marshal.StructureToPtr(api, FfiApiV4Ptr, false);
-                    }
-
-                    return FfiApiV4Ptr;
-                }
-            }
-            catch
-            {
-                return IntPtr.Zero;
-            }
-        }
-
-        private static unsafe FfiApiV2 CreateFfiApiV2()
-        {
-            return new FfiApiV2
-            {
-                Size = (nuint)Marshal.SizeOf<FfiApiV2>(),
+                Size = (nuint)Marshal.SizeOf<FfiApiV1>(),
                 AbiVersion = FfiBindingsAbiVersion,
                 FeatureFlags = (1UL << 4) | (1UL << 5) | (1UL << 6) | FfiFeatureAsyncOperationPrimitives |
                     FfiFeatureSessionPrimitives | FfiFeatureSessionPolling | FfiFeatureSnapshotProjections |
                     FfiFeatureSessionConfiguration | FfiFeatureSessionVariables | FfiFeatureCapabilityRpc |
-                    FfiFeatureLiveObjectProbe | FfiFeatureLiveSessionObjectProbe | FfiFeatureLiveObjectContracts,
+                    FfiFeatureLiveObjectProbe | FfiFeatureLiveSessionObjectProbe | FfiFeatureLiveObjectContracts |
+                    FfiFeatureLiveStreamPolling | FfiFeatureTypedResultPaging,
                 PowerShell_Create = (IntPtr)(delegate* unmanaged<IntPtr*, FfiCallResult*, int>)&FfiPowerShell_Create,
                 PowerShell_Release = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiPowerShell_Release,
                 PowerShell_AddArgumentUtf8 = (IntPtr)(delegate* unmanaged<IntPtr, byte*, int, FfiCallResult*, int>)&FfiPowerShell_AddArgumentUtf8,
@@ -420,16 +355,6 @@ namespace NativeHost
                 LiveObjectContractPack_Register = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiLiveObjectContractPack_Register,
                 PowerShellSession_SetLiveObjectContractVariable = (IntPtr)(delegate* unmanaged<IntPtr, byte*, int, NativeLiveObjectContractDescriptor*, IntPtr, FfiCallResult*, int>)&FfiPowerShellSession_SetLiveObjectContractVariable,
                 LiveObjectContractPack_RegisterMany = (IntPtr)(delegate* unmanaged<IntPtr*, uint, FfiCallResult*, int>)&FfiLiveObjectContractPack_RegisterMany,
-            };
-        }
-
-        private static unsafe FfiApiV3 CreateFfiApiV3()
-        {
-            return new FfiApiV3
-            {
-                Size = (nuint)Marshal.SizeOf<FfiApiV3>(),
-                AbiVersion = FfiBindingsLiveStreamAbiVersion,
-                FeatureFlags = FfiFeatureLiveStreamPolling,
                 PowerShell_BeginLiveInvocation = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr*, FfiCallResult*, int>)&FfiPowerShell_BeginLiveInvocation,
                 LiveInvocation_Poll = (IntPtr)(delegate* unmanaged<IntPtr, int*, FfiCallResult*, int>)&FfiLiveInvocation_Poll,
                 LiveInvocation_ReadBatch = (IntPtr)(delegate* unmanaged<IntPtr, long, int, IntPtr*, FfiCallResult*, int>)&FfiLiveInvocation_ReadBatch,
@@ -440,16 +365,6 @@ namespace NativeHost
                 LiveInvocation_Complete = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr*, FfiCallResult*, int>)&FfiLiveInvocation_Complete,
                 LiveInvocation_Stop = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiLiveInvocation_Stop,
                 LiveInvocation_Release = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiLiveInvocation_Release,
-            };
-        }
-
-        private static unsafe FfiApiV4 CreateFfiApiV4()
-        {
-            return new FfiApiV4
-            {
-                Size = (nuint)Marshal.SizeOf<FfiApiV4>(),
-                AbiVersion = FfiBindingsTypedResultPagingAbiVersion,
-                FeatureFlags = FfiFeatureTypedResultPaging,
                 PowerShell_BeginTypedResultInvocation = (IntPtr)(delegate* unmanaged<IntPtr, int, int, IntPtr*, FfiCallResult*, int>)&FfiPowerShell_BeginTypedResultInvocation,
                 TypedResultInvocation_Poll = (IntPtr)(delegate* unmanaged<IntPtr, int*, FfiCallResult*, int>)&FfiTypedResultInvocation_Poll,
                 TypedResultInvocation_ReadPage = (IntPtr)(delegate* unmanaged<IntPtr, long, int, IntPtr*, FfiCallResult*, int>)&FfiTypedResultInvocation_ReadPage,

--- a/dotnet/bindings/LiveObjectContractPackRegistry.cs
+++ b/dotnet/bindings/LiveObjectContractPackRegistry.cs
@@ -114,6 +114,7 @@ internal unsafe sealed class FfiLiveObjectContractPackRegistry
         }
 
         var additions = new Dictionary<PowerShellLiveObjectContract, Registration>();
+        var interfaceIds = new HashSet<Guid>();
         for (uint packIndex = 0; packIndex < apiCount; packIndex++)
         {
             IntPtr apiPointer = apiPointers[packIndex];
@@ -141,9 +142,11 @@ internal unsafe sealed class FfiLiveObjectContractPackRegistry
                 PowerShellLiveObjectContract contract =
                     PowerShellLiveObjectContract.FromNative(api.Contracts[contractIndex]);
                 if ((contract.Directions & PowerShellLiveObjectDirection.ConsumerToSession) == 0 ||
+                    !interfaceIds.Add(contract.InterfaceId) ||
                     !additions.TryAdd(contract, Registration.CreateExternal(create, release)))
                 {
-                    throw new InvalidOperationException("Live object contract pack contains duplicate or unsupported contracts.");
+                    throw new InvalidOperationException(
+                        "Live object contract packs contain duplicate or incompatible interface identifiers.");
                 }
             }
         }
@@ -152,9 +155,13 @@ internal unsafe sealed class FfiLiveObjectContractPackRegistry
         {
             foreach (PowerShellLiveObjectContract contract in additions.Keys)
             {
-                if (registrations.ContainsKey(contract))
+                foreach (PowerShellLiveObjectContract existing in registrations.Keys)
                 {
-                    throw new InvalidOperationException("A live object contract has already been registered.");
+                    if (existing.InterfaceId == contract.InterfaceId)
+                    {
+                        throw new InvalidOperationException(
+                            "A live object contract interface identifier has already been registered.");
+                    }
                 }
             }
 

--- a/dotnet/bindings/LiveObjectContractPackRegistry.cs
+++ b/dotnet/bindings/LiveObjectContractPackRegistry.cs
@@ -141,13 +141,23 @@ internal unsafe sealed class FfiLiveObjectContractPackRegistry
             {
                 PowerShellLiveObjectContract contract =
                     PowerShellLiveObjectContract.FromNative(api.Contracts[contractIndex]);
-                if ((contract.Directions & PowerShellLiveObjectDirection.ConsumerToSession) == 0 ||
-                    !interfaceIds.Add(contract.InterfaceId) ||
-                    !additions.TryAdd(contract, Registration.CreateExternal(create, release)))
-                {
-                    throw new InvalidOperationException(
-                        "Live object contract packs contain duplicate or incompatible interface identifiers.");
-                }
+                                if ((contract.Directions & PowerShellLiveObjectDirection.ConsumerToSession) == 0)
+                                {
+                                    throw new InvalidOperationException(
+                                        "Live object contract packs contain a contract with an unsupported direction.");
+                                }
+
+                                if (!interfaceIds.Add(contract.InterfaceId))
+                                {
+                                    throw new InvalidOperationException(
+                                        "Live object contract packs contain duplicate interface identifiers.");
+                                }
+
+                                if (!additions.TryAdd(contract, Registration.CreateExternal(create, release)))
+                                {
+                                    throw new InvalidOperationException(
+                                        "Live object contract packs contain incompatible interface identifiers.");
+                                }
             }
         }
 

--- a/dotnet/live-object-incompatible-test-pack/Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack.csproj
+++ b/dotnet/live-object-incompatible-test-pack/Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\interop\PowerShellLiveObjectContract.cs"
+             Link="PowerShellLiveObjectContract.cs" />
+  </ItemGroup>
+</Project>

--- a/dotnet/live-object-incompatible-test-pack/IncompatibleLiveObjectTestPack.cs
+++ b/dotnet/live-object-incompatible-test-pack/IncompatibleLiveObjectTestPack.cs
@@ -1,0 +1,53 @@
+#nullable enable
+
+using System.Runtime.InteropServices;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+namespace Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack;
+
+public static unsafe class IncompatibleLiveObjectTestPack
+{
+    private const int EFail = unchecked((int)0x80004005);
+    private static readonly IntPtr Api = CreateApi();
+
+    [UnmanagedCallersOnly]
+    public static IntPtr GetLiveObjectContractPackV1()
+    {
+        return Api;
+    }
+
+    [UnmanagedCallersOnly]
+    private static int CreatePayloadProxy(IntPtr _, IntPtr* __)
+    {
+        return EFail;
+    }
+
+    [UnmanagedCallersOnly]
+    private static void ReleasePayloadProxy(IntPtr _)
+    {
+    }
+
+    private static IntPtr CreateApi()
+    {
+        NativeLiveObjectContractDescriptor* contract =
+            (NativeLiveObjectContractDescriptor*)NativeMemory.Alloc((nuint)sizeof(NativeLiveObjectContractDescriptor));
+        *contract = new PowerShellLiveObjectContract(
+            Guid.Parse("C9A4FEA0-4EA6-48BE-8B4F-B30BB328CCBD"),
+            majorVersion: 1,
+            minorVersion: 1,
+            PowerShellLiveObjectDirection.ConsumerToSession).ToNative();
+
+        NativeLiveObjectContractPackApi* api =
+            (NativeLiveObjectContractPackApi*)NativeMemory.Alloc((nuint)sizeof(NativeLiveObjectContractPackApi));
+        *api = new NativeLiveObjectContractPackApi
+        {
+            Size = (nuint)sizeof(NativeLiveObjectContractPackApi),
+            AbiVersion = 1,
+            ContractCount = 1,
+            Contracts = contract,
+            CreatePayloadProxy = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr*, int>)&CreatePayloadProxy,
+            ReleasePayloadProxy = (IntPtr)(delegate* unmanaged<IntPtr, void>)&ReleasePayloadProxy,
+        };
+        return (IntPtr)api;
+    }
+}

--- a/dotnet/nativeaot-sample/NativeAotFfiSample.csproj
+++ b/dotnet/nativeaot-sample/NativeAotFfiSample.csproj
@@ -30,11 +30,16 @@
     <PwshFfiNativeLibrary>$(RepositoryRoot)\target\release\multi_pwsh_sdk.dll</PwshFfiNativeLibrary>
     <LiveObjectTestPackProject>$(MSBuildThisFileDirectory)..\live-object-test-pack\LiveObjectTestPack.csproj</LiveObjectTestPackProject>
     <LiveObjectTestPackAssembly>$(MSBuildThisFileDirectory)..\live-object-test-pack\bin\$(Configuration)\net8.0\Devolutions.MultiPwsh.LiveObject.TestPack.dll</LiveObjectTestPackAssembly>
+    <IncompatibleLiveObjectTestPackProject>$(MSBuildThisFileDirectory)..\live-object-incompatible-test-pack\Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack.csproj</IncompatibleLiveObjectTestPackProject>
+    <IncompatibleLiveObjectTestPackAssembly>$(MSBuildThisFileDirectory)..\live-object-incompatible-test-pack\bin\$(Configuration)\net8.0\Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack.dll</IncompatibleLiveObjectTestPackAssembly>
   </PropertyGroup>
 
   <Target Name="BuildAndStagePwshFfiNativeLibrary" BeforeTargets="Publish">
     <Exec Command="cargo build --release -p pwsh-sdk-ffi" WorkingDirectory="$(RepositoryRoot)" />
     <MSBuild Projects="$(LiveObjectTestPackProject)"
+             Targets="Restore;Build"
+             Properties="Configuration=$(Configuration)" />
+    <MSBuild Projects="$(IncompatibleLiveObjectTestPackProject)"
              Targets="Restore;Build"
              Properties="Configuration=$(Configuration)" />
   </Target>
@@ -43,5 +48,7 @@
     <Copy SourceFiles="$(PwshFfiNativeLibrary)" DestinationFiles="$(PublishDir)multi-pwsh-sdk.dll" />
     <Copy SourceFiles="$(LiveObjectTestPackAssembly)"
           DestinationFiles="$(PublishDir)Devolutions.MultiPwsh.LiveObject.TestPack.dll" />
+    <Copy SourceFiles="$(IncompatibleLiveObjectTestPackAssembly)"
+          DestinationFiles="$(PublishDir)Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack.dll" />
   </Target>
 </Project>

--- a/dotnet/nativeaot-sample/Program.cs
+++ b/dotnet/nativeaot-sample/Program.cs
@@ -11,9 +11,17 @@ using NativeAotFfiSample;
 string contractPackPath = System.IO.Path.Combine(
     AppContext.BaseDirectory,
     "Devolutions.MultiPwsh.LiveObject.TestPack.dll");
+string incompatibleContractPackPath = System.IO.Path.Combine(
+    AppContext.BaseDirectory,
+    "Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack.dll");
 if (!System.IO.File.Exists(contractPackPath))
 {
     Console.Error.WriteLine("NativeAOT facade did not publish the external live-object contract pack.");
+    return 1;
+}
+if (!System.IO.File.Exists(incompatibleContractPackPath))
+{
+    Console.Error.WriteLine("NativeAOT facade did not publish the incompatible live-object contract pack fixture.");
     return 1;
 }
 
@@ -23,6 +31,30 @@ PowerShellLiveObjectContractPack[] contractPacks =
         contractPackPath,
         "Devolutions.MultiPwsh.LiveObject.TestPack.LiveObjectTestPack, Devolutions.MultiPwsh.LiveObject.TestPack"),
 ];
+
+if (args.Length == 2 && args[1] == "--expect-incompatible-contract-pack")
+{
+    try
+    {
+        _ = PowerShellRuntime.Activate(
+            args[0],
+            [
+                contractPacks[0],
+                new PowerShellLiveObjectContractPack(
+                    incompatibleContractPackPath,
+                    "Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack.IncompatibleLiveObjectTestPack, Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack"),
+            ]);
+        Console.Error.WriteLine("Incompatible live-object contract metadata was accepted.");
+        return 1;
+    }
+    catch (PowerShellFfiException exception)
+        when (exception.Status == PowerShellFfiStatus.HostFailure &&
+              exception.Message.Contains("interface identifier", StringComparison.Ordinal))
+    {
+        Console.WriteLine("Incompatible live-object contract metadata: Rejected");
+        return 0;
+    }
+}
 
 PowerShellRuntime runtime;
 switch (args.Length)

--- a/dotnet/nativeaot-sample/Program.cs
+++ b/dotnet/nativeaot-sample/Program.cs
@@ -49,11 +49,13 @@ if (args.Length == 2 && args[1] == "--expect-incompatible-contract-pack")
     }
     catch (PowerShellFfiException exception)
         when (exception.Status == PowerShellFfiStatus.HostFailure &&
-              exception.Message.Contains("interface identifier", StringComparison.Ordinal))
-    {
-        Console.WriteLine("Incompatible live-object contract metadata: Rejected");
-        return 0;
-    }
+                  (exception.Message.Contains("interface identifier", StringComparison.Ordinal) ||
+                   exception.Message.Contains("unsupported direction", StringComparison.Ordinal) ||
+                   exception.Message.Contains("Live object contract packs", StringComparison.Ordinal)))
+        {
+            Console.WriteLine("Incompatible live-object contract metadata: Rejected");
+            return 0;
+        }
 }
 
 PowerShellRuntime runtime;

--- a/dotnet/sdk-ffi/PowerShell.cs
+++ b/dotnet/sdk-ffi/PowerShell.cs
@@ -38,7 +38,8 @@ public sealed unsafe class PowerShell : IDisposable
         InvocationMetadataFeature | AsyncOperationsFeature | SessionsFeature |
         SessionPollingFeature | SessionPoolRejectionFeature | SnapshotProjectionsFeature |
         SessionConfigurationFeature | SessionVariablesFeature | CapabilityRpcFeature |
-        LiveObjectProbeFeature | LiveSessionObjectProbeFeature | LiveObjectContractsFeature;
+        LiveObjectProbeFeature | LiveSessionObjectProbeFeature | LiveObjectContractsFeature |
+        LiveStreamPollingFeature | TypedResultPagingFeature;
     private const uint ResultTerminatingFailure = 1;
     private const uint ResultSequenceTruncated = 1 << 1;
     private const uint StreamTruncated = 1;

--- a/dotnet/sdk-ffi/README.md
+++ b/dotnet/sdk-ffi/README.md
@@ -78,13 +78,11 @@ wrappers over the single broker interface. The host must continue to end the
 lease authoritatively; generated root disposal never releases a lease held by
 potentially retained child wrappers.
 
-The facade requires native ABI v2. `ReadStreamBatch` is independently gated by
-the `LIVE_STREAM_POLLING` feature bit, so a native asset that lacks polling
-returns `UnsupportedCapability` before its additive export is called. Use
-matching 0.17.0 package and native assets to enable polling. Its `SafeHandle`
-wrapper keeps a native handle alive for each P/Invoke call, including concurrent
-disposal races. Empty strings are valid UTF-8 inputs; embedded NUL characters
-are rejected.
+The facade requires native ABI v2. The jointly shipped V1 payload binding table
+includes both `ReadStreamBatch` and typed-result paging; use matching package,
+native asset, and managed payload bindings. Its `SafeHandle` wrapper keeps a
+native handle alive for each P/Invoke call, including concurrent disposal races.
+Empty strings are valid UTF-8 inputs; embedded NUL characters are rejected.
 
 `PowerShellValue` is the only way to pass non-string values. It supports
 bounded primitive values, bytes, arrays, and property bags that become copied
@@ -168,17 +166,15 @@ are never silently complete. This primitive is deliberately distinct from
 typed data feed, and it never exposes SMA values or unbounded retention.
 
 `BeginTypedResultInvocation(options)` connects that acknowledgement model to
-an invocation's output through the additive `TYPED_RESULT_PAGING` native
-feature. `Read(acknowledgedThrough, maximumRecords)` acknowledges the prior
-page and returns only copied `PowerShellValue` records (including bounded
-arrays and property bags), never SMA objects, `PSObject`, or display text.
-The configured buffer is a hard producer backpressure limit; values are not
-dropped to make room. Each page reports total, dropped, truncation, terminal,
-and completeness metadata. Outputs that cannot be represented losslessly as a
-documented tagged value terminate the typed operation with `UnsupportedValue`
-rather than being converted to text or silently omitted. Older native assets
-are rejected with `UnsupportedCapability` before the additive exports are
-called.
+an invocation's output through the required V1 payload binding table.
+`Read(acknowledgedThrough, maximumRecords)` acknowledges the prior page and
+returns only copied `PowerShellValue` records (including bounded arrays and
+property bags), never SMA objects, `PSObject`, or display text. The configured
+buffer is a hard producer backpressure limit; values are not dropped to make
+room. Each page reports total, dropped, truncation, terminal, and completeness
+metadata. Outputs that cannot be represented losslessly as a documented tagged
+value terminate the typed operation with `UnsupportedValue` rather than being
+converted to text or silently omitted.
 
 `PowerShellRuntime.CreateSession(PowerShellSessionOptions)` creates a separate,
 reusable local-runspace session. `PowerShellSessionConfiguration` supplies

--- a/tests/PwshFfiApiBaseline.txt
+++ b/tests/PwshFfiApiBaseline.txt
@@ -1,6 +1,4 @@
-bindings:Bindings_GetFfiApiV2
-bindings:Bindings_GetFfiApiV3
-bindings:Bindings_GetFfiApiV4
+bindings:Bindings_GetFfiApiV1
 bindings:FfiInvocationResult_CopyStreamRecordFieldToUtf8
 bindings:FfiInvocationResult_CopyStreamRecordValue
 bindings:FfiInvocationResult_GetInfo

--- a/tests/PwshFfiApiBaselineInspector/Program.cs
+++ b/tests/PwshFfiApiBaselineInspector/Program.cs
@@ -112,9 +112,9 @@ static void ValidateAbiCompatibility(Assembly facadeAssembly, BindingFlags stati
         throw new InvalidOperationException("The facade must retain an ABI validation overload that accepts NativeAbiInfo.");
     }
 
-    const ulong allRequiredFeatures = 0xFFDFF;
+    const ulong allRequiredFeatures = 0x3FFDFF;
     ensureSupportedAbi.Invoke(null, [CreateAbiInfo(abiInfoType, allRequiredFeatures, abiVersion: 2, minimumCompatibleAbiVersion: 2)]);
-    for (int bit = 0; bit <= 19; bit++)
+    for (int bit = 0; bit <= 21; bit++)
     {
         if ((allRequiredFeatures & (1UL << bit)) == 0)
         {
@@ -144,31 +144,6 @@ static void ValidateAbiCompatibility(Assembly facadeAssembly, BindingFlags stati
         throw new InvalidOperationException("Facade ABI validation accepted an incompatible minimum ABI version.");
     }
 
-    MethodInfo? ensureTypedResultPagingSupported = powerShellType.GetMethod(
-        "EnsureTypedResultPagingSupported",
-        staticNonPublic,
-        binder: null,
-        types: [abiInfoType],
-        modifiers: null);
-    if (ensureTypedResultPagingSupported is null)
-    {
-        throw new InvalidOperationException("The facade must retain a typed result paging feature gate.");
-    }
-
-    const ulong typedResultPagingFeature = 1UL << 21;
-    ensureTypedResultPagingSupported.Invoke(
-        null,
-        [CreateAbiInfo(
-            abiInfoType,
-            allRequiredFeatures | typedResultPagingFeature,
-            abiVersion: 2,
-            minimumCompatibleAbiVersion: 2)]);
-    if (!IsUnsupportedCapability(
-            ensureTypedResultPagingSupported,
-            CreateAbiInfo(abiInfoType, allRequiredFeatures, abiVersion: 2, minimumCompatibleAbiVersion: 2)))
-    {
-        throw new InvalidOperationException("Facade typed result paging feature gate accepted an absent feature bit.");
-    }
 }
 
 static object CreateAbiInfo(Type abiInfoType, ulong featureFlags, uint abiVersion, uint minimumCompatibleAbiVersion)
@@ -191,21 +166,6 @@ static bool IsRejected(MethodInfo ensureSupportedAbi, object abiInfo)
         return false;
     }
     catch (TargetInvocationException exception) when (exception.InnerException is NotSupportedException)
-    {
-        return true;
-    }
-}
-
-static bool IsUnsupportedCapability(MethodInfo featureGate, object abiInfo)
-{
-    try
-    {
-        featureGate.Invoke(null, [abiInfo]);
-        return false;
-    }
-    catch (TargetInvocationException exception)
-        when (exception.InnerException is PowerShellFfiException ffiException &&
-              ffiException.Status == PowerShellFfiStatus.UnsupportedCapability)
     {
         return true;
     }

--- a/tests/Test-PwshFfiPackage.ps1
+++ b/tests/Test-PwshFfiPackage.ps1
@@ -33,6 +33,22 @@ function Get-MultiPwshVersion {
     return $match.Matches[0].Groups[1].Value
 }
 
+function Get-GlobalNuGetPackagesPath {
+    $line = & dotnet nuget locals global-packages --list |
+        Where-Object { $_ -like 'global-packages:*' } |
+        Select-Object -First 1
+    if ([string]::IsNullOrWhiteSpace($line)) {
+        throw 'Unable to resolve the global NuGet packages path.'
+    }
+
+    $path = $line.Substring('global-packages:'.Length).Trim()
+    if (-not (Test-Path $path -PathType Container)) {
+        throw "The global NuGet packages path does not exist: $path"
+    }
+
+    return $path
+}
+
 $multiPwshVersion = Get-MultiPwshVersion
 $sdkNativeAssets = @{
     'win-x64' = 'multi-pwsh-sdk.dll'
@@ -73,8 +89,15 @@ function Resolve-PowerShellPayloadDirectory {
 
     $resolved = (Resolve-Path $Path).Path
     if (-not (Test-Path (Join-Path $resolved 'pwsh.dll') -PathType Leaf) -or
-        -not (Test-Path (Join-Path $resolved 'pwsh.runtimeconfig.json') -PathType Leaf)) {
-        throw "The PowerShell payload is missing pwsh.dll or pwsh.runtimeconfig.json: $resolved"
+        -not (Test-Path (Join-Path $resolved 'pwsh.runtimeconfig.json') -PathType Leaf) -or
+        -not (Test-Path (Join-Path $resolved 'System.Management.Automation.dll') -PathType Leaf) -or
+        -not (Test-Path (Join-Path $resolved 'pwsh.exe') -PathType Leaf)) {
+        throw "The PowerShell payload is missing pwsh.dll, pwsh.runtimeconfig.json, System.Management.Automation.dll, or pwsh.exe: $resolved"
+    }
+
+    $version = & (Join-Path $resolved 'pwsh.exe') -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
+    if ($LASTEXITCODE -ne 0 -or $version -notmatch '^7\.4\.') {
+        throw "The FFI package smoke requires a PowerShell 7.4 payload, but '$resolved' reported '$version'."
     }
 
     return $resolved
@@ -154,7 +177,15 @@ $payloadDirectory = Resolve-PowerShellPayloadDirectory -Path $PowerShellPayloadD
 $workspace = Join-Path (Join-Path $repoRoot 'artifacts') "ffi-package-smoke-$([guid]::NewGuid().ToString('N'))"
 $nugetCache = Join-Path $workspace 'nuget-cache'
 $oldNugetPackages = $env:NUGET_PACKAGES
+$oldNugetFallbackPackages = $env:NUGET_FALLBACK_PACKAGES
+$globalNugetPackages = Get-GlobalNuGetPackagesPath
 $env:NUGET_PACKAGES = $nugetCache
+$env:NUGET_FALLBACK_PACKAGES = if ([string]::IsNullOrWhiteSpace($oldNugetFallbackPackages)) {
+    $globalNugetPackages
+}
+else {
+    $globalNugetPackages + [System.IO.Path]::PathSeparator + $oldNugetFallbackPackages
+}
 
 try {
     New-Item -Path $nugetCache -ItemType Directory -Force | Out-Null
@@ -581,6 +612,270 @@ async Task VerifySafeHandleDisposeRacesAsync()
     }
 }
 
+PowerShellValuePage WaitForTypedPage(
+    PowerShellTypedResultInvocation invocation,
+    ulong acknowledgedThrough,
+    int maximumRecords,
+    Func<PowerShellValuePage, bool> predicate,
+    string description)
+{
+    DateTime deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+    while (DateTime.UtcNow < deadline)
+    {
+        PowerShellValuePage page = invocation.Read(acknowledgedThrough, maximumRecords);
+        if (predicate(page))
+        {
+            return page;
+        }
+
+        Thread.Sleep(10);
+    }
+
+    throw new TimeoutException("Timed out waiting for " + description + ".");
+}
+
+PowerShell CreatePowerShellWhenAvailable(PowerShellRuntime runtime, string description)
+{
+    DateTime deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+    while (DateTime.UtcNow < deadline)
+    {
+        try
+        {
+            return runtime.Create();
+        }
+        catch (PowerShellFfiException exception)
+            when (exception.Status == PowerShellFfiStatus.Backpressure)
+        {
+            Thread.Sleep(10);
+        }
+    }
+
+    throw new TimeoutException("Timed out waiting for the typed result pipeline to release " + description + ".");
+}
+
+async Task VerifyTypedResultPagingAsync(PowerShellRuntime runtime)
+{
+    Require(
+        (runtime.FeatureFlags & (1UL << 21)) != 0,
+        "The packaged NativeAOT consumer did not negotiate typed result paging.");
+
+    using (PowerShell builder = CreatePowerShellWhenAvailable(runtime, "the first typed result builder"))
+    using (PowerShellTypedResultInvocation invocation = builder
+        .AddScript("1, 2, [pscustomobject]@{ Name = 'third'; Count = 3 }")
+        .BeginTypedResultInvocation(new PowerShellValuePagerOptions(
+            maximumBufferedRecords: 2,
+            maximumPageRecords: 2)))
+    {
+        PowerShellValuePage firstPage = WaitForTypedPage(
+            invocation,
+            acknowledgedThrough: 0,
+            maximumRecords: 2,
+            page => page.Records.Count == 2,
+            "the backpressure-limited first typed result page");
+        Require(
+            !firstPage.IsTerminal &&
+            firstPage.TotalRecordCount == 2 &&
+            firstPage.NextSequence == 2 &&
+            firstPage.Records[0].Value.TryGetSignedInteger(out long firstValue) &&
+            firstValue == 1 &&
+            firstPage.Records[1].Value.TryGetSignedInteger(out long secondValue) &&
+            secondValue == 2,
+            "Typed result paging did not retain the first bounded page before acknowledgement.");
+
+        PowerShellValuePage replayPage = invocation.Read(acknowledgedThrough: 0, maximumRecords: 2);
+        Require(
+            replayPage.AcknowledgedSequence == 0 &&
+            replayPage.Records.Select(record => record.Sequence).SequenceEqual(firstPage.Records.Select(record => record.Sequence)),
+            "Typed result paging implicitly acknowledged records without the caller cursor.");
+
+        PowerShellValuePage secondPage = WaitForTypedPage(
+            invocation,
+            acknowledgedThrough: firstPage.NextSequence,
+            maximumRecords: 1,
+            page => page.Records.Count == 1,
+            "the record released by typed result acknowledgement");
+        Require(
+            secondPage.AcknowledgedSequence == firstPage.NextSequence &&
+            secondPage.TotalRecordCount == 3 &&
+            secondPage.Records[0].Value.TryGetProperty("Name", out PowerShellValue? name) &&
+            name!.TryGetString(out string? nameText) &&
+            nameText == "third" &&
+            secondPage.Records[0].Value.TryGetProperty("Count", out PowerShellValue? count) &&
+            count!.TryGetSignedInteger(out long countValue) &&
+            countValue == 3,
+            "Acknowledging the first typed page did not release the blocked copied property-bag result.");
+
+        PowerShellValuePage completePage = WaitForTypedPage(
+            invocation,
+            acknowledgedThrough: secondPage.NextSequence,
+            maximumRecords: 1,
+            page => page.IsTerminal,
+            "typed result completion");
+        Require(
+            completePage.IsComplete &&
+            completePage.TerminalStatus == PowerShellFfiStatus.Success &&
+            completePage.TotalRecordCount == 3 &&
+            completePage.DroppedRecordCount == 0 &&
+            !completePage.IsTruncated,
+            "Typed result paging did not report fully acknowledged success.");
+    }
+
+    using (PowerShell unsupportedBuilder = CreatePowerShellWhenAvailable(runtime, "the unsupported result builder"))
+    using (PowerShellTypedResultInvocation unsupportedInvocation = unsupportedBuilder
+        .AddScript("Write-Output -NoEnumerate ([version]'1.2.3.4')")
+        .BeginTypedResultInvocation())
+    {
+        PowerShellValuePage unsupportedPage = WaitForTypedPage(
+            unsupportedInvocation,
+            acknowledgedThrough: 0,
+            maximumRecords: 1,
+            page => page.IsTerminal,
+            "an unsupported typed result terminal state");
+        Require(
+            unsupportedPage.TerminalStatus == PowerShellFfiStatus.UnsupportedValue &&
+            !unsupportedPage.IsComplete &&
+            unsupportedPage.Records.Count == 0,
+            "Unsupported typed PowerShell output was not surfaced as UnsupportedValue.");
+    }
+
+    using (PowerShell cancellationBuilder = CreatePowerShellWhenAvailable(runtime, "the cancellation builder"))
+    using (PowerShellTypedResultInvocation cancellationInvocation = cancellationBuilder
+        .AddScript("Start-Sleep -Seconds 5; 'must-not-complete'")
+        .BeginTypedResultInvocation())
+    {
+        Thread.Sleep(50);
+        cancellationInvocation.Stop();
+        cancellationInvocation.Stop();
+        PowerShellValuePage cancelledPage = WaitForTypedPage(
+            cancellationInvocation,
+            acknowledgedThrough: 0,
+            maximumRecords: 1,
+            page => page.IsTerminal,
+            "typed result cancellation");
+        Require(
+            cancelledPage.TerminalStatus == PowerShellFfiStatus.OperationCancelled &&
+            !cancelledPage.IsComplete,
+            "Stopping a typed result invocation did not produce the cancelled terminal state.");
+    }
+
+    for (int iteration = 0; iteration < 4; iteration++)
+    {
+        PowerShell lifecycleBuilder = CreatePowerShellWhenAvailable(runtime, "the lifecycle race builder")
+            .AddScript("Start-Sleep -Milliseconds 150; 'typed-safe-handle-lease'");
+        PowerShellTypedResultInvocation lifecycleInvocation = lifecycleBuilder.BeginTypedResultInvocation();
+        using var readStarted = new ManualResetEventSlim(false);
+        Task reader = Task.Run(() =>
+        {
+            readStarted.Set();
+            try
+            {
+                for (int read = 0; read < 32; read++)
+                {
+                    _ = lifecycleInvocation.Read(0, 1);
+                    Thread.Sleep(1);
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        });
+        Task disposer = Task.Run(() =>
+        {
+            readStarted.Wait();
+            Thread.Sleep(5);
+            lifecycleInvocation.Dispose();
+            lifecycleInvocation.Dispose();
+        });
+        await Task.WhenAll(reader, disposer).WaitAsync(TimeSpan.FromSeconds(10));
+        lifecycleBuilder.Dispose();
+    }
+
+    using PowerShell availabilityCheck = CreatePowerShellWhenAvailable(runtime, "subsequent facade calls");
+}
+
+void VerifyTransactionAndHostCapabilities(PowerShellSession session)
+{
+    var stagedIntent = new StagedIntentCapability();
+    var hostInteractions = new HostInteractionCapability();
+    PowerShellCapabilityDefinition stageIntentDefinition = new(
+        "example.stage-intent",
+        [new PowerShellCapabilityArgumentSchema([PowerShellValueKind.PropertyBag])],
+        [PowerShellValueKind.Null],
+        PowerShellCapabilityPermission.Write,
+        maximumInputBytes: 4096,
+        maximumOutputBytes: 64,
+        deadline: TimeSpan.FromSeconds(5));
+    using PowerShellCapabilitySet capabilities = PowerShellCapabilitySet.Register(
+    [
+        new PowerShellCapabilityBinding(stageIntentDefinition, stagedIntent),
+        new PowerShellCapabilityBinding(PowerShellHostInteraction.WriteText, hostInteractions),
+        new PowerShellCapabilityBinding(PowerShellHostInteraction.ReportProgress, hostInteractions),
+        new PowerShellCapabilityBinding(PowerShellHostInteraction.PromptChoice, hostInteractions),
+    ]);
+
+    using (PowerShell successful = session.CreatePowerShell())
+    {
+        PowerShellInvocationResult result = successful
+            .AddScript(
+                "`$null = `$DpsCapabilities.Invoke('example.stage-intent', [pscustomobject]@{ Id = 'intent-1'; Name = 'committed' })\n" +
+                "`$null = `$DpsCapabilities.Invoke('host.write-text', 'host-text')\n" +
+                "`$null = `$DpsCapabilities.Invoke('host.report-progress', [pscustomobject]@{ ActivityId = 9; ParentActivityId = -1; Activity = 'Copy'; StatusDescription = 'Running'; PercentComplete = 50; SecondsRemaining = 3; IsCompleted = `$false })\n" +
+                "`$DpsCapabilities.Invoke('host.prompt-choice', [pscustomobject]@{ Caption = 'Caption'; Message = 'Message'; Choices = @('first', 'second'); DefaultChoice = 0 })")
+            .WithCapabilities(capabilities)
+            .Invoke();
+        stagedIntent.CommitAfterSuccess(result);
+        Require(
+            result.Output.Records.Count == 1 &&
+            result.Output.Records[0].DisplayText == "1" &&
+            stagedIntent.CommittedName == "committed" &&
+            hostInteractions.Text == "host-text" &&
+            hostInteractions.Progress is { ActivityId: 9, PercentComplete: 50 } &&
+            hostInteractions.PromptCount == 1,
+            "Declared transaction and host capabilities did not round-trip through the copied capability bridge.");
+    }
+
+    using (PowerShell denied = session.CreatePowerShell())
+    {
+        int hostCalls = hostInteractions.CallCount;
+        try
+        {
+            denied
+                .AddScript("`$DpsCapabilities.Invoke('host.read-line', 'not-registered')")
+                .WithCapabilities(capabilities)
+                .Invoke();
+            throw new InvalidOperationException("An unregistered capability was accepted.");
+        }
+        catch (PowerShellInvocationException)
+        {
+        }
+
+        Require(
+            hostInteractions.CallCount == hostCalls,
+            "An unregistered capability reached a registered handler.");
+    }
+
+    using (PowerShell failed = session.CreatePowerShell())
+    {
+        try
+        {
+            failed
+                .AddScript("`$null = `$DpsCapabilities.Invoke('example.stage-intent', [pscustomobject]@{ Id = 'intent-2'; Name = 'discarded' }); throw 'rollback'")
+                .WithCapabilities(capabilities)
+                .Invoke();
+            throw new InvalidOperationException("A terminating transaction script returned successfully.");
+        }
+        catch (PowerShellInvocationException)
+        {
+            stagedIntent.Discard();
+        }
+
+        Require(
+            stagedIntent.CommittedName == "committed" &&
+            stagedIntent.StagedName is null,
+            "A failed invocation committed a staged capability intent.");
+    }
+}
+
 if (args.Length != 1)
 {
    return 2;
@@ -591,6 +886,7 @@ VerifyCopiedValueReaders();
 VerifyScriptParameterMetadata(runtime);
 VerifyProgressUpdate();
 await VerifyRecipesSchemasAndPoliciesAsync(runtime);
+await VerifyTypedResultPagingAsync(runtime);
 const string SecretMarker = "ffi-secret-marker-not-accepted";
 Require(
    PowerShellSecretTransfer.Policy == PowerShellSecretTransferPolicy.Rejected &&
@@ -963,7 +1259,11 @@ using (PowerShellInvocationOperation cancelledCapabilityOperation = cancelledCap
     Require(
         cancelledCapabilityOperation.Wait(TimeSpan.FromSeconds(5)).State == PowerShellOperationState.Cancelled,
         "Stopping an active capability invocation did not cancel the handler and operation.");
+    Require(
+        cancellableHandler.CancellationObserved,
+        "Stopping an active capability invocation did not signal the handler cancellation token.");
 }
+VerifyTransactionAndHostCapabilities(session);
 
 PowerShellValue copiedVariable = PowerShellValue.PropertyBag(new[]
 {
@@ -1250,6 +1550,8 @@ sealed class CancellableCapability : IPowerShellCapabilityHandler, IDisposable
 {
     public ManualResetEventSlim Started { get; } = new(false);
 
+    public bool CancellationObserved { get; private set; }
+
     public PowerShellValue Invoke(
         PowerShellCapabilityInvocation invocation,
         IReadOnlyList<PowerShellValue> arguments)
@@ -1260,6 +1562,7 @@ sealed class CancellableCapability : IPowerShellCapabilityHandler, IDisposable
             Thread.Sleep(10);
         }
 
+        CancellationObserved = true;
         invocation.CancellationToken.ThrowIfCancellationRequested();
         return PowerShellValue.Null;
     }
@@ -1267,6 +1570,105 @@ sealed class CancellableCapability : IPowerShellCapabilityHandler, IDisposable
     public void Dispose()
     {
         Started.Dispose();
+    }
+}
+
+sealed class StagedIntentCapability : IPowerShellCapabilityHandler
+{
+    public string? StagedName { get; private set; }
+
+    public string? CommittedName { get; private set; }
+
+    public PowerShellValue Invoke(
+        PowerShellCapabilityInvocation invocation,
+        IReadOnlyList<PowerShellValue> arguments)
+    {
+        if (invocation.Definition.Name != "example.stage-intent" ||
+            arguments.Count != 1 ||
+            arguments[0].Kind != PowerShellValueKind.PropertyBag)
+        {
+            throw new ArgumentException("The staged intent capability contract was not preserved.");
+        }
+
+        IReadOnlyDictionary<string, PowerShellValue> properties = arguments[0].GetPropertyBag();
+        if (properties.Count != 2 ||
+            !properties.TryGetValue("Id", out PowerShellValue? identifier) ||
+            !identifier!.TryGetString(out string? identifierText) ||
+            identifierText != "intent-1" && identifierText != "intent-2" ||
+            !properties.TryGetValue("Name", out PowerShellValue? name) ||
+            !name!.TryGetString(out string? nameText) ||
+            string.IsNullOrWhiteSpace(nameText))
+        {
+            throw new ArgumentException("The staged intent payload is invalid.");
+        }
+
+        StagedName = nameText;
+        return PowerShellValue.Null;
+    }
+
+    public void CommitAfterSuccess(PowerShellInvocationResult result)
+    {
+        if (result.HadErrors || result.IsTerminatingFailure || StagedName is null)
+        {
+            throw new InvalidOperationException("Only a successful invocation can commit a staged intent.");
+        }
+
+        CommittedName = StagedName;
+        StagedName = null;
+    }
+
+    public void Discard()
+    {
+        StagedName = null;
+    }
+}
+
+sealed class HostInteractionCapability : IPowerShellCapabilityHandler
+{
+    public int CallCount { get; private set; }
+
+    public string? Text { get; private set; }
+
+    public PowerShellProgressUpdate? Progress { get; private set; }
+
+    public int PromptCount { get; private set; }
+
+    public PowerShellValue Invoke(
+        PowerShellCapabilityInvocation invocation,
+        IReadOnlyList<PowerShellValue> arguments)
+    {
+        CallCount++;
+        switch (invocation.Definition.Name)
+        {
+            case "host.write-text":
+                if (arguments.Count != 1 ||
+                    !arguments[0].TryGetString(out string? text) ||
+                    text != "host-text")
+                {
+                    throw new ArgumentException("The host text capability payload is invalid.");
+                }
+
+                Text = text;
+                return PowerShellValue.Null;
+            case "host.report-progress":
+                if (arguments.Count != 1)
+                {
+                    throw new ArgumentException("The host progress capability payload is invalid.");
+                }
+
+                Progress = PowerShellHostInteraction.ParseProgressUpdate(arguments[0]);
+                return PowerShellValue.Null;
+            case "host.prompt-choice":
+                if (arguments.Count != 1 || arguments[0].Kind != PowerShellValueKind.PropertyBag)
+                {
+                    throw new ArgumentException("The host choice capability payload is invalid.");
+                }
+
+                PromptCount++;
+                return PowerShellValue.SignedInteger(1);
+            default:
+                throw new ArgumentException("The host capability is not registered.");
+        }
     }
 }
 "@ | Set-Content -Path (Join-Path $consumerDirectory 'Program.cs') -Encoding utf8
@@ -1295,6 +1697,12 @@ finally {
     }
     else {
         $env:NUGET_PACKAGES = $oldNugetPackages
+    }
+    if ($null -eq $oldNugetFallbackPackages) {
+        Remove-Item Env:NUGET_FALLBACK_PACKAGES -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:NUGET_FALLBACK_PACKAGES = $oldNugetFallbackPackages
     }
 
     if ($KeepWorkspace) {

--- a/tests/Test-PwshFfiPackage.ps1
+++ b/tests/Test-PwshFfiPackage.ps1
@@ -33,20 +33,41 @@ function Get-MultiPwshVersion {
     return $match.Matches[0].Groups[1].Value
 }
 
-function Get-GlobalNuGetPackagesPath {
-    $line = & dotnet nuget locals global-packages --list |
-        Where-Object { $_ -like 'global-packages:*' } |
-        Select-Object -First 1
-    if ([string]::IsNullOrWhiteSpace($line)) {
-        throw 'Unable to resolve the global NuGet packages path.'
+function Assert-RestoredPackageMatchesInspectedNupkg {
+    param(
+        [Parameter(Mandatory)][string]$NugetCache,
+        [Parameter(Mandatory)][string]$PackageId,
+        [Parameter(Mandatory)][string]$PackageVersion,
+        [Parameter(Mandatory)][string]$InspectedPackagePath
+    )
+
+    $restoredRoot = Join-Path $NugetCache ("{0}\{1}" -f $PackageId.ToLowerInvariant(), $PackageVersion)
+    if (-not (Test-Path -LiteralPath $restoredRoot -PathType Container)) {
+        throw "Restore did not install $PackageId $PackageVersion into the isolated NuGet cache at $restoredRoot."
     }
 
-    $path = $line.Substring('global-packages:'.Length).Trim()
-    if (-not (Test-Path $path -PathType Container)) {
-        throw "The global NuGet packages path does not exist: $path"
+    $expectedHash = (Get-FileHash -Algorithm SHA512 -LiteralPath $InspectedPackagePath).Hash
+    $shaFile = Join-Path $restoredRoot "$PackageId.$PackageVersion.nupkg.sha512"
+    if (Test-Path -LiteralPath $shaFile -PathType Leaf) {
+        $actualBase64 = (Get-Content -LiteralPath $shaFile -Raw).Trim()
+        $actualBytes = [Convert]::FromBase64String($actualBase64)
+        $actualHash = [BitConverter]::ToString($actualBytes).Replace('-', '')
+        if (-not $actualHash.Equals($expectedHash, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Restored $PackageId $PackageVersion does not match the inspected local nupkg hash."
+        }
+
+        return
     }
 
-    return $path
+    $restoredNupkg = Join-Path $restoredRoot "$PackageId.$PackageVersion.nupkg"
+    if (-not (Test-Path -LiteralPath $restoredNupkg -PathType Leaf)) {
+        throw "Restore did not materialize $PackageId $PackageVersion nupkg metadata for hash verification."
+    }
+
+    $actualHash = (Get-FileHash -Algorithm SHA512 -LiteralPath $restoredNupkg).Hash
+    if (-not $actualHash.Equals($expectedHash, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Restored $PackageId $PackageVersion does not match the inspected local nupkg hash."
+    }
 }
 
 $multiPwshVersion = Get-MultiPwshVersion
@@ -174,21 +195,22 @@ finally {
 }
 
 $payloadDirectory = Resolve-PowerShellPayloadDirectory -Path $PowerShellPayloadDirectory
-$workspace = Join-Path (Join-Path $repoRoot 'artifacts') "ffi-package-smoke-$([guid]::NewGuid().ToString('N'))"
-$nugetCache = Join-Path $workspace 'nuget-cache'
+$smokeId = [guid]::NewGuid().ToString('N')
+$workspace = Join-Path (Join-Path $repoRoot 'artifacts') "ffi-package-smoke-$smokeId"
+# Keep the isolated package cache on a short path so NativeAOT link inputs stay well
+# under legacy MAX_PATH limits while still excluding every fallback folder.
+$nugetCache = Join-Path ([System.IO.Path]::GetTempPath()) "mpwsh-nupkg-$smokeId"
 $oldNugetPackages = $env:NUGET_PACKAGES
 $oldNugetFallbackPackages = $env:NUGET_FALLBACK_PACKAGES
-$globalNugetPackages = Get-GlobalNuGetPackagesPath
 $env:NUGET_PACKAGES = $nugetCache
-$env:NUGET_FALLBACK_PACKAGES = if ([string]::IsNullOrWhiteSpace($oldNugetFallbackPackages)) {
-    $globalNugetPackages
-}
-else {
-    $globalNugetPackages + [System.IO.Path]::PathSeparator + $oldNugetFallbackPackages
-}
+# Do not point fallback folders at the user global cache: a pre-existing
+# Devolutions.MultiPwsh.Sdk/<version> copy there would satisfy restore without
+# exercising the inspected local nupkg.
+$env:NUGET_FALLBACK_PACKAGES = ''
 
 try {
     New-Item -Path $nugetCache -ItemType Directory -Force | Out-Null
+    New-Item -Path $workspace -ItemType Directory -Force | Out-Null
     $nugetConfig = Join-Path $workspace 'NuGet.Config'
     @"
 <?xml version="1.0" encoding="utf-8"?>
@@ -219,6 +241,7 @@ try {
     'using System; Console.WriteLine("inert");' | Set-Content -Path (Join-Path $inertProjectDirectory 'Program.cs') -Encoding utf8
 
     Invoke-CheckedCommand -FilePath dotnet -ArgumentList @('restore', $inertProject, '--configfile', $nugetConfig)
+    Assert-RestoredPackageMatchesInspectedNupkg -NugetCache $nugetCache -PackageId $packageId -PackageVersion $PackageVersion -InspectedPackagePath $package.FullName
     Invoke-CheckedCommand -FilePath dotnet -ArgumentList @('build', $inertProject, '--no-restore', '-c', $Configuration)
     $inertNativeAsset = Join-Path $inertProjectDirectory "bin\$Configuration\net10.0\win-x64\multi-pwsh-sdk.dll"
     if (Test-Path $inertNativeAsset -PathType Leaf) {
@@ -1674,7 +1697,8 @@ sealed class HostInteractionCapability : IPowerShellCapabilityHandler
 "@ | Set-Content -Path (Join-Path $consumerDirectory 'Program.cs') -Encoding utf8
 
     Invoke-CheckedCommand -FilePath dotnet -ArgumentList @('restore', $consumerProject, '--configfile', $nugetConfig)
-    Invoke-CheckedCommand -FilePath dotnet -ArgumentList @('publish', $consumerProject, '--no-restore', '-c', $Configuration)
+        Assert-RestoredPackageMatchesInspectedNupkg -NugetCache $nugetCache -PackageId $packageId -PackageVersion $PackageVersion -InspectedPackagePath $package.FullName
+        Invoke-CheckedCommand -FilePath dotnet -ArgumentList @('publish', $consumerProject, '--no-restore', '-c', $Configuration)
 
     $publishDirectory = Join-Path $consumerDirectory "bin\$Configuration\net10.0\win-x64\publish"
     $consumerExe = Join-Path $publishDirectory 'FfiPackageConsumer.exe'
@@ -1707,8 +1731,10 @@ finally {
 
     if ($KeepWorkspace) {
         Write-Host "Kept smoke workspace: $workspace"
+            Write-Host "Kept isolated NuGet cache: $nugetCache"
+        }
+        else {
+            Remove-Item -Path $workspace -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $nugetCache -Recurse -Force -ErrorAction SilentlyContinue
+        }
     }
-    else {
-        Remove-Item -Path $workspace -Recurse -Force -ErrorAction SilentlyContinue
-    }
-}

--- a/tests/Verify-PwshFfiApiBaseline.ps1
+++ b/tests/Verify-PwshFfiApiBaseline.ps1
@@ -296,19 +296,6 @@ $expectedTableSlots = @(
     @{ Field = 'LiveObjectContractPack_RegisterMany'; Rust = 'live_object_contract_pack_register_many_fn'; Alias = 'FnFfiLiveObjectContractPackRegisterMany'; Method = 'FfiLiveObjectContractPack_RegisterMany'; Signature = 'IntPtr*,uint,FfiCallResult*,int' }
 )
 
-$ffiApiType = $bindingsAssemblyObject.GetType('NativeHost.Bindings+FfiApiV2', $true)
-Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiType)) -Expected 424 -Description 'Managed FfiApiV2 size'
-$ffiApiFields = @($ffiApiType.GetFields($instanceFields) | Sort-Object MetadataToken)
-$expectedFfiApiFieldNames = @('Size', 'AbiVersion', 'FeatureFlags') + @($expectedTableSlots | ForEach-Object { $_.Field })
-Assert-Sequence -Actual @($ffiApiFields | ForEach-Object Name) -Expected $expectedFfiApiFieldNames -Description 'Managed FfiApiV2 slot order'
-for ($index = 0; $index -lt $ffiApiFields.Count; $index++) {
-    $field = $ffiApiFields[$index]
-    $expectedOffset = if ($index -eq 0) { 0 } elseif ($index -eq 1) { 8 } elseif ($index -eq 2) { 16 } else { 24 + (($index - 3) * 8) }
-    $expectedType = if ($index -eq 0) { 'System.UIntPtr' } elseif ($index -eq 1) { 'System.UInt32' } elseif ($index -eq 2) { 'System.UInt64' } else { 'System.IntPtr' }
-    Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::OffsetOf($ffiApiType, $field.Name).ToInt64()) -Expected ([Int64]$expectedOffset) -Description "Managed FfiApiV2 '$($field.Name)' offset"
-    Assert-Equal -Actual (Get-ManagedTypeName $field.FieldType) -Expected $expectedType -Description "Managed FfiApiV2 '$($field.Name)' type"
-}
-
 $expectedLiveTableSlots = @(
     @{ Field = 'PowerShell_BeginLiveInvocation'; Method = 'FfiPowerShell_BeginLiveInvocation'; Signature = 'IntPtr,IntPtr*,FfiCallResult*,int' }
     @{ Field = 'LiveInvocation_Poll'; Method = 'FfiLiveInvocation_Poll'; Signature = 'IntPtr,int*,FfiCallResult*,int' }
@@ -333,85 +320,40 @@ $expectedTypedResultTableSlots = @(
     @{ Field = 'TypedResultPage_CopyRecordValue'; Rust = 'typed_result_page_copy_record_value_fn'; Alias = 'FnFfiTypedResultPageCopyRecordValue'; Method = 'FfiTypedResultPage_CopyRecordValue'; Signature = 'IntPtr,int,uint*,byte*,int,int*,FfiCallResult*,int' }
     @{ Field = 'TypedResultPage_Release'; Rust = 'typed_result_page_release_fn'; Alias = 'FnFfiTypedResultInvocationComplete'; Method = 'FfiTypedResultPage_Release'; Signature = 'IntPtr,FfiCallResult*,int' }
 )
-$ffiApiV3Type = $bindingsAssemblyObject.GetType('NativeHost.Bindings+FfiApiV3', $true)
-Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiV3Type)) -Expected 104 -Description 'Managed FfiApiV3 size'
-$ffiApiV3Fields = @($ffiApiV3Type.GetFields($instanceFields) | Sort-Object MetadataToken)
-$expectedFfiApiV3FieldNames = @('Size', 'AbiVersion', 'FeatureFlags') + @($expectedLiveTableSlots | ForEach-Object { $_.Field })
-Assert-Sequence -Actual @($ffiApiV3Fields | ForEach-Object Name) -Expected $expectedFfiApiV3FieldNames -Description 'Managed FfiApiV3 slot order'
-for ($index = 0; $index -lt $ffiApiV3Fields.Count; $index++) {
-    $field = $ffiApiV3Fields[$index]
-    $expectedOffset = if ($index -eq 0) { 0 } elseif ($index -eq 1) { 8 } elseif ($index -eq 2) { 16 } else { 24 + (($index - 3) * 8) }
-    $expectedType = if ($index -eq 0) { 'System.UIntPtr' } elseif ($index -eq 1) { 'System.UInt32' } elseif ($index -eq 2) { 'System.UInt64' } else { 'System.IntPtr' }
-    Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::OffsetOf($ffiApiV3Type, $field.Name).ToInt64()) -Expected ([Int64]$expectedOffset) -Description "Managed FfiApiV3 '$($field.Name)' offset"
-    Assert-Equal -Actual (Get-ManagedTypeName $field.FieldType) -Expected $expectedType -Description "Managed FfiApiV3 '$($field.Name)' type"
-}
-
-$ffiApiV4Type = $bindingsAssemblyObject.GetType('NativeHost.Bindings+FfiApiV4', $true)
-Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiV4Type)) -Expected 104 -Description 'Managed FfiApiV4 size'
-$ffiApiV4Fields = @($ffiApiV4Type.GetFields($instanceFields) | Sort-Object MetadataToken)
-$expectedFfiApiV4FieldNames = @('Size', 'AbiVersion', 'FeatureFlags') + @($expectedTypedResultTableSlots | ForEach-Object { $_.Field })
-Assert-Sequence -Actual @($ffiApiV4Fields | ForEach-Object Name) -Expected $expectedFfiApiV4FieldNames -Description 'Managed FfiApiV4 slot order'
-for ($index = 0; $index -lt $ffiApiV4Fields.Count; $index++) {
-    $field = $ffiApiV4Fields[$index]
-    $expectedOffset = if ($index -eq 0) { 0 } elseif ($index -eq 1) { 8 } elseif ($index -eq 2) { 16 } else { 24 + (($index - 3) * 8) }
-    $expectedType = if ($index -eq 0) { 'System.UIntPtr' } elseif ($index -eq 1) { 'System.UInt32' } elseif ($index -eq 2) { 'System.UInt64' } else { 'System.IntPtr' }
-    Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::OffsetOf($ffiApiV4Type, $field.Name).ToInt64()) -Expected ([Int64]$expectedOffset) -Description "Managed FfiApiV4 '$($field.Name)' offset"
-    Assert-Equal -Actual (Get-ManagedTypeName $field.FieldType) -Expected $expectedType -Description "Managed FfiApiV4 '$($field.Name)' type"
-}
-
 $compactFfiBindingsSource = $ffiBindingsSource -replace '\s+', ''
-$expectedBridgeFeatures = 'FeatureFlags=(1UL<<4)|(1UL<<5)|(1UL<<6)|FfiFeatureAsyncOperationPrimitives|FfiFeatureSessionPrimitives|FfiFeatureSessionPolling|FfiFeatureSnapshotProjections|FfiFeatureSessionConfiguration|FfiFeatureSessionVariables|FfiFeatureCapabilityRpc|FfiFeatureLiveObjectProbe|FfiFeatureLiveSessionObjectProbe|FfiFeatureLiveObjectContracts'
-if (-not $compactFfiBindingsSource.Contains($expectedBridgeFeatures)) {
-    throw 'Managed FfiApiV2 feature flags no longer advertise the checked bridge capabilities.'
-}
-foreach ($slot in $expectedTableSlots) {
-    $assignment = "$($slot.Field)=(IntPtr)(delegate*unmanaged<$($slot.Signature)>)&$($slot.Method)"
-    if ($compactFfiBindingsSource.IndexOf($assignment, [StringComparison]::Ordinal) -lt 0) {
-        throw "Managed FfiApiV2 slot '$($slot.Field)' does not have its checked target and signature '$($slot.Signature)'."
-    }
-}
-if (-not $compactFfiBindingsSource.Contains('FeatureFlags=FfiFeatureLiveStreamPolling')) {
-    throw 'Managed FfiApiV3 does not advertise live stream polling.'
-}
-foreach ($slot in $expectedLiveTableSlots) {
-    $assignment = "$($slot.Field)=(IntPtr)(delegate*unmanaged<$($slot.Signature)>)&$($slot.Method)"
-    if ($compactFfiBindingsSource.IndexOf($assignment, [StringComparison]::Ordinal) -lt 0) {
-        throw "Managed FfiApiV3 slot '$($slot.Field)' does not have its checked target and signature '$($slot.Signature)'."
-    }
-}
-if (-not $compactFfiBindingsSource.Contains('FeatureFlags=FfiFeatureTypedResultPaging')) {
-    throw 'Managed FfiApiV4 does not advertise typed result paging.'
-}
-foreach ($slot in $expectedTypedResultTableSlots) {
-    $assignment = "$($slot.Field)=(IntPtr)(delegate*unmanaged<$($slot.Signature)>)&$($slot.Method)"
-    if ($compactFfiBindingsSource.IndexOf($assignment, [StringComparison]::Ordinal) -lt 0) {
-        throw "Managed FfiApiV4 slot '$($slot.Field)' does not have its checked target and signature '$($slot.Signature)'."
-    }
+$allTableSlots = @($expectedTableSlots) + @($expectedLiveTableSlots) + @($expectedTypedResultTableSlots)
+$ffiApiType = $bindingsAssemblyObject.GetType('NativeHost.Bindings+FfiApiV1', $true)
+Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiType)) -Expected 584 -Description 'Managed FfiApiV1 size'
+$ffiApiFields = @($ffiApiType.GetFields($instanceFields) | Sort-Object MetadataToken)
+$expectedFfiApiFieldNames = @('Size', 'AbiVersion', 'FeatureFlags') + @($allTableSlots | ForEach-Object { $_.Field })
+Assert-Sequence -Actual @($ffiApiFields | ForEach-Object Name) -Expected $expectedFfiApiFieldNames -Description 'Managed FfiApiV1 slot order'
+for ($index = 0; $index -lt $ffiApiFields.Count; $index++) {
+    $field = $ffiApiFields[$index]
+    $expectedOffset = if ($index -eq 0) { 0 } elseif ($index -eq 1) { 8 } elseif ($index -eq 2) { 16 } else { 24 + (($index - 3) * 8) }
+    $expectedType = if ($index -eq 0) { 'System.UIntPtr' } elseif ($index -eq 1) { 'System.UInt32' } elseif ($index -eq 2) { 'System.UInt64' } else { 'System.IntPtr' }
+    Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::OffsetOf($ffiApiType, $field.Name).ToInt64()) -Expected ([Int64]$expectedOffset) -Description "Managed FfiApiV1 '$($field.Name)' offset"
+    Assert-Equal -Actual (Get-ManagedTypeName $field.FieldType) -Expected $expectedType -Description "Managed FfiApiV1 '$($field.Name)' type"
 }
 
-$rustApiTableMatch = [regex]::Match($rustBindingsSource, '(?s)struct\s+FfiApiV2\s*\{(?<body>.*?)\n\s*\}')
+$expectedBridgeFeatures = 'FeatureFlags=(1UL<<4)|(1UL<<5)|(1UL<<6)|FfiFeatureAsyncOperationPrimitives|FfiFeatureSessionPrimitives|FfiFeatureSessionPolling|FfiFeatureSnapshotProjections|FfiFeatureSessionConfiguration|FfiFeatureSessionVariables|FfiFeatureCapabilityRpc|FfiFeatureLiveObjectProbe|FfiFeatureLiveSessionObjectProbe|FfiFeatureLiveObjectContracts|FfiFeatureLiveStreamPolling|FfiFeatureTypedResultPaging'
+if (-not $compactFfiBindingsSource.Contains($expectedBridgeFeatures)) {
+    throw 'Managed FfiApiV1 feature flags no longer advertise the checked bridge capabilities.'
+}
+foreach ($slot in $allTableSlots) {
+    $assignment = "$($slot.Field)=(IntPtr)(delegate*unmanaged<$($slot.Signature)>)&$($slot.Method)"
+    if ($compactFfiBindingsSource.IndexOf($assignment, [StringComparison]::Ordinal) -lt 0) {
+        throw "Managed FfiApiV1 slot '$($slot.Field)' does not have its checked target and signature '$($slot.Signature)'."
+    }
+}
+$rustApiTableMatch = [regex]::Match($rustBindingsSource, '(?s)struct\s+FfiApiV1\s*\{(?<body>.*?)\n\s*\}')
 if (-not $rustApiTableMatch.Success) {
-    throw 'Rust FfiApiV2 table declaration is missing.'
+    throw 'Rust FfiApiV1 table declaration is missing.'
 }
 $rustApiTableFields = @(
     [regex]::Matches($rustApiTableMatch.Groups['body'].Value, '(?m)^\s*(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*[^,]+,') |
         ForEach-Object { $_.Groups['name'].Value }
 )
-$expectedRustApiTableFields = @('size', 'abi_version', 'feature_flags') + @($expectedTableSlots | ForEach-Object Rust)
-Assert-Sequence -Actual $rustApiTableFields -Expected $expectedRustApiTableFields -Description 'Rust FfiApiV2 slot order'
-
-$rustLiveApiTableMatch = [regex]::Match($rustBindingsSource, '(?s)struct\s+FfiApiV3\s*\{(?<body>.*?)\n\s*\}')
-if (-not $rustLiveApiTableMatch.Success) {
-    throw 'Rust FfiApiV3 table declaration is missing.'
-}
-$rustLiveApiTableFields = @(
-    [regex]::Matches($rustLiveApiTableMatch.Groups['body'].Value, '(?m)^\s*(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*[^,]+,') |
-        ForEach-Object { $_.Groups['name'].Value }
-)
-Assert-Sequence -Actual $rustLiveApiTableFields -Expected @(
-    'size',
-    'abi_version',
-    'feature_flags',
+$expectedLiveRustTableFields = @(
     'power_shell_begin_live_invocation_fn',
     'live_invocation_poll_fn',
     'live_invocation_read_batch_fn',
@@ -422,27 +364,12 @@ Assert-Sequence -Actual $rustLiveApiTableFields -Expected @(
     'live_invocation_complete_fn',
     'live_invocation_stop_fn',
     'live_invocation_release_fn'
-) -Description 'Rust FfiApiV3 slot order'
-
-$rustTypedResultApiTableMatch = [regex]::Match($rustBindingsSource, '(?s)struct\s+FfiApiV4\s*\{(?<body>.*?)\n\s*\}')
-if (-not $rustTypedResultApiTableMatch.Success) {
-    throw 'Rust FfiApiV4 table declaration is missing.'
-}
-$rustTypedResultApiTableFields = @(
-    [regex]::Matches($rustTypedResultApiTableMatch.Groups['body'].Value, '(?m)^\s*(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*[^,]+,') |
-        ForEach-Object { $_.Groups['name'].Value }
 )
-Assert-Sequence -Actual $rustTypedResultApiTableFields -Expected (@(
-        'size',
-        'abi_version',
-        'feature_flags'
-    ) + @($expectedTypedResultTableSlots | ForEach-Object Rust)) -Description 'Rust FfiApiV4 slot order'
-if (-not [regex]::IsMatch($rustBindingsSource, '(?s)Bindings_GetFfiApiV4.*?Err\(_\)\s*=>\s*None')) {
-    throw 'Rust bindings must treat the typed result paging managed table as optional for payload compatibility.'
-}
-if (-not [regex]::IsMatch($rustBindingsSource, '(?s)Bindings_GetFfiApiV3.*?Err\(_\)\s*=>\s*None')) {
-    throw 'Rust bindings must retain V3 managed table optionality for payload compatibility.'
-}
+$expectedRustApiTableFields = @('size', 'abi_version', 'feature_flags') +
+    @($expectedTableSlots | ForEach-Object Rust) +
+    $expectedLiveRustTableFields +
+    @($expectedTypedResultTableSlots | ForEach-Object Rust)
+Assert-Sequence -Actual $rustApiTableFields -Expected $expectedRustApiTableFields -Description 'Rust FfiApiV1 slot order'
 
 $rustBindingsTableMatch = [regex]::Match($rustBindingsSource, '(?s)pub\(crate\)\s+struct\s+FfiBindings\s*\{(?<body>.*?)\n\s*\}')
 if (-not $rustBindingsTableMatch.Success) {
@@ -452,19 +379,16 @@ $rustBindingsFields = @(
     [regex]::Matches($rustBindingsTableMatch.Groups['body'].Value, '(?m)^\s*(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?<type>[A-Za-z_][A-Za-z0-9_]*),') |
         ForEach-Object { "$($_.Groups['name'].Value)|$($_.Groups['type'].Value)" }
 )
-Assert-Sequence -Actual $rustBindingsFields -Expected @($expectedTableSlots | ForEach-Object { "$($_.Rust)|$($_.Alias)" }) -Description 'Rust FfiBindings slot order and aliases'
-if (-not [regex]::IsMatch(
-        $rustBindingsTableMatch.Groups['body'].Value,
-        '(?m)^\s*typed_result_paging\s*:\s*Option<FfiTypedResultPagingBindings>,'
-    )) {
-    throw 'Rust FfiBindings must retain an optional typed result paging binding table.'
-}
+Assert-Sequence -Actual $rustBindingsFields -Expected (
+    @($expectedTableSlots | ForEach-Object { "$($_.Rust)|$($_.Alias)" }) +
+    @('live_stream|FfiLiveStreamBindings', 'typed_result_paging|FfiTypedResultPagingBindings')
+) -Description 'Rust FfiBindings slot order and aliases'
 if (-not $rustFfiSource.Contains('const FEATURE_TYPED_RESULT_PAGING: u64 = 1 << 21;')) {
     throw 'Rust native ABI must advertise typed result paging feature bit 21.'
 }
 
 $expectedRustFunctionAliases = @'
-FnBindingsGetFfiApiV2|unsafeextern"system"fn()->*constFfiApiV2
+FnBindingsGetFfiApiV1|unsafeextern"system"fn()->*constFfiApiV1
 FnFfiPowerShellCreate|unsafeextern"system"fn(*mutPowerShellHandle,*mutFfiCallResult)->i32
 FnFfiPowerShellRelease|unsafeextern"system"fn(PowerShellHandle,*mutFfiCallResult)->i32
 FnFfiPowerShellAddUtf8|unsafeextern"system"fn(PowerShellHandle,*constu8,i32,*mutFfiCallResult)->i32


### PR DESCRIPTION
## Summary

- consolidate core, live-stream, and typed-result operations into one required V1 payload binding table while retaining public native ABI v2
- qualify the locally packed SDK with a self-contained Win-x64 NativeAOT consumer and real PowerShell 7.4 payload, including typed paging, cancellation, lifecycle, capability, and host-interaction coverage
- reject conflicting live-contract interface IDs before registration and exercise the rejection path in the NativeAOT sample

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets -- --test-threads=1`
- `dotnet build dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj -p:PwshExePath=...`
- `dotnet test dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj --no-build -p:PwshExePath=...`
- `tests\Verify-PwshFfiApiBaseline.ps1`
- packaged NativeAOT SDK consumer smoke with PowerShell 7.4.17
- NativeAOT normal and incompatible-contract-pack samples