### PR TITLE
Add finite operation primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,12 @@ jobs:
           if (-not ($sampleOutput | Where-Object { $_ -eq 'NativeAOT observed presentation: Success' })) {
             throw 'The NativeAOT SDK sample did not execute the observed presentation smoke.'
           }
-          if (-not ($sampleOutput | Where-Object { $_ -eq 'NativeAOT finite-operation bridge attachment: Success' })) {
+          $finiteOperationOutput = & dotnet/nativeaot-sample/bin/Release/net10.0/win-x64/publish/NativeAotFfiSample.exe `
+            $payloadDirectory `
+            '--finite-operation-bridge-only'
+          $finiteOperationOutput | ForEach-Object { Write-Host $_ }
+          if ($LASTEXITCODE -ne 0) { throw "The finite-operation NativeAOT SDK sample failed with exit code $LASTEXITCODE." }
+          if (-not ($finiteOperationOutput | Where-Object { $_ -eq 'NativeAOT finite-operation bridge attachment: Success' })) {
             throw 'The NativeAOT SDK sample did not execute the finite-operation bridge attachment smoke.'
           }
           foreach ($contractPackFixture in @(
@@ -340,6 +345,10 @@ jobs:
               "--expect-rejected-contract-pack:$contractPackFixture"
             if ($LASTEXITCODE -ne 0) { throw "The '$contractPackFixture' contract-pack rejection sample failed with exit code $LASTEXITCODE." }
           }
+          & dotnet/nativeaot-sample/bin/Release/net10.0/win-x64/publish/NativeAotFfiSample.exe `
+            $payloadDirectory `
+            '--expect-rejected-multiple-bridge-packs'
+          if ($LASTEXITCODE -ne 0) { throw "The multiple bridge contract packs rejection sample failed with exit code $LASTEXITCODE." }
           & dotnet/nativeaot-sample/bin/Release/net10.0/win-x64/publish/NativeAotFfiSample.exe `
             $payloadDirectory `
             '--expect-bridge-setup-failure-cleans-broker'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,9 @@ jobs:
           if (-not ($sampleOutput | Where-Object { $_ -eq 'NativeAOT observed presentation: Success' })) {
             throw 'The NativeAOT SDK sample did not execute the observed presentation smoke.'
           }
+          if (-not ($sampleOutput | Where-Object { $_ -eq 'NativeAOT finite-operation bridge attachment: Success' })) {
+            throw 'The NativeAOT SDK sample did not execute the finite-operation bridge attachment smoke.'
+          }
           foreach ($contractPackFixture in @(
             'duplicate-across-packs',
             'duplicate-within-pack',

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.17.0"
+version = "0.18.0-bridge-v2.dbc.local.3"
 dependencies = [
  "flate2",
  "home",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.17.0"
+version = "0.18.0-bridge-v2.dbc.local.3"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-sdk-ffi"
-version = "0.17.0"
+version = "0.18.0-bridge-v2.dbc.local.3"
 dependencies = [
  "pwsh-host",
  "winresource",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.18.0-bridge-v2.dbc.local.3"
+version = "0.18.0-bridge-v2.dbc.local.4"
 dependencies = [
  "flate2",
  "home",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.18.0-bridge-v2.dbc.local.3"
+version = "0.18.0-bridge-v2.dbc.local.4"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-sdk-ffi"
-version = "0.18.0-bridge-v2.dbc.local.3"
+version = "0.18.0-bridge-v2.dbc.local.4"
 dependencies = [
  "pwsh-host",
  "winresource",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "multi-pwsh"
-version = "0.18.0-bridge-v2.dbc.local.4"
+version = "0.18.0-bridge-v2.dbc.local.6"
 dependencies = [
  "flate2",
  "home",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-host"
-version = "0.18.0-bridge-v2.dbc.local.4"
+version = "0.18.0-bridge-v2.dbc.local.6"
 dependencies = [
  "base64 0.13.1",
  "cfg-if 0.1.10",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "pwsh-sdk-ffi"
-version = "0.18.0-bridge-v2.dbc.local.4"
+version = "0.18.0-bridge-v2.dbc.local.6"
 dependencies = [
  "pwsh-host",
  "winresource",

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/latest/download/in
 irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.16.0`):
+Install a specific tag (example `v0.18.0-bridge-v2.dbc.local.3`):
 
 ```bash
-curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.16.0/install-multi-pwsh.sh | bash -s -- v0.16.0
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.18.0-bridge-v2.dbc.local.3/install-multi-pwsh.sh | bash -s -- v0.18.0-bridge-v2.dbc.local.3
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.16.0/install-multi-pwsh.ps1))) -Version v0.16.0
+& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.18.0-bridge-v2.dbc.local.3/install-multi-pwsh.ps1))) -Version v0.18.0-bridge-v2.dbc.local.3
 ```
 
 Uninstall bootstrap scripts:
@@ -289,7 +289,7 @@ Package authors can consume the launchers privately and map them into their own 
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.16.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.3" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -311,7 +311,7 @@ For a simple single-RID project, AppHost mode can copy the selected binary direc
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.16.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.3" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/latest/download/in
 irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.18.0-bridge-v2.dbc.local.4`):
+Install a specific tag (example `v0.18.0-bridge-v2.dbc.local.6`):
 
 ```bash
-curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.18.0-bridge-v2.dbc.local.4/install-multi-pwsh.sh | bash -s -- v0.18.0-bridge-v2.dbc.local.4
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.18.0-bridge-v2.dbc.local.6/install-multi-pwsh.sh | bash -s -- v0.18.0-bridge-v2.dbc.local.6
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.18.0-bridge-v2.dbc.local.4/install-multi-pwsh.ps1))) -Version v0.18.0-bridge-v2.dbc.local.4
+& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.18.0-bridge-v2.dbc.local.6/install-multi-pwsh.ps1))) -Version v0.18.0-bridge-v2.dbc.local.6
 ```
 
 Uninstall bootstrap scripts:
@@ -289,7 +289,7 @@ Package authors can consume the launchers privately and map them into their own 
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.4" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.6" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -311,7 +311,7 @@ For a simple single-RID project, AppHost mode can copy the selected binary direc
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.4" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.6" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/latest/download/in
 irm https://github.com/Devolutions/multi-pwsh/releases/latest/download/install-multi-pwsh.ps1 | iex
 ```
 
-Install a specific tag (example `v0.18.0-bridge-v2.dbc.local.3`):
+Install a specific tag (example `v0.18.0-bridge-v2.dbc.local.4`):
 
 ```bash
-curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.18.0-bridge-v2.dbc.local.3/install-multi-pwsh.sh | bash -s -- v0.18.0-bridge-v2.dbc.local.3
+curl -fsSL https://github.com/Devolutions/multi-pwsh/releases/download/v0.18.0-bridge-v2.dbc.local.4/install-multi-pwsh.sh | bash -s -- v0.18.0-bridge-v2.dbc.local.4
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.18.0-bridge-v2.dbc.local.3/install-multi-pwsh.ps1))) -Version v0.18.0-bridge-v2.dbc.local.3
+& ([scriptblock]::Create((irm https://github.com/Devolutions/multi-pwsh/releases/download/v0.18.0-bridge-v2.dbc.local.4/install-multi-pwsh.ps1))) -Version v0.18.0-bridge-v2.dbc.local.4
 ```
 
 Uninstall bootstrap scripts:
@@ -289,7 +289,7 @@ Package authors can consume the launchers privately and map them into their own 
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.3" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.4" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -311,7 +311,7 @@ For a simple single-RID project, AppHost mode can copy the selected binary direc
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.3" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.4" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.18.0-bridge-v2.dbc.local.3"
+version = "0.18.0-bridge-v2.dbc.local.4"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/multi-pwsh"

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.17.0"
+version = "0.18.0-bridge-v2.dbc.local.3"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/multi-pwsh"

--- a/crates/multi-pwsh/Cargo.toml
+++ b/crates/multi-pwsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-pwsh"
-version = "0.18.0-bridge-v2.dbc.local.4"
+version = "0.18.0-bridge-v2.dbc.local.6"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/multi-pwsh"

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.18.0-bridge-v2.dbc.local.4"
+version = "0.18.0-bridge-v2.dbc.local.6"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.18.0-bridge-v2.dbc.local.3"
+version = "0.18.0-bridge-v2.dbc.local.4"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/crates/pwsh-host/Cargo.toml
+++ b/crates/pwsh-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-host"
-version = "0.17.0"
+version = "0.18.0-bridge-v2.dbc.local.3"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/pwsh-host-rs"

--- a/crates/pwsh-sdk-ffi/Cargo.toml
+++ b/crates/pwsh-sdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-sdk-ffi"
-version = "0.17.0"
+version = "0.18.0-bridge-v2.dbc.local.3"
 edition = "2018"
 license = "MIT/Apache-2.0"
 publish = false

--- a/crates/pwsh-sdk-ffi/Cargo.toml
+++ b/crates/pwsh-sdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-sdk-ffi"
-version = "0.18.0-bridge-v2.dbc.local.4"
+version = "0.18.0-bridge-v2.dbc.local.6"
 edition = "2018"
 license = "MIT/Apache-2.0"
 publish = false

--- a/crates/pwsh-sdk-ffi/Cargo.toml
+++ b/crates/pwsh-sdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwsh-sdk-ffi"
-version = "0.18.0-bridge-v2.dbc.local.3"
+version = "0.18.0-bridge-v2.dbc.local.4"
 edition = "2018"
 license = "MIT/Apache-2.0"
 publish = false

--- a/crates/pwsh-sdk-ffi/src/lib.rs
+++ b/crates/pwsh-sdk-ffi/src/lib.rs
@@ -8911,6 +8911,10 @@ mod tests {
         frame
     }
 
+    fn broker_attach_consumer(channel: u64) {
+        assert_eq!(broker_wait_for_frame(channel, 0), 0);
+    }
+
     fn broker_close_channel(channel: u64) {
         let mut diagnostic = [0_u8; 256];
         let mut result = broker_call_result(&mut diagnostic);
@@ -9004,6 +9008,7 @@ mod tests {
         let attachment = broker_test_attachment(channel);
         let generation = attachment.generation;
 
+        broker_attach_consumer(channel);
         let payload = std::thread::spawn(move || broker_enqueue(channel, generation, 7, b"ping"));
 
         let frame = broker_wait_for_frame(channel, 5_000);
@@ -9061,6 +9066,7 @@ mod tests {
         let channel = open_broker_channel(&broker_default_options());
         let attachment = broker_test_attachment(channel);
         let generation = attachment.generation;
+        broker_attach_consumer(channel);
         let payload = std::thread::spawn(move || broker_enqueue(channel, generation, 1, b"observe"));
 
         let frame = broker_wait_for_frame(channel, 5_000);
@@ -9145,6 +9151,7 @@ mod tests {
         let channel = open_broker_channel(&broker_default_options());
         let attachment = broker_test_attachment(channel);
         let generation = attachment.generation;
+        broker_attach_consumer(channel);
         let payload = std::thread::spawn(move || broker_enqueue(channel, generation, 1, b"close"));
 
         let frame = broker_wait_for_frame(channel, 5_000);
@@ -9209,6 +9216,7 @@ mod tests {
         let channel = open_broker_channel(&broker_default_options());
         let attachment = broker_test_attachment(channel);
         let generation = attachment.generation;
+        broker_attach_consumer(channel);
         let payload = std::thread::spawn(move || broker_enqueue(channel, generation, 1, b"x"));
 
         let frame = broker_wait_for_frame(channel, 5_000);
@@ -9253,6 +9261,7 @@ mod tests {
         let channel = open_broker_channel(&broker_default_options());
         let attachment = broker_test_attachment(channel);
         let generation = attachment.generation;
+        broker_attach_consumer(channel);
         let payload = std::thread::spawn(move || broker_enqueue(channel, generation, 2, b"y"));
 
         let frame = broker_wait_for_frame(channel, 5_000);
@@ -9281,6 +9290,7 @@ mod tests {
         let channel = open_broker_channel(&broker_default_options());
         let attachment = broker_test_attachment(channel);
         let generation = attachment.generation;
+        broker_attach_consumer(channel);
         let payload = std::thread::spawn(move || broker_enqueue(channel, generation, 3, b"z"));
 
         let frame = broker_wait_for_frame(channel, 5_000);
@@ -9359,7 +9369,7 @@ mod tests {
         let channel = open_broker_channel(&broker_default_options());
         let attachment = broker_test_attachment(channel);
         let generation = attachment.generation;
-        assert_eq!(broker_wait_for_frame(channel, 50), 0);
+        broker_attach_consumer(channel);
 
         let payload = std::thread::spawn(move || broker_enqueue(channel, generation, 6, b"c"));
         // Let the request reach the queue, then close.
@@ -9419,6 +9429,7 @@ mod tests {
         let channel = open_broker_channel(&broker_default_options());
         let attachment = broker_test_attachment(channel);
         let generation = attachment.generation;
+        broker_attach_consumer(channel);
         let payload = std::thread::spawn(move || broker_enqueue(channel, generation, 10, b"h"));
 
         let frame = broker_wait_for_frame(channel, 5_000);
@@ -9449,6 +9460,7 @@ mod tests {
         let channel = open_broker_channel(&broker_default_options());
         let attachment = broker_test_attachment(channel);
         let generation = attachment.generation;
+        broker_attach_consumer(channel);
         let payload = std::thread::spawn(move || broker_enqueue(channel, generation, 11, b"d"));
 
         let frame = broker_wait_for_frame(channel, 5_000);
@@ -9489,6 +9501,7 @@ mod tests {
         let channel = open_broker_channel(&broker_default_options());
         let attachment = broker_test_attachment(channel);
         let generation = attachment.generation;
+        broker_attach_consumer(channel);
         let payload = std::thread::spawn(move || broker_enqueue(channel, generation, 12, b"o"));
 
         let frame = broker_wait_for_frame(channel, 5_000);

--- a/docs/bridge-contract-v2-dbc.md
+++ b/docs/bridge-contract-v2-dbc.md
@@ -37,6 +37,12 @@ Only the async invocation paths are legal for an attached bridge. Synchronous
 invocation is rejected by the existing broker guard before a pipeline can
 block waiting for a host dispatcher.
 
+Each payload admits at most one independently compiled contract-pack API that
+declares a bridge contract. The shared generated COM handshake is payload-local,
+so registering a second bridge pack is rejected during activation rather than
+allowing incompatible projections to run. Add finite operations and typed pages
+as closed members or child objects of the existing bridge contract pack.
+
 ## Fixed DBC frames
 
 The DBC body for every generated bridge frame starts with this fixed

--- a/docs/bridge-contract-v2-dbc.md
+++ b/docs/bridge-contract-v2-dbc.md
@@ -371,3 +371,48 @@ remoting/PSRP, named-pipe console attachment, pools or concurrent sessions,
 PowerCLI compatibility, generic RDM feature flags, or generic RDM
 authorization/persistence. It is a finite, generated, bounded local bridge
 only.
+
+## Finite operation and copied-page primitive
+
+`PowerShellFiniteOperationRegistry<TPage>` is a host-side, opt-in state
+machine for a trusted application that has already selected one generated
+Bridge Contract v2 page shape. It does not add a payload binding-table slot,
+event protocol, worker, dispatcher, or contract root. The application uses its
+generated data type as `TPage`, supplies a fixed schema identity and a direct
+copy codec, then exposes only its fixed generated `Start`, `ReadPage`,
+`Cancel`, and `Release` members.
+
+The registry allocates a cryptographically random `Guid` operation identifier.
+The value is opaque and is never re-issued, but it is not an authorization
+token: every registry call also requires the untransferable
+`PowerShellFiniteOperationOwner` that created it. Unknown, stale, released, or
+wrong-owner identifiers return the same access-denied outcome. Owner disposal
+explicitly releases all of its entries.
+
+The application supplies a positive deadline and terminal retention window,
+both capped by the primitive (one hour and fifteen minutes respectively).
+Under its locked state transition, deadline expiry wins first; otherwise a
+recorded cancellation wins over a later completion or failure; a committed
+terminal outcome wins over subsequent cancellation or completion. Cancellation
+is idempotent and every terminal transition signals the host-provided
+cooperative cancellation token. This primitive deliberately does not schedule
+or execute work.
+
+On completion, each page is copied with its exact item and encoded-byte count.
+The registry rejects over-limit page counts, item counts, byte counts, and
+failed copies before exposing any page. The hard ceilings are 256 pages, 4,096
+items per page, and the generated bridge-frame maximum (64 KiB) per page. Each
+`ReadPage` revalidates the original snapshot and permission revisions through
+the application validator before returning another detached copy. Snapshot
+invalidation, permission changes, bad cursors, bounds failures, cancellation,
+deadline expiry, and application failure are deterministic results; no event is
+used as completion authority.
+
+A terminal result remains readable only through its finite retention lease.
+After that lease it becomes an explicit `Expired` tombstone that continues to
+consume a bounded table entry until `TryRelease` or owner disposal. There is no
+implicit cleanup, durable session, checkpoint, persistence, dynamic schema,
+generic script or job dispatcher, arbitrary target, reflection, JSON,
+remoting, credential transfer, UI, callback, pooling, or staged mutation
+behavior in this primitive. Durable checkpoints require a separate
+identity/provenance/anti-rollback design.

--- a/docs/host-and-venv.md
+++ b/docs/host-and-venv.md
@@ -33,7 +33,7 @@ Typical downstream vendored-SDK usage:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.16.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.3" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/docs/host-and-venv.md
+++ b/docs/host-and-venv.md
@@ -33,7 +33,7 @@ Typical downstream vendored-SDK usage:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.4" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.6" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/docs/host-and-venv.md
+++ b/docs/host-and-venv.md
@@ -33,7 +33,7 @@ Typical downstream vendored-SDK usage:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.3" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.4" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/dotnet/bindings/LiveObjectContractPackRegistry.cs
+++ b/dotnet/bindings/LiveObjectContractPackRegistry.cs
@@ -626,6 +626,7 @@ internal unsafe sealed class FfiLiveObjectContractPackRegistry
 
         var additions = new Dictionary<PowerShellLiveObjectContract, Registration>();
         var interfaceIds = new HashSet<Guid>();
+        bool hasBridgeContractPack = false;
         for (uint packIndex = 0; packIndex < apiCount; packIndex++)
         {
             IntPtr apiPointer = apiPointers[packIndex];
@@ -648,32 +649,58 @@ internal unsafe sealed class FfiLiveObjectContractPackRegistry
 
             var create = (delegate* unmanaged<IntPtr, IntPtr*, int>)api.CreatePayloadProxy;
             var release = (delegate* unmanaged<IntPtr, void>)api.ReleasePayloadProxy;
+            bool packHasBridgeContract = false;
             for (uint contractIndex = 0; contractIndex < api.ContractCount; contractIndex++)
             {
                 PowerShellLiveObjectContract contract =
                     PowerShellLiveObjectContract.FromNative(api.Contracts[contractIndex]);
-                                if ((contract.Directions & PowerShellLiveObjectDirection.ConsumerToSession) == 0)
-                                {
-                                    throw new InvalidOperationException(
-                                        "Live object contract packs contain a contract with an unsupported direction.");
-                                }
+                if ((contract.Directions & PowerShellLiveObjectDirection.ConsumerToSession) == 0)
+                {
+                    throw new InvalidOperationException(
+                        "Live object contract packs contain a contract with an unsupported direction.");
+                }
 
-                                if (!interfaceIds.Add(contract.InterfaceId))
-                                {
-                                    throw new InvalidOperationException(
-                                        "Live object contract packs contain duplicate interface identifiers.");
-                                }
+                if (!interfaceIds.Add(contract.InterfaceId))
+                {
+                    throw new InvalidOperationException(
+                        "Live object contract packs contain duplicate interface identifiers.");
+                }
 
-                                if (!additions.TryAdd(contract, Registration.CreateExternal(create, release)))
-                                {
-                                    throw new InvalidOperationException(
-                                        "Live object contract packs contain incompatible interface identifiers.");
-                                }
+                if ((contract.Directions & PowerShellLiveObjectDirection.BridgeContract) != 0)
+                {
+                    packHasBridgeContract = true;
+                }
+
+                if (!additions.TryAdd(contract, Registration.CreateExternal(create, release)))
+                {
+                    throw new InvalidOperationException(
+                        "Live object contract packs contain incompatible interface identifiers.");
+                }
             }
+
+            if (packHasBridgeContract && hasBridgeContractPack)
+            {
+                throw new InvalidOperationException(
+                    "Live object contract packs support at most one bridge contract pack per payload.");
+            }
+
+            hasBridgeContractPack |= packHasBridgeContract;
         }
 
         lock (gate)
         {
+            if (hasBridgeContractPack)
+            {
+                foreach (PowerShellLiveObjectContract existing in registrations.Keys)
+                {
+                    if ((existing.Directions & PowerShellLiveObjectDirection.BridgeContract) != 0)
+                    {
+                        throw new InvalidOperationException(
+                            "Live object contract packs support at most one bridge contract pack per payload.");
+                    }
+                }
+            }
+
             foreach (PowerShellLiveObjectContract contract in additions.Keys)
             {
                 foreach (PowerShellLiveObjectContract existing in registrations.Keys)

--- a/dotnet/finite-operation-test-host/FiniteOperationTestHost.cs
+++ b/dotnet/finite-operation-test-host/FiniteOperationTestHost.cs
@@ -1,0 +1,207 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+namespace Devolutions.MultiPwsh.FiniteOperationTest;
+
+/// <summary>
+/// Acceptance-only host for the fixed finite-operation contract. Its three modes
+/// prove a completed copied report, an idempotently cancelled pending job, and
+/// a deliberately short retained terminal result;
+/// it never accepts an application target, script, schema, or callback.
+/// </summary>
+public sealed class FiniteOperationTestHost : IDisposable
+{
+    private readonly Handler handler;
+    private readonly PowerShellBridgeTestFiniteOperationDispatcher dispatcher;
+
+    public FiniteOperationTestHost()
+    {
+        handler = new Handler();
+        dispatcher = new PowerShellBridgeTestFiniteOperationDispatcher(handler, new Authorizer());
+    }
+
+    public IPowerShellBridgeDispatcher Dispatcher => dispatcher;
+
+    public void InvalidateSnapshot() => handler.InvalidateSnapshot();
+
+    public void Dispose()
+    {
+        dispatcher.Dispose();
+        handler.Dispose();
+    }
+
+    private sealed class Handler :
+        IPowerShellBridgeTestFiniteOperationBridgeHandler,
+        IPowerShellFinitePageAccessValidator,
+        IDisposable
+    {
+        private static readonly Guid SchemaId = new("4D67D86E-5193-473F-98C3-90E786A5FC3D");
+
+        private readonly PowerShellFiniteOperationRegistry<Page> operations;
+        private readonly PowerShellFiniteOperationOwner owner;
+        private long snapshotRevision = 1;
+        private long permissionRevision = 1;
+
+        internal Handler()
+        {
+            operations = new PowerShellFiniteOperationRegistry<Page>(
+                new PowerShellFinitePageContract<Page>(
+                    SchemaId,
+                    maximumPages: 2,
+                    maximumItemsPerPage: 1,
+                    maximumPageBytes: 64,
+                    new PageCodec(),
+                    this),
+                maximumOperations: 8);
+            owner = operations.CreateOwner();
+        }
+
+        public FiniteOperationTicketValue Start(in PowerShellBridgeTestFiniteOperationCallContext context, int mode)
+        {
+            if (mode is < 1 or > 3)
+            {
+                return Ticket(default, PowerShellFiniteOperationStatus.InvalidArgument);
+            }
+
+            PowerShellFiniteOperationResult started = operations.TryStart(
+                owner,
+                new PowerShellFiniteOperationBinding(
+                    SchemaId,
+                    checked((ulong)Volatile.Read(ref snapshotRevision)),
+                    checked((ulong)Volatile.Read(ref permissionRevision))),
+                new PowerShellFiniteOperationOptions(
+                    TimeSpan.FromSeconds(30),
+                    mode == 3 ? TimeSpan.FromSeconds(1) : TimeSpan.FromMinutes(1)),
+                out _);
+            if (started.Status != PowerShellFiniteOperationStatus.Active)
+            {
+                return Ticket(started);
+            }
+
+            if (mode is 1 or 3)
+            {
+                _ = operations.TryComplete(
+                    owner,
+                    started.OperationId,
+                    [new Page(0, "alpha"), new Page(1, "beta")]);
+            }
+
+            return Ticket(operations.TryGet(owner, started.OperationId));
+        }
+
+        public FiniteOperationPageReadValue ReadPage(
+            in PowerShellBridgeTestFiniteOperationCallContext context,
+            Guid operationId,
+            int cursor)
+        {
+            if (!PowerShellFinitePageCursor.TryCreate(cursor, out PowerShellFinitePageCursor pageCursor))
+            {
+                return new FiniteOperationPageReadValue(
+                    (int)PowerShellFiniteOperationStatus.InvalidCursor,
+                    false,
+                    -1,
+                    -1,
+                    Array.Empty<string>());
+            }
+
+            PowerShellFinitePageReadResult<Page> page = operations.TryReadPage(
+                owner,
+                PowerShellFiniteOperationId.FromValue(operationId),
+                pageCursor);
+            return new FiniteOperationPageReadValue(
+                (int)page.Operation.Status,
+                page.HasPage,
+                page.NextCursor?.Index ?? -1,
+                page.HasPage ? page.Page!.Ordinal : -1,
+                page.HasPage ? [page.Page!.Label] : Array.Empty<string>());
+        }
+
+        public FiniteOperationTicketValue Cancel(
+            in PowerShellBridgeTestFiniteOperationCallContext context,
+            Guid operationId) =>
+            Ticket(operations.TryCancel(owner, PowerShellFiniteOperationId.FromValue(operationId)));
+
+        public int Release(
+            in PowerShellBridgeTestFiniteOperationCallContext context,
+            Guid operationId) =>
+            (int)operations.TryRelease(owner, PowerShellFiniteOperationId.FromValue(operationId)).Status;
+
+        public void Release(in PowerShellBridgeTestFiniteOperationCallContext context)
+        {
+        }
+
+        public PowerShellFinitePageValidation Validate(in PowerShellFiniteOperationBinding binding)
+        {
+            if (binding.SnapshotRevision != checked((ulong)Volatile.Read(ref snapshotRevision)))
+            {
+                return PowerShellFinitePageValidation.SnapshotInvalidated;
+            }
+
+            return binding.PermissionRevision == checked((ulong)Volatile.Read(ref permissionRevision))
+                ? PowerShellFinitePageValidation.Allowed
+                : PowerShellFinitePageValidation.PermissionChanged;
+        }
+
+        internal void InvalidateSnapshot() => Interlocked.Increment(ref snapshotRevision);
+
+        public void Dispose()
+        {
+            owner.Dispose();
+            operations.Dispose();
+        }
+
+        private FiniteOperationTicketValue Ticket(PowerShellFiniteOperationResult result) =>
+            Ticket(result.OperationId, result.Status);
+
+        private FiniteOperationTicketValue Ticket(
+            PowerShellFiniteOperationId operationId,
+            PowerShellFiniteOperationStatus status) =>
+            new(
+                operationId.Value,
+                (int)status,
+                Volatile.Read(ref snapshotRevision),
+                Volatile.Read(ref permissionRevision));
+    }
+
+    private sealed class Authorizer : IPowerShellBridgeTestFiniteOperationAuthorizer
+    {
+        public bool IsAuthorized(in PowerShellBridgeTestFiniteOperationCallContext context) => true;
+    }
+
+    private sealed class Page
+    {
+        internal Page(int ordinal, string label)
+        {
+            Ordinal = ordinal;
+            Label = label;
+        }
+
+        internal int Ordinal { get; }
+
+        internal string Label { get; }
+    }
+
+    private sealed class PageCodec : IPowerShellFinitePageCodec<Page>
+    {
+        public bool TryCopy(Page source, out Page copy, out int itemCount, out int byteCount)
+        {
+            copy = null!;
+            itemCount = 0;
+            byteCount = 0;
+            if (source is null || source.Label is null)
+            {
+                return false;
+            }
+
+            itemCount = 1;
+            byteCount = checked(sizeof(int) + Encoding.UTF8.GetByteCount(source.Label));
+            copy = new Page(source.Ordinal, source.Label);
+            return true;
+        }
+    }
+}

--- a/dotnet/finite-operation-test-host/FiniteOperationTestHost.cs
+++ b/dotnet/finite-operation-test-host/FiniteOperationTestHost.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using Devolutions.PowerShell.Ffi.LiveObjects;
+using Devolutions.PowerShell.Ffi.LiveObjects.FiniteOperations;
 
 namespace Devolutions.MultiPwsh.FiniteOperationTest;
 

--- a/dotnet/finite-operation-test-host/FiniteOperationTestHost.csproj
+++ b/dotnet/finite-operation-test-host/FiniteOperationTestHost.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LiveContractMode>Host</LiveContractMode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\live-contracts\Devolutions.MultiPwsh.LiveContracts.csproj" />
+    <ProjectReference Include="..\live-contract-generator\Devolutions.MultiPwsh.LiveContract.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+    <Compile Include="..\interop\FiniteOperationTestContract.cs"
+             Link="FiniteOperationTestContract.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="LiveContractMode" />
+  </ItemGroup>
+</Project>

--- a/dotnet/finite-operation-test-pack/FiniteOperationTestPack.cs
+++ b/dotnet/finite-operation-test-pack/FiniteOperationTestPack.cs
@@ -1,0 +1,258 @@
+#nullable enable
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+namespace Devolutions.MultiPwsh.FiniteOperationTest;
+
+/// <summary>NativeAOT payload pack for the static finite-operation acceptance contract.</summary>
+public static unsafe partial class FiniteOperationTestPack
+{
+    private const int EFail = unchecked((int)0x80004005);
+    private static readonly StrategyBasedComWrappers ComWrappers = new();
+    private static readonly IntPtr Api = CreateApi();
+
+    [UnmanagedCallersOnly]
+    public static IntPtr GetLiveObjectContractPackV1() => Api;
+
+    [UnmanagedCallersOnly]
+    private static int CreatePayloadProxy(IntPtr comObject, IntPtr* proxyHandle)
+    {
+        if (comObject == IntPtr.Zero || proxyHandle == null)
+        {
+            return EFail;
+        }
+
+        *proxyHandle = IntPtr.Zero;
+        try
+        {
+            object projected = ComWrappers.GetOrCreateObjectForComInstance(comObject, CreateObjectFlags.UniqueInstance);
+            if (projected is not ComObject sinkComObject)
+            {
+                throw new InvalidOperationException("The finite-operation pack did not receive a bridge sink.");
+            }
+
+            PowerShellBridgeTestFiniteOperationBridgeBinding binding;
+            IPowerShellBridgeContractSink? contractSink = projected as IPowerShellBridgeContractSink;
+            IPowerShellBridgeBrokerSink? brokerSink = projected as IPowerShellBridgeBrokerSink;
+            if (contractSink is not null)
+            {
+                binding = PowerShellBridgeTestFiniteOperationBridgeBinding.Create(contractSink, sinkComObject);
+            }
+            else if (brokerSink is not null)
+            {
+                binding = PowerShellBridgeTestFiniteOperationBridgeBinding.Create(brokerSink, sinkComObject);
+            }
+            else
+            {
+                throw new InvalidOperationException("The finite-operation pack received an unsupported bridge sink.");
+            }
+
+            var callback = new FiniteOperationCallback(binding);
+            IntPtr callbackPointer = IntPtr.Zero;
+            try
+            {
+                callbackPointer = ComWrappers.GetOrCreateComInterfaceForObject(
+                    callback,
+                    CreateComInterfaceFlags.None);
+                if (callbackPointer == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException("The finite-operation pack could not create its invocation callback.");
+                }
+
+                if (contractSink is not null)
+                {
+                    PowerShellBridgeTestFiniteOperationBridgeBinding.Declare(contractSink, callbackPointer);
+                }
+                else
+                {
+                    PowerShellBridgeTestFiniteOperationBridgeBinding.Declare(brokerSink!, callbackPointer);
+                }
+
+                *proxyHandle = GCHandle.ToIntPtr(GCHandle.Alloc(callback));
+            }
+            catch
+            {
+                callback.Dispose();
+                throw;
+            }
+            finally
+            {
+                if (callbackPointer != IntPtr.Zero)
+                {
+                    PowerShellBridgeComReference.Release(callbackPointer);
+                }
+            }
+
+            return PowerShellBridgeStatus.Success;
+        }
+        catch (PowerShellBridgeException exception)
+        {
+            return exception.Status;
+        }
+        catch (COMException exception)
+        {
+            return exception.HResult;
+        }
+        catch
+        {
+            return EFail;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    private static void ReleasePayloadProxy(IntPtr proxyHandle)
+    {
+        if (proxyHandle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        GCHandle handle = GCHandle.FromIntPtr(proxyHandle);
+        try
+        {
+            (handle.Target as IDisposable)?.Dispose();
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
+
+    private static IntPtr CreateApi()
+    {
+        NativeLiveObjectContractDescriptor* contract =
+            (NativeLiveObjectContractDescriptor*)NativeMemory.Alloc((nuint)sizeof(NativeLiveObjectContractDescriptor));
+        contract[0] = new PowerShellLiveObjectContract(
+            typeof(IPowerShellBridgeTestFiniteOperationTransport).GUID,
+            majorVersion: 1,
+            minorVersion: 0,
+            PowerShellLiveObjectDirection.ConsumerToSession | PowerShellLiveObjectDirection.BridgeContract).ToNative();
+
+        NativeLiveObjectContractPackApi* api =
+            (NativeLiveObjectContractPackApi*)NativeMemory.Alloc((nuint)sizeof(NativeLiveObjectContractPackApi));
+        *api = new NativeLiveObjectContractPackApi
+        {
+            Size = (nuint)sizeof(NativeLiveObjectContractPackApi),
+            AbiVersion = 1,
+            ContractCount = 1,
+            Contracts = contract,
+            CreatePayloadProxy = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr*, int>)&CreatePayloadProxy,
+            ReleasePayloadProxy = (IntPtr)(delegate* unmanaged<IntPtr, void>)&ReleasePayloadProxy,
+        };
+        return (IntPtr)api;
+    }
+
+    [GeneratedComClass]
+    private sealed partial class FiniteOperationCallback : IPowerShellBridgePayloadCallback, IDisposable
+    {
+        private readonly object gate = new();
+        private PowerShellBridgeTestFiniteOperationBridgeBinding? binding;
+        private IntPtr rootHandle;
+
+        internal FiniteOperationCallback(PowerShellBridgeTestFiniteOperationBridgeBinding binding)
+        {
+            this.binding = binding ?? throw new ArgumentNullException(nameof(binding));
+        }
+
+        public int Bind(out nint root)
+        {
+            root = IntPtr.Zero;
+            lock (gate)
+            {
+                if (rootHandle != IntPtr.Zero)
+                {
+                    return PowerShellBridgeStatus.AccessDenied;
+                }
+
+                try
+                {
+                    object value = binding?.Bind()
+                        ?? throw new ObjectDisposedException(nameof(FiniteOperationCallback));
+                    rootHandle = GCHandle.ToIntPtr(GCHandle.Alloc(value));
+                    root = rootHandle;
+                    return PowerShellBridgeStatus.Success;
+                }
+                catch (PowerShellBridgeException exception)
+                {
+                    return exception.Status;
+                }
+                catch
+                {
+                    return EFail;
+                }
+            }
+        }
+
+        public int Unbind()
+        {
+            lock (gate)
+            {
+                try
+                {
+                    binding?.Unbind();
+                    return PowerShellBridgeStatus.Success;
+                }
+                catch (PowerShellBridgeException exception)
+                {
+                    return exception.Status;
+                }
+                catch
+                {
+                    return EFail;
+                }
+            }
+        }
+
+        public int ReleaseRoot(nint root)
+        {
+            lock (gate)
+            {
+                if (root == IntPtr.Zero || root != rootHandle)
+                {
+                    return PowerShellBridgeStatus.AccessDenied;
+                }
+
+                try
+                {
+                    GCHandle.FromIntPtr(rootHandle).Free();
+                    rootHandle = IntPtr.Zero;
+                    return PowerShellBridgeStatus.Success;
+                }
+                catch
+                {
+                    return EFail;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            PowerShellBridgeTestFiniteOperationBridgeBinding? release;
+            IntPtr root;
+            lock (gate)
+            {
+                release = binding;
+                binding = null;
+                root = rootHandle;
+                rootHandle = IntPtr.Zero;
+            }
+
+            try
+            {
+                release?.Unbind();
+            }
+            finally
+            {
+                if (root != IntPtr.Zero)
+                {
+                    GCHandle.FromIntPtr(root).Free();
+                }
+
+                release?.Dispose();
+            }
+        }
+    }
+}

--- a/dotnet/finite-operation-test-pack/FiniteOperationTestPack.csproj
+++ b/dotnet/finite-operation-test-pack/FiniteOperationTestPack.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>Devolutions.MultiPwsh.FiniteOperation.TestPack</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LiveContractMode>Payload</LiveContractMode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\live-contracts\BridgeContractAttributes.cs"
+             Link="BridgeContractAttributes.cs" />
+    <Compile Include="..\live-contracts\BridgeContractWire.cs"
+             Link="BridgeContractWire.cs" />
+    <Compile Include="..\live-contracts\BridgeContractRuntime.cs"
+             Link="BridgeContractRuntime.cs" />
+    <Compile Include="..\live-contracts\BridgeContractLease.cs"
+             Link="BridgeContractLease.cs" />
+    <Compile Include="..\interop\PowerShellLiveObjectContract.cs"
+             Link="PowerShellLiveObjectContract.cs" />
+    <Compile Include="..\interop\FiniteOperationTestContract.cs"
+             Link="FiniteOperationTestContract.cs" />
+    <ProjectReference Include="..\live-contract-generator\Devolutions.MultiPwsh.LiveContract.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="LiveContractMode" />
+  </ItemGroup>
+</Project>

--- a/dotnet/interop/FiniteOperationTestContract.cs
+++ b/dotnet/interop/FiniteOperationTestContract.cs
@@ -1,0 +1,90 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+namespace Devolutions.MultiPwsh.FiniteOperationTest;
+
+/// <summary>
+/// Acceptance-only fixed transport and schema used to prove that finite
+/// operation identifiers and copied pages traverse the generated payload path.
+/// </summary>
+[GeneratedComInterface]
+[Guid("82AD9A61-416F-47B3-A0B5-8CB2DA29D5CC")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public partial interface IPowerShellBridgeTestFiniteOperationTransport
+{
+    [PreserveSig]
+    int Invoke(
+        ulong leaseId,
+        uint generation,
+        ulong objectId,
+        uint memberId,
+        nint input,
+        int inputLength,
+        nint output,
+        int outputCapacity,
+        out int outputLength);
+
+    [PreserveSig]
+    int CloseLease(ulong leaseId, uint generation);
+}
+
+/// <summary>
+/// A static, finite contract: it has two fixed operation modes and one fixed
+/// copied report-page shape. It is deliberately not a generic job dispatcher.
+/// </summary>
+[BridgeContract("3F1DD1D0-AB49-4FE1-A40C-FE5BB48D8AEC", 1, 0, "82AD9A61-416F-47B3-A0B5-8CB2DA29D5CC")]
+[BridgeObject(1, ReleaseId = 701)]
+public interface IPowerShellBridgeTestFiniteOperation
+{
+    [BridgeMember(1, Permission = BridgePermission.Execute)]
+    IFiniteOperationTicket Start(int mode);
+
+    [BridgeMember(2, Permission = BridgePermission.Read)]
+    IFiniteOperationPageRead ReadPage(Guid operationId, int cursor);
+
+    [BridgeMember(3, Permission = BridgePermission.Execute)]
+    IFiniteOperationTicket Cancel(Guid operationId);
+
+    [BridgeMember(4, Permission = BridgePermission.Execute)]
+    int Release(Guid operationId);
+}
+
+[BridgeData(80)]
+public interface IFiniteOperationTicket
+{
+    [BridgeField(1)]
+    Guid OperationId { get; }
+
+    [BridgeField(2)]
+    int Status { get; }
+
+    [BridgeField(3)]
+    long SnapshotRevision { get; }
+
+    [BridgeField(4)]
+    long PermissionRevision { get; }
+}
+
+[BridgeData(81)]
+public interface IFiniteOperationPageRead
+{
+    [BridgeField(1)]
+    int Status { get; }
+
+    [BridgeField(2)]
+    bool HasPage { get; }
+
+    [BridgeField(3)]
+    int NextCursor { get; }
+
+    [BridgeField(4)]
+    int Ordinal { get; }
+
+    [BridgeField(5, MaximumCollectionCount = 2, MaximumUtf8Bytes = 32)]
+    IReadOnlyList<string> Rows { get; }
+}

--- a/dotnet/interop/FiniteOperationTestContract.cs
+++ b/dotnet/interop/FiniteOperationTestContract.cs
@@ -34,7 +34,7 @@ public partial interface IPowerShellBridgeTestFiniteOperationTransport
 }
 
 /// <summary>
-/// A static, finite contract: it has two fixed operation modes and one fixed
+/// A static, finite contract: it has three fixed operation modes and one fixed
 /// copied report-page shape. It is deliberately not a generic job dispatcher.
 /// </summary>
 [BridgeContract("3F1DD1D0-AB49-4FE1-A40C-FE5BB48D8AEC", 1, 0, "82AD9A61-416F-47B3-A0B5-8CB2DA29D5CC")]

--- a/dotnet/live-contract-generator-tests/BridgeContractTests.cs
+++ b/dotnet/live-contract-generator-tests/BridgeContractTests.cs
@@ -94,6 +94,65 @@ internal static class BridgeContractTests
         }
         """;
 
+    private const string FiniteOperationContract = """
+        using System;
+        using System.Runtime.InteropServices;
+        using System.Runtime.InteropServices.Marshalling;
+        using Devolutions.PowerShell.Ffi.LiveObjects;
+
+        namespace Fixture;
+
+        [GeneratedComInterface]
+        [Guid("EDC40A8B-3320-4DA6-9A4D-321D27531FC0")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public partial interface IFiniteOperationTransport
+        {
+            [PreserveSig]
+            int Invoke(ulong leaseId, uint generation, ulong objectId, uint memberId,
+                       nint input, int inputLength, nint output, int outputCapacity, out int outputLength);
+
+            [PreserveSig]
+            int CloseLease(ulong leaseId, uint generation);
+        }
+
+        [BridgeContract("2D24AB26-A9E5-4EF4-AC18-DB99F42B5B03", 1, 0, "EDC40A8B-3320-4DA6-9A4D-321D27531FC0")]
+        [BridgeObject(1, ReleaseId = 701)]
+        public interface IFiniteOperationRoot
+        {
+            [BridgeMember(1, Permission = BridgePermission.Execute)]
+            IFiniteOperationTicket Start(int mode);
+
+            [BridgeMember(2, Permission = BridgePermission.Read)]
+            IFiniteOperationPageRead ReadPage(Guid operationId, int cursor);
+
+            [BridgeMember(3, Permission = BridgePermission.Execute)]
+            IFiniteOperationTicket Cancel(Guid operationId);
+
+            [BridgeMember(4, Permission = BridgePermission.Execute)]
+            int Release(Guid operationId);
+        }
+
+        [BridgeData(80)]
+        public interface IFiniteOperationTicket
+        {
+            [BridgeField(1)] Guid OperationId { get; }
+            [BridgeField(2)] int Status { get; }
+            [BridgeField(3)] long SnapshotRevision { get; }
+            [BridgeField(4)] long PermissionRevision { get; }
+        }
+
+        [BridgeData(81)]
+        public interface IFiniteOperationPageRead
+        {
+            [BridgeField(1)] int Status { get; }
+            [BridgeField(2)] bool HasPage { get; }
+            [BridgeField(3)] int NextCursor { get; }
+            [BridgeField(4)] int Ordinal { get; }
+            [BridgeField(5, MaximumCollectionCount = 2, MaximumUtf8Bytes = 32)]
+            System.Collections.Generic.IReadOnlyList<string> Rows { get; }
+        }
+        """;
+
     internal static void Run(
         Func<string, string, (GeneratorDriverRunResult Result, Compilation Output)> run,
         Action<IEnumerable<Diagnostic>> assertNoErrors)
@@ -110,6 +169,8 @@ internal static class BridgeContractTests
         VerifyNoDynamicDispatch(run, assertNoErrors);
         VerifyReleaseOrdinals(run, assertNoErrors);
         VerifyPayloadBindingSurface(run, assertNoErrors);
+        VerifySurface(run, assertNoErrors, "Host", "FiniteOperationPageReadValue", FiniteOperationContract);
+        VerifySurface(run, assertNoErrors, "Payload", "public FiniteOperationPageReadValue ReadPage", FiniteOperationContract);
 
         // Every rejection is a compile-time diagnostic, never a runtime failure.
         VerifyDiagnostic(run, Valid.Replace(", MaximumUtf8Bytes = 256", string.Empty, StringComparison.Ordinal), "MPWLC016");
@@ -643,9 +704,10 @@ internal static class BridgeContractTests
         Func<string, string, (GeneratorDriverRunResult Result, Compilation Output)> run,
         Action<IEnumerable<Diagnostic>> assertNoErrors,
         string mode,
-        string required)
+        string required,
+        string? source = null)
     {
-        var (result, output) = run(Valid, mode);
+        var (result, output) = run(source ?? Valid, mode);
         assertNoErrors(Diagnostics(result));
         assertNoErrors(output.GetDiagnostics());
         string generated = Generated(result);

--- a/dotnet/live-contract-generator-tests/FiniteOperationTests.cs
+++ b/dotnet/live-contract-generator-tests/FiniteOperationTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Devolutions.PowerShell.Ffi.LiveObjects;
+using Devolutions.PowerShell.Ffi.LiveObjects.FiniteOperations;
 
 /// <summary>
 /// Focused lifecycle tests for the finite operation primitive. The bridge
@@ -18,6 +19,7 @@ internal static class FiniteOperationTests
     internal static void Run()
     {
         OwnerAndTerminalPrecedenceAreClosed();
+        ActiveDeadlineCancelsWorkersWithoutLaterRegistryCall();
         CopiedPagesAreBoundedAndRevalidated();
         RetentionAndExplicitCleanupAreFinite();
     }
@@ -126,6 +128,33 @@ internal static class FiniteOperationTests
             registry.TryReadPage(owner, pending.OperationId, PowerShellFinitePageCursor.Start).Operation.Status ==
                 PowerShellFiniteOperationStatus.Active,
             "an active operation has no page before terminal success");
+    }
+
+    private static void ActiveDeadlineCancelsWorkersWithoutLaterRegistryCall()
+    {
+        var validator = new TestValidator();
+        using var registry = new PowerShellFiniteOperationRegistry<Page>(
+            new PowerShellFinitePageContract<Page>(
+                SchemaId,
+                maximumPages: 1,
+                maximumItemsPerPage: 1,
+                maximumPageBytes: 128,
+                new PageCodec(),
+                validator),
+            maximumOperations: 1);
+        using PowerShellFiniteOperationOwner owner = registry.CreateOwner();
+
+        PowerShellFiniteOperationResult started = registry.TryStart(
+            owner,
+            new PowerShellFiniteOperationBinding(SchemaId, snapshotRevision: 1, permissionRevision: 1),
+            new PowerShellFiniteOperationOptions(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)),
+            out PowerShellFiniteOperationLease lease);
+
+        Require(
+            started.Status == PowerShellFiniteOperationStatus.Active &&
+            lease.CancellationToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)) &&
+            registry.TryGet(owner, started.OperationId).Status == PowerShellFiniteOperationStatus.TimedOut,
+            "an elapsed deadline cancels an idle worker and resolves to timeout");
     }
 
     private static void RetentionAndExplicitCleanupAreFinite()

--- a/dotnet/live-contract-generator-tests/FiniteOperationTests.cs
+++ b/dotnet/live-contract-generator-tests/FiniteOperationTests.cs
@@ -1,0 +1,259 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+/// <summary>
+/// Focused lifecycle tests for the finite operation primitive. The bridge
+/// generator tests prove the same fixed schemas compile on Host and Payload;
+/// these tests prove the host-side retained state never needs reflection,
+/// serialization, or a scheduler.
+/// </summary>
+internal static class FiniteOperationTests
+{
+    private static readonly Guid SchemaId = new("59E1C18D-EE83-4FC8-90E9-BE3E62D95D80");
+
+    internal static void Run()
+    {
+        OwnerAndTerminalPrecedenceAreClosed();
+        CopiedPagesAreBoundedAndRevalidated();
+        RetentionAndExplicitCleanupAreFinite();
+    }
+
+    private static void OwnerAndTerminalPrecedenceAreClosed()
+    {
+        using PowerShellFiniteOperationRegistry<Page> registry = CreateRegistry(out TestClock clock, out _);
+        using PowerShellFiniteOperationOwner owner = registry.CreateOwner();
+        using PowerShellFiniteOperationOwner otherOwner = registry.CreateOwner();
+
+        PowerShellFiniteOperationResult started = Start(registry, owner, clock, out PowerShellFiniteOperationLease lease);
+        Require(started.Status == PowerShellFiniteOperationStatus.Active && started.OperationId.IsValid, "start creates an opaque active operation");
+        Require(
+            registry.TryGet(otherOwner, started.OperationId).Status == PowerShellFiniteOperationStatus.AccessDenied,
+            "a different owner cannot probe an operation identifier");
+
+        Require(
+            registry.TryCancel(owner, started.OperationId).Status == PowerShellFiniteOperationStatus.Cancelled &&
+            registry.TryCancel(owner, started.OperationId).Status == PowerShellFiniteOperationStatus.Cancelled,
+            "cancellation is idempotent");
+        Require(
+            registry.TryComplete(owner, started.OperationId, [new Page(1, "late")]).Status == PowerShellFiniteOperationStatus.Cancelled,
+            "recorded cancellation wins over a late completion");
+        Require(lease.CancellationToken.IsCancellationRequested, "cancellation signals the host worker token");
+
+        PowerShellFiniteOperationResult completed = Start(registry, owner, clock, out _);
+        Require(
+            registry.TryComplete(owner, completed.OperationId, [new Page(1, "done")]).Status == PowerShellFiniteOperationStatus.Succeeded &&
+            registry.TryCancel(owner, completed.OperationId).Status == PowerShellFiniteOperationStatus.Succeeded,
+            "a committed terminal outcome wins over later cancellation");
+
+        PowerShellFiniteOperationResult timedOut = Start(
+            registry,
+            owner,
+            clock,
+            out _,
+            deadline: TimeSpan.FromSeconds(1));
+        clock.Advance(TimeSpan.FromSeconds(1));
+        Require(
+            registry.TryCancel(owner, timedOut.OperationId).Status == PowerShellFiniteOperationStatus.TimedOut,
+            "deadline wins before cancellation at the same transition");
+
+        PowerShellFiniteOperationResult failed = Start(registry, owner, clock, out _);
+        Require(
+            registry.TryFail(owner, failed.OperationId, 17).Status == PowerShellFiniteOperationStatus.Failed &&
+            registry.TryGet(owner, failed.OperationId).ErrorCode == 17,
+            "application failure is retained as a deterministic numeric terminal outcome");
+    }
+
+    private static void CopiedPagesAreBoundedAndRevalidated()
+    {
+        using PowerShellFiniteOperationRegistry<Page> registry = CreateRegistry(out TestClock clock, out TestValidator validator);
+        using PowerShellFiniteOperationOwner owner = registry.CreateOwner();
+
+        var source = new Page(11, "alpha");
+        PowerShellFiniteOperationResult completed = Start(registry, owner, clock, out _);
+        Require(
+            registry.TryComplete(owner, completed.OperationId, [source, new Page(12, "beta")]).Status == PowerShellFiniteOperationStatus.Succeeded,
+            "bounded fixed-schema pages complete successfully");
+        source.Label = "mutated-after-complete";
+
+        PowerShellFinitePageReadResult<Page> first = registry.TryReadPage(
+            owner,
+            completed.OperationId,
+            PowerShellFinitePageCursor.Start);
+        Require(
+            first.Operation.Status == PowerShellFiniteOperationStatus.Succeeded &&
+            first.HasPage &&
+            first.Page is { Value: 11, Label: "alpha" } &&
+            first.NextCursor is { Index: 1 } &&
+            validator.Calls == 1,
+            "each page is detached and revalidated before it is returned");
+
+        validator.Result = PowerShellFinitePageValidation.SnapshotInvalidated;
+        PowerShellFinitePageReadResult<Page> invalidated = registry.TryReadPage(
+            owner,
+            completed.OperationId,
+            first.NextCursor!.Value);
+        Require(
+            invalidated.Operation.Status == PowerShellFiniteOperationStatus.SnapshotInvalidated &&
+            !invalidated.HasPage &&
+            validator.Calls == 2,
+            "snapshot invalidation becomes a deterministic terminal page outcome");
+
+        validator.Result = PowerShellFinitePageValidation.Allowed;
+        PowerShellFiniteOperationResult permissionBound = Start(registry, owner, clock, out _);
+        Require(
+            registry.TryComplete(owner, permissionBound.OperationId, [new Page(13, "gamma")]).Status ==
+                PowerShellFiniteOperationStatus.Succeeded,
+            "a separate fixed-schema page sequence completes before permission revalidation");
+        validator.Result = PowerShellFinitePageValidation.PermissionChanged;
+        Require(
+            registry.TryReadPage(owner, permissionBound.OperationId, PowerShellFinitePageCursor.Start).Operation.Status ==
+                PowerShellFiniteOperationStatus.PermissionChanged,
+            "permission revision changes become a deterministic terminal page outcome");
+
+        validator.Result = PowerShellFinitePageValidation.Allowed;
+        PowerShellFiniteOperationResult oversized = Start(registry, owner, clock, out _);
+        Require(
+            registry.TryComplete(owner: owner, operationId: oversized.OperationId, pages: [new Page(1, new string('x', 129))]).Status ==
+                PowerShellFiniteOperationStatus.BoundsExceeded,
+            "an oversized copied page fails closed");
+
+        PowerShellFiniteOperationResult pending = Start(registry, owner, clock, out _);
+        Require(
+            registry.TryReadPage(owner, pending.OperationId, PowerShellFinitePageCursor.Start).Operation.Status ==
+                PowerShellFiniteOperationStatus.Active,
+            "an active operation has no page before terminal success");
+    }
+
+    private static void RetentionAndExplicitCleanupAreFinite()
+    {
+        using PowerShellFiniteOperationRegistry<Page> registry = CreateRegistry(out TestClock clock, out _);
+        using PowerShellFiniteOperationOwner owner = registry.CreateOwner();
+
+        PowerShellFiniteOperationResult completed = Start(
+            registry,
+            owner,
+            clock,
+            out PowerShellFiniteOperationLease lease,
+            retention: TimeSpan.FromSeconds(1));
+        Require(
+            registry.TryComplete(owner, completed.OperationId, [new Page(1, "retained")]).Status == PowerShellFiniteOperationStatus.Succeeded,
+            "a completed operation enters its finite retention lease");
+
+        clock.Advance(TimeSpan.FromSeconds(1));
+        Require(
+            registry.TryGet(owner, completed.OperationId).Status == PowerShellFiniteOperationStatus.Expired &&
+            registry.TryReadPage(owner, completed.OperationId, PowerShellFinitePageCursor.Start).Operation.Status ==
+                PowerShellFiniteOperationStatus.Expired,
+            "terminal retention expiry clears pages and leaves an explicit tombstone");
+        Require(
+            registry.TryRelease(owner, completed.OperationId).Status == PowerShellFiniteOperationStatus.Released &&
+            lease.CancellationToken.IsCancellationRequested &&
+            registry.TryGet(owner, completed.OperationId).Status == PowerShellFiniteOperationStatus.AccessDenied,
+            "explicit cleanup releases the bounded tombstone and signals its worker token");
+    }
+
+    private static PowerShellFiniteOperationRegistry<Page> CreateRegistry(
+        out TestClock clock,
+        out TestValidator validator)
+    {
+        clock = new TestClock(new DateTimeOffset(2026, 8, 3, 0, 0, 0, TimeSpan.Zero));
+        validator = new TestValidator();
+        return new PowerShellFiniteOperationRegistry<Page>(
+            new PowerShellFinitePageContract<Page>(
+                SchemaId,
+                maximumPages: 4,
+                maximumItemsPerPage: 1,
+                maximumPageBytes: 128,
+                new PageCodec(),
+                validator),
+            maximumOperations: 16,
+            timeProvider: clock);
+    }
+
+    private static PowerShellFiniteOperationResult Start(
+        PowerShellFiniteOperationRegistry<Page> registry,
+        PowerShellFiniteOperationOwner owner,
+        TestClock clock,
+        out PowerShellFiniteOperationLease lease,
+        TimeSpan? deadline = null,
+        TimeSpan? retention = null)
+    {
+        PowerShellFiniteOperationResult result = registry.TryStart(
+            owner,
+            new PowerShellFiniteOperationBinding(SchemaId, snapshotRevision: 1, permissionRevision: 1),
+            new PowerShellFiniteOperationOptions(
+                deadline ?? TimeSpan.FromMinutes(1),
+                retention ?? TimeSpan.FromMinutes(1)),
+            out lease);
+        Require(result.Status == PowerShellFiniteOperationStatus.Active, "finite operation start succeeds");
+        return result;
+    }
+
+    private static void Require(bool condition, string description)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException($"Finite operation test failed: {description}.");
+        }
+    }
+
+    private sealed class Page
+    {
+        internal Page(int value, string label)
+        {
+            Value = value;
+            Label = label;
+        }
+
+        internal int Value { get; }
+
+        internal string Label { get; set; }
+    }
+
+    private sealed class PageCodec : IPowerShellFinitePageCodec<Page>
+    {
+        public bool TryCopy(Page source, out Page copy, out int itemCount, out int byteCount)
+        {
+            copy = null!;
+            itemCount = 0;
+            byteCount = 0;
+            if (source is null || source.Label is null)
+            {
+                return false;
+            }
+
+            byteCount = checked(sizeof(int) + Encoding.UTF8.GetByteCount(source.Label));
+            itemCount = 1;
+            copy = new Page(source.Value, source.Label);
+            return true;
+        }
+    }
+
+    private sealed class TestValidator : IPowerShellFinitePageAccessValidator
+    {
+        internal int Calls { get; private set; }
+
+        internal PowerShellFinitePageValidation Result { get; set; }
+
+        public PowerShellFinitePageValidation Validate(in PowerShellFiniteOperationBinding binding)
+        {
+            Calls++;
+            return Result;
+        }
+    }
+
+    private sealed class TestClock : TimeProvider
+    {
+        private DateTimeOffset now;
+
+        internal TestClock(DateTimeOffset now) => this.now = now;
+
+        public override DateTimeOffset GetUtcNow() => now;
+
+        internal void Advance(TimeSpan value) => now += value;
+    }
+}

--- a/dotnet/live-contract-generator-tests/Program.cs
+++ b/dotnet/live-contract-generator-tests/Program.cs
@@ -55,6 +55,7 @@ BridgeContractTests.Run(RunBridgeGenerators, AssertNoErrors);
 BridgeWireTests.Run();
 BridgeRoundTripTests.Run(CompileBridgeAssembly);
 BridgeFiniteOperationLeaseTests.Run();
+FiniteOperationTests.Run();
 
 Console.WriteLine("live-contract and bridge-contract generator fixtures passed");
 

--- a/dotnet/live-contracts/PowerShellFiniteOperations.cs
+++ b/dotnet/live-contracts/PowerShellFiniteOperations.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Threading;
 
-namespace Devolutions.PowerShell.Ffi.LiveObjects;
+namespace Devolutions.PowerShell.Ffi.LiveObjects.FiniteOperations;
 
 /// <summary>
 /// The finite lifecycle states and request failures returned by
@@ -187,12 +187,24 @@ public sealed class PowerShellFinitePageContract<TPage>
         IPowerShellFinitePageCodec<TPage> codec,
         IPowerShellFinitePageAccessValidator accessValidator)
     {
-        if (schemaId == Guid.Empty ||
-            maximumPages is < 1 or > HardMaximumPages ||
-            maximumItemsPerPage is < 1 or > HardMaximumItemsPerPage ||
-            maximumPageBytes is < 1 or > HardMaximumPageBytes)
+        if (schemaId == Guid.Empty)
         {
-            throw new ArgumentOutOfRangeException(nameof(maximumPages), "The finite page contract bounds are invalid.");
+            throw new ArgumentOutOfRangeException(nameof(schemaId));
+        }
+
+        if (maximumPages is < 1 or > HardMaximumPages)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumPages));
+        }
+
+        if (maximumItemsPerPage is < 1 or > HardMaximumItemsPerPage)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumItemsPerPage));
+        }
+
+        if (maximumPageBytes is < 1 or > HardMaximumPageBytes)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumPageBytes));
         }
 
         SchemaId = schemaId;
@@ -293,7 +305,7 @@ public readonly struct PowerShellFiniteOperationResult
 
     public PowerShellFiniteOperationId OperationId { get; }
 
-    /// <summary>Gets the last read time for a retained terminal state, when retained.</summary>
+    /// <summary>Gets the expiration time for a retained terminal state, when retained.</summary>
     public DateTimeOffset? ExpiresAt { get; }
 
     /// <summary>Gets the host-supplied non-zero error code for a failed operation.</summary>
@@ -413,6 +425,11 @@ public sealed class PowerShellFiniteOperationRegistry<TPage> : IDisposable, IFin
         lock (gate)
         {
             ThrowIfDisposed();
+            if (!Owns(owner))
+            {
+                return Result(PowerShellFiniteOperationStatus.AccessDenied);
+            }
+
             if (entries.Count >= maximumOperations)
             {
                 return Result(PowerShellFiniteOperationStatus.CapacityExceeded);
@@ -423,6 +440,7 @@ public sealed class PowerShellFiniteOperationRegistry<TPage> : IDisposable, IFin
             var operationId = PowerShellFiniteOperationId.FromValue(value);
             var entry = new Entry(owner, binding, now + options.Deadline, options.TerminalRetention);
             entries.Add(value, entry);
+            entry.ScheduleDeadline(timeProvider, () => OnDeadline(value, entry));
             lease = new PowerShellFiniteOperationLease(operationId, entry.Cancellation.Token, entry.Deadline);
             return Result(entry, operationId);
         }
@@ -897,6 +915,7 @@ public sealed class PowerShellFiniteOperationRegistry<TPage> : IDisposable, IFin
     private static void DisposeEntry(Entry entry)
     {
         entry.Pages = null;
+        entry.DisposeDeadlineTimer();
         try
         {
             entry.Cancellation.Cancel();
@@ -914,6 +933,7 @@ public sealed class PowerShellFiniteOperationRegistry<TPage> : IDisposable, IFin
         int errorCode)
     {
         entry.Status = status;
+        entry.DisposeDeadlineTimer();
         entry.ErrorCode = errorCode;
         if (status != PowerShellFiniteOperationStatus.Succeeded)
         {
@@ -965,6 +985,29 @@ public sealed class PowerShellFiniteOperationRegistry<TPage> : IDisposable, IFin
         }
     }
 
+    private void OnDeadline(Guid operationValue, Entry expected)
+    {
+        lock (gate)
+        {
+            if (Volatile.Read(ref disposed) != 0 ||
+                !entries.TryGetValue(operationValue, out Entry? entry) ||
+                !ReferenceEquals(entry, expected) ||
+                entry.Status != PowerShellFiniteOperationStatus.Active)
+            {
+                return;
+            }
+
+            DateTimeOffset now = timeProvider.GetUtcNow();
+            if (now >= entry.Deadline)
+            {
+                TransitionLocked(entry, PowerShellFiniteOperationStatus.TimedOut, now, 0);
+                return;
+            }
+
+            entry.RescheduleDeadline(entry.Deadline - now);
+        }
+    }
+
     private void ThrowIfDisposed()
     {
         if (Volatile.Read(ref disposed) != 0)
@@ -1006,5 +1049,30 @@ public sealed class PowerShellFiniteOperationRegistry<TPage> : IDisposable, IFin
         internal DateTimeOffset? ExpiresAt { get; set; }
 
         internal List<TPage>? Pages { get; set; }
+
+        private ITimer? deadlineTimer;
+
+        internal void ScheduleDeadline(TimeProvider timeProvider, Action callback)
+        {
+            TimeSpan dueTime = Deadline - timeProvider.GetUtcNow();
+            deadlineTimer = timeProvider.CreateTimer(
+                static state => ((Action)state!).Invoke(),
+                callback,
+                dueTime > TimeSpan.Zero ? dueTime : TimeSpan.Zero,
+                Timeout.InfiniteTimeSpan);
+        }
+
+        internal void RescheduleDeadline(TimeSpan dueTime)
+        {
+            _ = deadlineTimer?.Change(
+                dueTime > TimeSpan.Zero ? dueTime : TimeSpan.Zero,
+                Timeout.InfiniteTimeSpan);
+        }
+
+        internal void DisposeDeadlineTimer()
+        {
+            deadlineTimer?.Dispose();
+            deadlineTimer = null;
+        }
     }
 }

--- a/dotnet/live-contracts/PowerShellFiniteOperations.cs
+++ b/dotnet/live-contracts/PowerShellFiniteOperations.cs
@@ -1,0 +1,1010 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading;
+
+namespace Devolutions.PowerShell.Ffi.LiveObjects;
+
+/// <summary>
+/// The finite lifecycle states and request failures returned by
+/// <see cref="PowerShellFiniteOperationRegistry{TPage}"/>.
+/// </summary>
+public enum PowerShellFiniteOperationStatus
+{
+    InvalidArgument = 1,
+    AccessDenied = 2,
+    CapacityExceeded = 3,
+    Active = 4,
+    Succeeded = 5,
+    Failed = 6,
+    Cancelled = 7,
+    TimedOut = 8,
+    Expired = 9,
+    SnapshotInvalidated = 10,
+    PermissionChanged = 11,
+    InvalidCursor = 12,
+    BoundsExceeded = 13,
+    Released = 14,
+}
+
+/// <summary>
+/// A generated operation identifier. It is random, never re-issued by a
+/// registry, and only usable with the owner capability that created it.
+/// </summary>
+public readonly struct PowerShellFiniteOperationId : IEquatable<PowerShellFiniteOperationId>
+{
+    private readonly Guid value;
+
+    private PowerShellFiniteOperationId(Guid value) => this.value = value;
+
+    /// <summary>Gets the opaque value carried over a fixed generated contract.</summary>
+    public Guid Value => value;
+
+    /// <summary>Returns whether this identifier carries a non-empty random value.</summary>
+    public bool IsValid => value != Guid.Empty;
+
+    /// <summary>
+    /// Converts a value received through a fixed contract. Possession of this
+    /// value alone never grants access: every registry operation also requires
+    /// its owner capability.
+    /// </summary>
+    public static PowerShellFiniteOperationId FromValue(Guid value) => new(value);
+
+    public bool Equals(PowerShellFiniteOperationId other) => value.Equals(other.value);
+
+    public override bool Equals(object? obj) => obj is PowerShellFiniteOperationId other && Equals(other);
+
+    public override int GetHashCode() => value.GetHashCode();
+
+    public static bool operator ==(PowerShellFiniteOperationId left, PowerShellFiniteOperationId right) => left.Equals(right);
+
+    public static bool operator !=(PowerShellFiniteOperationId left, PowerShellFiniteOperationId right) => !left.Equals(right);
+}
+
+/// <summary>
+/// A non-forgeable host-side capability that binds operations to one owner.
+/// It is intentionally not serializable or transferable through a bridge
+/// contract. Disposing it performs explicit cleanup of all of its operations.
+/// </summary>
+public sealed class PowerShellFiniteOperationOwner : IDisposable
+{
+    private IFiniteOperationOwnerRegistry? registry;
+
+    internal PowerShellFiniteOperationOwner(IFiniteOperationOwnerRegistry registry) =>
+        this.registry = registry ?? throw new ArgumentNullException(nameof(registry));
+
+    internal bool IsOwnedBy(IFiniteOperationOwnerRegistry expected) =>
+        ReferenceEquals(Volatile.Read(ref registry), expected);
+
+    /// <summary>Releases every operation owned by this capability.</summary>
+    public void Dispose()
+    {
+        Interlocked.Exchange(ref registry, null)?.ReleaseOwner(this);
+        GC.SuppressFinalize(this);
+    }
+}
+
+internal interface IFiniteOperationOwnerRegistry
+{
+    void ReleaseOwner(PowerShellFiniteOperationOwner owner);
+}
+
+/// <summary>
+/// Immutable snapshot, permission, and fixed-schema binding for one operation.
+/// The registry rejects an empty schema identity or zero snapshot/revision
+/// values so a caller cannot accidentally opt out of revalidation.
+/// </summary>
+public readonly struct PowerShellFiniteOperationBinding
+{
+    public PowerShellFiniteOperationBinding(Guid schemaId, ulong snapshotRevision, ulong permissionRevision)
+    {
+        SchemaId = schemaId;
+        SnapshotRevision = snapshotRevision;
+        PermissionRevision = permissionRevision;
+    }
+
+    public Guid SchemaId { get; }
+
+    public ulong SnapshotRevision { get; }
+
+    public ulong PermissionRevision { get; }
+
+    internal bool IsValid =>
+        SchemaId != Guid.Empty &&
+        SnapshotRevision != 0 &&
+        PermissionRevision != 0;
+}
+
+/// <summary>
+/// The bounded active lifetime and terminal retention window of one operation.
+/// The registry applies both values only after validating them against its fixed
+/// limits; no operation can request an unlimited lifetime or retention lease.
+/// </summary>
+public readonly struct PowerShellFiniteOperationOptions
+{
+    public PowerShellFiniteOperationOptions(TimeSpan deadline, TimeSpan terminalRetention)
+    {
+        Deadline = deadline;
+        TerminalRetention = terminalRetention;
+    }
+
+    public TimeSpan Deadline { get; }
+
+    public TimeSpan TerminalRetention { get; }
+}
+
+/// <summary>
+/// The fixed-schema copy function used by a finite page registry. Implementations
+/// must create a detached value and report its exact item and encoded byte
+/// counts. No serializer, reflection, or run-time schema discovery is involved.
+/// </summary>
+public interface IPowerShellFinitePageCodec<TPage>
+{
+    bool TryCopy(TPage source, out TPage copy, out int itemCount, out int byteCount);
+}
+
+/// <summary>Result of revalidating the operation's snapshot and permission binding.</summary>
+public enum PowerShellFinitePageValidation
+{
+    Allowed = 0,
+    SnapshotInvalidated = 1,
+    PermissionChanged = 2,
+}
+
+/// <summary>
+/// Revalidates the immutable snapshot and permission-revision binding for every
+/// page read. It must return a value rather than throw so an invalidation becomes
+/// one deterministic terminal outcome.
+/// </summary>
+public interface IPowerShellFinitePageAccessValidator
+{
+    PowerShellFinitePageValidation Validate(in PowerShellFiniteOperationBinding binding);
+}
+
+/// <summary>
+/// Static limits and the exact codec/validator for one finite page shape. The
+/// shape identity is supplied by the application from its generated contract and
+/// must match each operation binding exactly.
+/// </summary>
+public sealed class PowerShellFinitePageContract<TPage>
+{
+    /// <summary>Hard page count ceiling for one completed operation.</summary>
+    public const int HardMaximumPages = 256;
+
+    /// <summary>Hard item cardinality ceiling for one copied page.</summary>
+    public const int HardMaximumItemsPerPage = PowerShellBridgeWire.MaximumCollectionCount;
+
+    /// <summary>Hard encoded page size ceiling.</summary>
+    public const int HardMaximumPageBytes = PowerShellBridgeWire.MaximumFrameBytes;
+
+    public PowerShellFinitePageContract(
+        Guid schemaId,
+        int maximumPages,
+        int maximumItemsPerPage,
+        int maximumPageBytes,
+        IPowerShellFinitePageCodec<TPage> codec,
+        IPowerShellFinitePageAccessValidator accessValidator)
+    {
+        if (schemaId == Guid.Empty ||
+            maximumPages is < 1 or > HardMaximumPages ||
+            maximumItemsPerPage is < 1 or > HardMaximumItemsPerPage ||
+            maximumPageBytes is < 1 or > HardMaximumPageBytes)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumPages), "The finite page contract bounds are invalid.");
+        }
+
+        SchemaId = schemaId;
+        MaximumPageCount = maximumPages;
+        MaximumItemsPerPage = maximumItemsPerPage;
+        MaximumPageBytes = maximumPageBytes;
+        Codec = codec ?? throw new ArgumentNullException(nameof(codec));
+        AccessValidator = accessValidator ?? throw new ArgumentNullException(nameof(accessValidator));
+    }
+
+    public Guid SchemaId { get; }
+
+    public int MaximumPageCount { get; }
+
+    public int MaximumItemsPerPage { get; }
+
+    public int MaximumPageBytes { get; }
+
+    public IPowerShellFinitePageCodec<TPage> Codec { get; }
+
+    public IPowerShellFinitePageAccessValidator AccessValidator { get; }
+}
+
+/// <summary>A validated zero-based cursor into one finite copied page sequence.</summary>
+public readonly struct PowerShellFinitePageCursor : IEquatable<PowerShellFinitePageCursor>
+{
+    private readonly int index;
+
+    internal PowerShellFinitePageCursor(int index) => this.index = index;
+
+    /// <summary>Gets the first page cursor.</summary>
+    public static PowerShellFinitePageCursor Start => new(0);
+
+    /// <summary>Gets the zero-based cursor position.</summary>
+    public int Index => index;
+
+    /// <summary>Creates a valid cursor from a fixed-schema integer position.</summary>
+    public static bool TryCreate(int index, out PowerShellFinitePageCursor cursor)
+    {
+        cursor = default;
+        if (index < 0)
+        {
+            return false;
+        }
+
+        cursor = new PowerShellFinitePageCursor(index);
+        return true;
+    }
+
+    public bool Equals(PowerShellFinitePageCursor other) => index == other.index;
+
+    public override bool Equals(object? obj) => obj is PowerShellFinitePageCursor other && Equals(other);
+
+    public override int GetHashCode() => index;
+}
+
+/// <summary>One host-side operation lease returned when an operation is created.</summary>
+public readonly struct PowerShellFiniteOperationLease
+{
+    internal PowerShellFiniteOperationLease(
+        PowerShellFiniteOperationId operationId,
+        CancellationToken cancellationToken,
+        DateTimeOffset deadline)
+    {
+        OperationId = operationId;
+        CancellationToken = cancellationToken;
+        Deadline = deadline;
+    }
+
+    public PowerShellFiniteOperationId OperationId { get; }
+
+    /// <summary>
+    /// Gets the cooperative cancellation token. The registry cancels it when a
+    /// cancellation, timeout, terminal transition, explicit release, owner
+    /// disposal, or registry disposal wins the lifecycle transition.
+    /// </summary>
+    public CancellationToken CancellationToken { get; }
+
+    public DateTimeOffset Deadline { get; }
+}
+
+/// <summary>Terminal or active state returned by finite operation operations.</summary>
+public readonly struct PowerShellFiniteOperationResult
+{
+    internal PowerShellFiniteOperationResult(
+        PowerShellFiniteOperationStatus status,
+        PowerShellFiniteOperationId operationId,
+        DateTimeOffset? expiresAt,
+        int errorCode)
+    {
+        Status = status;
+        OperationId = operationId;
+        ExpiresAt = expiresAt;
+        ErrorCode = errorCode;
+    }
+
+    public PowerShellFiniteOperationStatus Status { get; }
+
+    public PowerShellFiniteOperationId OperationId { get; }
+
+    /// <summary>Gets the last read time for a retained terminal state, when retained.</summary>
+    public DateTimeOffset? ExpiresAt { get; }
+
+    /// <summary>Gets the host-supplied non-zero error code for a failed operation.</summary>
+    public int ErrorCode { get; }
+
+    public bool IsTerminal => PowerShellFiniteOperationRegistry<object>.IsTerminal(Status);
+}
+
+/// <summary>The result of reading one copied finite page.</summary>
+public readonly struct PowerShellFinitePageReadResult<TPage>
+{
+    internal PowerShellFinitePageReadResult(
+        PowerShellFiniteOperationResult operation,
+        TPage? page,
+        bool hasPage,
+        PowerShellFinitePageCursor? nextCursor)
+    {
+        Operation = operation;
+        Page = page;
+        HasPage = hasPage;
+        NextCursor = nextCursor;
+    }
+
+    public PowerShellFiniteOperationResult Operation { get; }
+
+    public TPage? Page { get; }
+
+    public bool HasPage { get; }
+
+    public PowerShellFinitePageCursor? NextCursor { get; }
+}
+
+/// <summary>
+/// A bounded, owner-capability-backed store for finite typed operations and
+/// copied fixed-schema pages. It owns no worker pool and does not dispatch work:
+/// the host starts, completes, fails, or cancels its own fixed operation.
+/// </summary>
+public sealed class PowerShellFiniteOperationRegistry<TPage> : IDisposable, IFiniteOperationOwnerRegistry
+{
+    /// <summary>Maximum operation entries, including retained terminal entries.</summary>
+    public const int MaximumOperations = 64;
+
+    /// <summary>Largest accepted active deadline.</summary>
+    public static readonly TimeSpan MaximumDeadline = TimeSpan.FromHours(1);
+
+    /// <summary>Largest accepted terminal retention lease.</summary>
+    public static readonly TimeSpan MaximumTerminalRetention = TimeSpan.FromMinutes(15);
+
+    private readonly object gate = new();
+    private readonly Dictionary<Guid, Entry> entries = new();
+    private readonly PowerShellFinitePageContract<TPage> contract;
+    private readonly TimeProvider timeProvider;
+    private readonly int maximumOperations;
+    private int disposed;
+
+    public PowerShellFiniteOperationRegistry(
+        PowerShellFinitePageContract<TPage> contract,
+        int maximumOperations = MaximumOperations,
+        TimeProvider? timeProvider = null)
+    {
+        if (maximumOperations is < 1 or > MaximumOperations)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumOperations));
+        }
+
+        this.contract = contract ?? throw new ArgumentNullException(nameof(contract));
+        this.maximumOperations = maximumOperations;
+        this.timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>Gets the number of active or retained entries consuming the bounded table.</summary>
+    public int Count
+    {
+        get
+        {
+            lock (gate)
+            {
+                ThrowIfDisposed();
+                return entries.Count;
+            }
+        }
+    }
+
+    /// <summary>Creates a host-only capability used to own a finite operation set.</summary>
+    public PowerShellFiniteOperationOwner CreateOwner()
+    {
+        ThrowIfDisposed();
+        return new PowerShellFiniteOperationOwner(this);
+    }
+
+    /// <summary>
+    /// Starts an empty finite operation. The caller performs its own fixed work
+    /// and later completes it with copied pages or fails it with a numeric code.
+    /// </summary>
+    public PowerShellFiniteOperationResult TryStart(
+        PowerShellFiniteOperationOwner owner,
+        in PowerShellFiniteOperationBinding binding,
+        in PowerShellFiniteOperationOptions options,
+        out PowerShellFiniteOperationLease lease)
+    {
+        lease = default;
+        if (!Owns(owner))
+        {
+            return Result(PowerShellFiniteOperationStatus.AccessDenied);
+        }
+
+        if (!binding.IsValid ||
+            binding.SchemaId != contract.SchemaId ||
+            options.Deadline <= TimeSpan.Zero ||
+            options.Deadline > MaximumDeadline ||
+            options.TerminalRetention <= TimeSpan.Zero ||
+            options.TerminalRetention > MaximumTerminalRetention)
+        {
+            return Result(PowerShellFiniteOperationStatus.InvalidArgument);
+        }
+
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            if (entries.Count >= maximumOperations)
+            {
+                return Result(PowerShellFiniteOperationStatus.CapacityExceeded);
+            }
+
+            Guid value = NewIdentifierLocked();
+            DateTimeOffset now = timeProvider.GetUtcNow();
+            var operationId = PowerShellFiniteOperationId.FromValue(value);
+            var entry = new Entry(owner, binding, now + options.Deadline, options.TerminalRetention);
+            entries.Add(value, entry);
+            lease = new PowerShellFiniteOperationLease(operationId, entry.Cancellation.Token, entry.Deadline);
+            return Result(entry, operationId);
+        }
+    }
+
+    /// <summary>
+    /// Completes an active operation with copied pages. Page count, item count,
+    /// and byte count are validated before the terminal success transition.
+    /// </summary>
+    public PowerShellFiniteOperationResult TryComplete(
+        PowerShellFiniteOperationOwner owner,
+        PowerShellFiniteOperationId operationId,
+        IReadOnlyList<TPage>? pages)
+    {
+        if (!TryResolveActive(owner, operationId, out Entry entry, out PowerShellFiniteOperationResult result))
+        {
+            return result;
+        }
+
+        if (pages is null || pages.Count > contract.MaximumPageCount)
+        {
+            return Transition(owner, operationId, entry, PowerShellFiniteOperationStatus.BoundsExceeded, 0);
+        }
+
+        var copies = new List<TPage>(pages.Count);
+        for (int index = 0; index < pages.Count; index++)
+        {
+            TPage source = pages[index];
+            if (source is null ||
+                !contract.Codec.TryCopy(source, out TPage copy, out int itemCount, out int byteCount) ||
+                copy is null ||
+                itemCount is < 0 or > int.MaxValue ||
+                byteCount is < 0 or > int.MaxValue ||
+                itemCount > contract.MaximumItemsPerPage ||
+                byteCount > contract.MaximumPageBytes)
+            {
+                return Transition(owner, operationId, entry, PowerShellFiniteOperationStatus.BoundsExceeded, 0);
+            }
+
+            copies.Add(copy);
+        }
+
+        lock (gate)
+        {
+            if (!TryLookupLocked(owner, operationId, out Entry current))
+            {
+                return Result(PowerShellFiniteOperationStatus.AccessDenied);
+            }
+
+            DateTimeOffset now = timeProvider.GetUtcNow();
+            PowerShellFiniteOperationStatus status = ResolveLocked(current, now);
+            if (status != PowerShellFiniteOperationStatus.Active)
+            {
+                return Result(current, operationId);
+            }
+
+            current.Pages = copies;
+            TransitionLocked(current, PowerShellFiniteOperationStatus.Succeeded, now, 0);
+            return Result(current, operationId);
+        }
+    }
+
+    /// <summary>
+    /// Records one deterministic application failure. A non-zero code is copied
+    /// into the retained terminal result; text, exceptions, and arbitrary objects
+    /// are intentionally outside this primitive.
+    /// </summary>
+    public PowerShellFiniteOperationResult TryFail(
+        PowerShellFiniteOperationOwner owner,
+        PowerShellFiniteOperationId operationId,
+        int errorCode)
+    {
+        if (errorCode == 0)
+        {
+            return Result(PowerShellFiniteOperationStatus.InvalidArgument);
+        }
+
+        if (!TryResolveActive(owner, operationId, out Entry entry, out PowerShellFiniteOperationResult result))
+        {
+            return result;
+        }
+
+        return Transition(owner, operationId, entry, PowerShellFiniteOperationStatus.Failed, errorCode);
+    }
+
+    /// <summary>
+    /// Cancels an operation idempotently. At one locked transition the precedence
+    /// is deadline first, then recorded cancellation, then an already committed
+    /// terminal outcome. Thus a later completion can never replace a cancellation.
+    /// </summary>
+    public PowerShellFiniteOperationResult TryCancel(
+        PowerShellFiniteOperationOwner owner,
+        PowerShellFiniteOperationId operationId)
+    {
+        if (!Owns(owner))
+        {
+            return Result(PowerShellFiniteOperationStatus.AccessDenied);
+        }
+
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            if (!TryLookupLocked(owner, operationId, out Entry entry))
+            {
+                return Result(PowerShellFiniteOperationStatus.AccessDenied);
+            }
+
+            DateTimeOffset now = timeProvider.GetUtcNow();
+            if (ResolveLocked(entry, now) == PowerShellFiniteOperationStatus.Active)
+            {
+                TransitionLocked(entry, PowerShellFiniteOperationStatus.Cancelled, now, 0);
+            }
+
+            return Result(entry, operationId);
+        }
+    }
+
+    /// <summary>Reads the retained operation state without reading a page.</summary>
+    public PowerShellFiniteOperationResult TryGet(
+        PowerShellFiniteOperationOwner owner,
+        PowerShellFiniteOperationId operationId)
+    {
+        if (!Owns(owner))
+        {
+            return Result(PowerShellFiniteOperationStatus.AccessDenied);
+        }
+
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            if (!TryLookupLocked(owner, operationId, out Entry entry))
+            {
+                return Result(PowerShellFiniteOperationStatus.AccessDenied);
+            }
+
+            _ = ResolveLocked(entry, timeProvider.GetUtcNow());
+            return Result(entry, operationId);
+        }
+    }
+
+    /// <summary>
+    /// Reads one fixed-schema copied page. Every successful page read invokes the
+    /// access validator with the original snapshot and permission revisions before
+    /// a detached page leaves the registry.
+    /// </summary>
+    public PowerShellFinitePageReadResult<TPage> TryReadPage(
+        PowerShellFiniteOperationOwner owner,
+        PowerShellFiniteOperationId operationId,
+        PowerShellFinitePageCursor cursor)
+    {
+        if (!Owns(owner))
+        {
+            return ReadResult(PowerShellFiniteOperationStatus.AccessDenied);
+        }
+
+        Entry entry;
+        TPage source;
+        PowerShellFiniteOperationBinding binding;
+        int nextIndex;
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            if (!TryLookupLocked(owner, operationId, out entry))
+            {
+                return ReadResult(PowerShellFiniteOperationStatus.AccessDenied);
+            }
+
+            PowerShellFiniteOperationStatus status = ResolveLocked(entry, timeProvider.GetUtcNow());
+            if (status != PowerShellFiniteOperationStatus.Succeeded)
+            {
+                return ReadResult(Result(entry, operationId));
+            }
+
+            if (entry.Pages is null || cursor.Index >= entry.Pages.Count)
+            {
+                return ReadResult(PowerShellFiniteOperationStatus.InvalidCursor, operationId);
+            }
+
+            source = entry.Pages[cursor.Index];
+            binding = entry.Binding;
+            nextIndex = cursor.Index + 1;
+        }
+
+        PowerShellFinitePageValidation validation = contract.AccessValidator.Validate(binding);
+        if (validation != PowerShellFinitePageValidation.Allowed)
+        {
+            return InvalidatePageAccess(owner, operationId, validation);
+        }
+
+        if (source is null ||
+            !contract.Codec.TryCopy(source, out TPage copy, out int itemCount, out int byteCount) ||
+            copy is null ||
+            itemCount is < 0 or > int.MaxValue ||
+            byteCount is < 0 or > int.MaxValue ||
+            itemCount > contract.MaximumItemsPerPage ||
+            byteCount > contract.MaximumPageBytes)
+        {
+            return FailPageBounds(owner, operationId);
+        }
+
+        lock (gate)
+        {
+            if (!TryLookupLocked(owner, operationId, out Entry current))
+            {
+                return ReadResult(PowerShellFiniteOperationStatus.AccessDenied);
+            }
+
+            PowerShellFiniteOperationStatus status = ResolveLocked(current, timeProvider.GetUtcNow());
+            if (status != PowerShellFiniteOperationStatus.Succeeded)
+            {
+                return ReadResult(Result(current, operationId));
+            }
+
+            PowerShellFinitePageCursor? next = current.Pages is not null && nextIndex < current.Pages.Count
+                ? new PowerShellFinitePageCursor(nextIndex)
+                : null;
+            return new PowerShellFinitePageReadResult<TPage>(Result(current, operationId), copy, hasPage: true, next);
+        }
+    }
+
+    /// <summary>
+    /// Explicitly ends an operation lease and releases its copied pages. A worker
+    /// holding its cancellation token is notified before the entry is removed.
+    /// </summary>
+    public PowerShellFiniteOperationResult TryRelease(
+        PowerShellFiniteOperationOwner owner,
+        PowerShellFiniteOperationId operationId)
+    {
+        if (!Owns(owner))
+        {
+            return Result(PowerShellFiniteOperationStatus.AccessDenied);
+        }
+
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            if (!TryLookupLocked(owner, operationId, out Entry entry))
+            {
+                return Result(PowerShellFiniteOperationStatus.AccessDenied);
+            }
+
+            entries.Remove(operationId.Value);
+            DisposeEntry(entry);
+            return new PowerShellFiniteOperationResult(
+                PowerShellFiniteOperationStatus.Released,
+                operationId,
+                expiresAt: null,
+                errorCode: 0);
+        }
+    }
+
+    /// <summary>
+    /// Resolves elapsed terminal retentions into explicit <see cref="PowerShellFiniteOperationStatus.Expired"/>
+    /// tombstones. Tombstones retain a bounded table slot until
+    /// <see cref="TryRelease"/> or owner disposal performs explicit cleanup.
+    /// </summary>
+    public int ExpireRetainedOperations()
+    {
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            DateTimeOffset now = timeProvider.GetUtcNow();
+            int expired = 0;
+            foreach (Entry entry in entries.Values)
+            {
+                if (entry.Status != PowerShellFiniteOperationStatus.Expired &&
+                    ResolveLocked(entry, now) == PowerShellFiniteOperationStatus.Expired)
+                {
+                    expired++;
+                }
+            }
+
+            return expired;
+        }
+    }
+
+    /// <summary>Returns whether a status represents a lifecycle terminal outcome.</summary>
+    public static bool IsTerminal(PowerShellFiniteOperationStatus status) =>
+        status is
+            PowerShellFiniteOperationStatus.Succeeded or
+            PowerShellFiniteOperationStatus.Failed or
+            PowerShellFiniteOperationStatus.Cancelled or
+            PowerShellFiniteOperationStatus.TimedOut or
+            PowerShellFiniteOperationStatus.Expired or
+            PowerShellFiniteOperationStatus.SnapshotInvalidated or
+            PowerShellFiniteOperationStatus.PermissionChanged or
+            PowerShellFiniteOperationStatus.BoundsExceeded or
+            PowerShellFiniteOperationStatus.Released;
+
+    void IFiniteOperationOwnerRegistry.ReleaseOwner(PowerShellFiniteOperationOwner owner) => ReleaseOwner(owner);
+
+    /// <summary>Closes every owner-bound operation and releases copied pages.</summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref disposed, 1) != 0)
+        {
+            return;
+        }
+
+        lock (gate)
+        {
+            foreach (Entry entry in entries.Values)
+            {
+                DisposeEntry(entry);
+            }
+
+            entries.Clear();
+        }
+    }
+
+    private PowerShellFiniteOperationResult Transition(
+        PowerShellFiniteOperationOwner owner,
+        PowerShellFiniteOperationId operationId,
+        Entry expected,
+        PowerShellFiniteOperationStatus requested,
+        int errorCode)
+    {
+        lock (gate)
+        {
+            if (!TryLookupLocked(owner, operationId, out Entry entry) || !ReferenceEquals(entry, expected))
+            {
+                return Result(PowerShellFiniteOperationStatus.AccessDenied);
+            }
+
+            DateTimeOffset now = timeProvider.GetUtcNow();
+            if (ResolveLocked(entry, now) == PowerShellFiniteOperationStatus.Active)
+            {
+                TransitionLocked(entry, requested, now, errorCode);
+            }
+
+            return Result(entry, operationId);
+        }
+    }
+
+    private bool TryResolveActive(
+        PowerShellFiniteOperationOwner owner,
+        PowerShellFiniteOperationId operationId,
+        out Entry entry,
+        out PowerShellFiniteOperationResult result)
+    {
+        entry = null!;
+        result = default;
+        if (!Owns(owner))
+        {
+            result = Result(PowerShellFiniteOperationStatus.AccessDenied);
+            return false;
+        }
+
+        lock (gate)
+        {
+            ThrowIfDisposed();
+            if (!TryLookupLocked(owner, operationId, out entry))
+            {
+                result = Result(PowerShellFiniteOperationStatus.AccessDenied);
+                return false;
+            }
+
+            PowerShellFiniteOperationStatus status = ResolveLocked(entry, timeProvider.GetUtcNow());
+            if (status != PowerShellFiniteOperationStatus.Active)
+            {
+                result = Result(entry, operationId);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    private PowerShellFinitePageReadResult<TPage> InvalidatePageAccess(
+        PowerShellFiniteOperationOwner owner,
+        PowerShellFiniteOperationId operationId,
+        PowerShellFinitePageValidation validation)
+    {
+        PowerShellFiniteOperationStatus requested = validation == PowerShellFinitePageValidation.SnapshotInvalidated
+            ? PowerShellFiniteOperationStatus.SnapshotInvalidated
+            : PowerShellFiniteOperationStatus.PermissionChanged;
+
+        lock (gate)
+        {
+            if (!TryLookupLocked(owner, operationId, out Entry entry))
+            {
+                return ReadResult(PowerShellFiniteOperationStatus.AccessDenied);
+            }
+
+            DateTimeOffset now = timeProvider.GetUtcNow();
+            if (ResolveLocked(entry, now) == PowerShellFiniteOperationStatus.Succeeded)
+            {
+                TransitionLocked(entry, requested, now, 0);
+            }
+
+            return ReadResult(Result(entry, operationId));
+        }
+    }
+
+    private PowerShellFinitePageReadResult<TPage> FailPageBounds(
+        PowerShellFiniteOperationOwner owner,
+        PowerShellFiniteOperationId operationId)
+    {
+        lock (gate)
+        {
+            if (!TryLookupLocked(owner, operationId, out Entry entry))
+            {
+                return ReadResult(PowerShellFiniteOperationStatus.AccessDenied);
+            }
+
+            DateTimeOffset now = timeProvider.GetUtcNow();
+            if (ResolveLocked(entry, now) == PowerShellFiniteOperationStatus.Succeeded)
+            {
+                TransitionLocked(entry, PowerShellFiniteOperationStatus.BoundsExceeded, now, 0);
+            }
+
+            return ReadResult(Result(entry, operationId));
+        }
+    }
+
+    private bool Owns(PowerShellFiniteOperationOwner? owner)
+    {
+        ThrowIfDisposed();
+        return owner is not null && owner.IsOwnedBy(this);
+    }
+
+    private bool TryLookupLocked(PowerShellFiniteOperationOwner owner, PowerShellFiniteOperationId operationId, out Entry entry)
+    {
+        entry = null!;
+        if (!operationId.IsValid ||
+            !entries.TryGetValue(operationId.Value, out Entry? candidate) ||
+            candidate is null ||
+            !ReferenceEquals(candidate.Owner, owner) ||
+            !owner.IsOwnedBy(this))
+        {
+            return false;
+        }
+
+        entry = candidate;
+        return true;
+    }
+
+    private Guid NewIdentifierLocked()
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        Guid value;
+        do
+        {
+            RandomNumberGenerator.Fill(bytes);
+            value = new Guid(bytes);
+        }
+        while (value == Guid.Empty || entries.ContainsKey(value));
+
+        return value;
+    }
+
+    private PowerShellFiniteOperationStatus ResolveLocked(Entry entry, DateTimeOffset now)
+    {
+        if (entry.Status == PowerShellFiniteOperationStatus.Active && now >= entry.Deadline)
+        {
+            TransitionLocked(entry, PowerShellFiniteOperationStatus.TimedOut, now, 0);
+        }
+        else if (IsTerminal(entry.Status) &&
+            entry.Status != PowerShellFiniteOperationStatus.Expired &&
+            entry.Status != PowerShellFiniteOperationStatus.Released &&
+            entry.ExpiresAt is DateTimeOffset expiresAt &&
+            now >= expiresAt)
+        {
+            entry.Pages = null;
+            entry.Status = PowerShellFiniteOperationStatus.Expired;
+            entry.ErrorCode = 0;
+        }
+
+        return entry.Status;
+    }
+
+    private static void DisposeEntry(Entry entry)
+    {
+        entry.Pages = null;
+        try
+        {
+            entry.Cancellation.Cancel();
+        }
+        finally
+        {
+            entry.Cancellation.Dispose();
+        }
+    }
+
+    private static void TransitionLocked(
+        Entry entry,
+        PowerShellFiniteOperationStatus status,
+        DateTimeOffset now,
+        int errorCode)
+    {
+        entry.Status = status;
+        entry.ErrorCode = errorCode;
+        if (status != PowerShellFiniteOperationStatus.Succeeded)
+        {
+            entry.Pages = null;
+        }
+
+        entry.ExpiresAt = now + entry.TerminalRetention;
+        entry.Cancellation.Cancel();
+    }
+
+    private static PowerShellFiniteOperationResult Result(PowerShellFiniteOperationStatus status) =>
+        new(status, default, expiresAt: null, errorCode: 0);
+
+    private static PowerShellFiniteOperationResult Result(Entry entry, PowerShellFiniteOperationId operationId) =>
+        new(entry.Status, operationId, entry.ExpiresAt, entry.ErrorCode);
+
+    private static PowerShellFinitePageReadResult<TPage> ReadResult(PowerShellFiniteOperationStatus status) =>
+        new(Result(status), default, hasPage: false, nextCursor: null);
+
+    private static PowerShellFinitePageReadResult<TPage> ReadResult(
+        PowerShellFiniteOperationStatus status,
+        PowerShellFiniteOperationId operationId) =>
+        new(new PowerShellFiniteOperationResult(status, operationId, expiresAt: null, errorCode: 0), default, hasPage: false, nextCursor: null);
+
+    private static PowerShellFinitePageReadResult<TPage> ReadResult(PowerShellFiniteOperationResult operation) =>
+        new(operation, default, hasPage: false, nextCursor: null);
+
+    private void ReleaseOwner(PowerShellFiniteOperationOwner owner)
+    {
+        lock (gate)
+        {
+            List<Guid>? removed = null;
+            foreach ((Guid operationId, Entry entry) in entries)
+            {
+                if (ReferenceEquals(entry.Owner, owner))
+                {
+                    (removed ??= []).Add(operationId);
+                    DisposeEntry(entry);
+                }
+            }
+
+            if (removed is not null)
+            {
+                foreach (Guid operationId in removed)
+                {
+                    entries.Remove(operationId);
+                }
+            }
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref disposed) != 0)
+        {
+            throw new ObjectDisposedException(nameof(PowerShellFiniteOperationRegistry<TPage>));
+        }
+    }
+
+    private sealed class Entry
+    {
+        internal Entry(
+            PowerShellFiniteOperationOwner owner,
+            PowerShellFiniteOperationBinding binding,
+            DateTimeOffset deadline,
+            TimeSpan terminalRetention)
+        {
+            Owner = owner;
+            Binding = binding;
+            Deadline = deadline;
+            TerminalRetention = terminalRetention;
+            Cancellation = new CancellationTokenSource();
+            Status = PowerShellFiniteOperationStatus.Active;
+        }
+
+        internal PowerShellFiniteOperationOwner Owner { get; }
+
+        internal PowerShellFiniteOperationBinding Binding { get; }
+
+        internal DateTimeOffset Deadline { get; }
+
+        internal TimeSpan TerminalRetention { get; }
+
+        internal CancellationTokenSource Cancellation { get; }
+
+        internal PowerShellFiniteOperationStatus Status { get; set; }
+
+        internal int ErrorCode { get; set; }
+
+        internal DateTimeOffset? ExpiresAt { get; set; }
+
+        internal List<TPage>? Pages { get; set; }
+    }
+}

--- a/dotnet/nativeaot-sample/FiniteOperationAttachmentSmoke.cs
+++ b/dotnet/nativeaot-sample/FiniteOperationAttachmentSmoke.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Devolutions.MultiPwsh.FiniteOperationTest;
+using Devolutions.PowerShell.Ffi;
+
+namespace NativeAotFfiSample;
+
+/// <summary>
+/// Proves the fixed finite-operation contract across the real DBC payload
+/// boundary. The payload only invokes generated, closed contract members.
+/// </summary>
+internal static class FiniteOperationAttachmentSmoke
+{
+    internal static bool Run(PowerShellRuntime runtime)
+    {
+        using var channel = runtime.CreateBridgeChannel(
+            new PowerShellBrokerChannelOptions(
+                maximumInflightFrames: 8,
+                maximumBodyBytes: 4096,
+                defaultDeadline: TimeSpan.FromSeconds(20)));
+        using var host = new FiniteOperationTestHost();
+        using PowerShellBridgeBinding binding = channel.CreateBinding(host.Dispatcher);
+        using var stopping = new CancellationTokenSource();
+        using var ready = new ManualResetEventSlim();
+        Exception pumpFailure = null;
+        int dispatched = 0;
+
+        var pump = new Thread(() =>
+        {
+            try
+            {
+                if (!channel.TryReceive(TimeSpan.Zero, out _))
+                {
+                    throw new InvalidOperationException("The finite-operation bridge channel closed before the pump attached.");
+                }
+
+                ready.Set();
+                while (!stopping.IsCancellationRequested &&
+                    channel.TryReceive(TimeSpan.FromMilliseconds(100), out PowerShellBridgeDispatch dispatch))
+                {
+                    if (dispatch is null)
+                    {
+                        continue;
+                    }
+
+                    _ = Task.Run(() =>
+                    {
+                        if (dispatch.Dispatch())
+                        {
+                            Interlocked.Increment(ref dispatched);
+                        }
+                    });
+                }
+            }
+            catch (Exception exception)
+            {
+                pumpFailure = exception;
+                ready.Set();
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "finite-operation-bridge-pump",
+        };
+        pump.Start();
+
+        try
+        {
+            if (!ready.Wait(TimeSpan.FromSeconds(5)) || pumpFailure is not null)
+            {
+                Console.Error.WriteLine(
+                    $"NativeAOT finite-operation bridge pump failed: {pumpFailure?.Message ?? "did not attach"}");
+                return false;
+            }
+
+            PowerShellInvocationResult completed = Invoke(
+                runtime,
+                binding,
+                @"
+                    $ticket = $RDM.Start(1)
+                    $first = $RDM.ReadPage($ticket.OperationId, 0)
+                    $copy = $RDM.ReadPage($ticket.OperationId, 0)
+                    ""$($ticket.Status)|$($first.Status)|$($first.Rows[0])|$($first.NextCursor)|$($copy.Rows[0])""
+                ");
+            if (!IsSingleOutput(completed, "5|5|alpha|1|alpha"))
+            {
+                Console.Error.WriteLine("NativeAOT finite-operation bridge did not return detached fixed-schema pages.");
+                return false;
+            }
+
+            Guid invalidatedOperation = Start(runtime, binding, 1);
+            if (invalidatedOperation == Guid.Empty)
+            {
+                Console.Error.WriteLine("NativeAOT finite-operation bridge could not start the snapshot test operation.");
+                return false;
+            }
+
+            PowerShellInvocationResult firstPage = Invoke(
+                runtime,
+                binding,
+                $"$page = $RDM.ReadPage([guid]'{invalidatedOperation:D}', 0); \"$($page.Status)|$($page.Rows[0])\"");
+            if (!IsSingleOutput(firstPage, "5|alpha"))
+            {
+                Console.Error.WriteLine("NativeAOT finite-operation bridge could not read its initial copied page.");
+                return false;
+            }
+
+            host.InvalidateSnapshot();
+            PowerShellInvocationResult invalidated = Invoke(
+                runtime,
+                binding,
+                $"$page = $RDM.ReadPage([guid]'{invalidatedOperation:D}', 1); \"$($page.Status)|$($page.HasPage)\"");
+            if (!IsSingleOutput(invalidated, "10|False"))
+            {
+                Console.Error.WriteLine("NativeAOT finite-operation bridge did not terminally invalidate a later page read.");
+                return false;
+            }
+
+            PowerShellInvocationResult cancelled = Invoke(
+                runtime,
+                binding,
+                @"
+                    $ticket = $RDM.Start(2)
+                    $first = $RDM.Cancel($ticket.OperationId)
+                    $second = $RDM.Cancel($ticket.OperationId)
+                    $released = $RDM.Release($ticket.OperationId)
+                    ""$($first.Status)|$($second.Status)|$released""
+                ");
+            if (!IsSingleOutput(cancelled, "7|7|14"))
+            {
+                Console.Error.WriteLine("NativeAOT finite-operation bridge did not preserve idempotent cancellation and release.");
+                return false;
+            }
+
+            Guid expiringOperation = Start(runtime, binding, 3);
+            if (expiringOperation == Guid.Empty)
+            {
+                Console.Error.WriteLine("NativeAOT finite-operation bridge could not start the retention test operation.");
+                return false;
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(1200));
+            PowerShellInvocationResult expired = Invoke(
+                runtime,
+                binding,
+                $"$page = $RDM.ReadPage([guid]'{expiringOperation:D}', 0); \"$($page.Status)|$($page.HasPage)\"");
+            if (!IsSingleOutput(expired, "9|False") ||
+                pumpFailure is not null ||
+                Volatile.Read(ref dispatched) < 12)
+            {
+                Console.Error.WriteLine("NativeAOT finite-operation bridge did not retain and expire a terminal operation deterministically.");
+                return false;
+            }
+        }
+        finally
+        {
+            stopping.Cancel();
+            channel.Dispose();
+            pump.Join(TimeSpan.FromSeconds(5));
+        }
+
+        Console.WriteLine("NativeAOT finite-operation bridge attachment: Success");
+        return true;
+    }
+
+    private static Guid Start(PowerShellRuntime runtime, PowerShellBridgeBinding binding, int mode)
+    {
+        PowerShellInvocationResult started = Invoke(
+            runtime,
+            binding,
+            $"$ticket = $RDM.Start({mode}); \"$($ticket.Status)|$($ticket.OperationId)\"");
+        if (started.Output.Records.Count != 1 ||
+            started.Output.Records[0].DisplayText is not string text)
+        {
+            Console.Error.WriteLine(
+                $"NativeAOT finite-operation start returned {started.Output.Records.Count} output record(s) and {started.Errors.Records.Count} error record(s).");
+            return Guid.Empty;
+        }
+
+        string[] parts = text.Split('|');
+        if (parts.Length != 2 || parts[0] != "5" || !Guid.TryParse(parts[1], out Guid operationId))
+        {
+            Console.Error.WriteLine($"NativeAOT finite-operation start returned '{text}'.");
+            return Guid.Empty;
+        }
+
+        return
+            operationId;
+    }
+
+    private static PowerShellInvocationResult Invoke(
+        PowerShellRuntime runtime,
+        PowerShellBridgeBinding binding,
+        string script)
+    {
+        using PowerShell command = runtime.Create();
+        return command
+            .AddScript(script)
+            .WithBridge(binding, "RDM")
+            .InvokeAsync(CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    private static bool IsSingleOutput(PowerShellInvocationResult result, string expected) =>
+        !result.HadErrors &&
+        result.Output.Records.Count == 1 &&
+        result.Output.Records[0].DisplayText == expected;
+}

--- a/dotnet/nativeaot-sample/NativeAotFfiSample.csproj
+++ b/dotnet/nativeaot-sample/NativeAotFfiSample.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\live-contracts\Devolutions.MultiPwsh.LiveContracts.csproj" />
     <ProjectReference Include="..\sdk-ffi\Devolutions.MultiPwsh.Sdk.csproj" />
     <ProjectReference Include="..\bridge-contract-test-host\BridgeContractTestHost.csproj" />
+    <ProjectReference Include="..\finite-operation-test-host\FiniteOperationTestHost.csproj" />
     <ProjectReference Include="..\live-contract-generator\Devolutions.MultiPwsh.LiveContract.Generator.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
@@ -33,6 +34,8 @@
     <LiveObjectTestPackAssembly>$(MSBuildThisFileDirectory)..\live-object-test-pack\bin\$(Configuration)\net8.0\Devolutions.MultiPwsh.LiveObject.TestPack.dll</LiveObjectTestPackAssembly>
     <BridgeContractTestPackProject>$(MSBuildThisFileDirectory)..\bridge-contract-test-pack\BridgeContractTestPack.csproj</BridgeContractTestPackProject>
     <BridgeContractTestPackAssembly>$(MSBuildThisFileDirectory)..\bridge-contract-test-pack\bin\$(Configuration)\net8.0\Devolutions.MultiPwsh.BridgeContract.TestPack.dll</BridgeContractTestPackAssembly>
+    <FiniteOperationTestPackProject>$(MSBuildThisFileDirectory)..\finite-operation-test-pack\FiniteOperationTestPack.csproj</FiniteOperationTestPackProject>
+    <FiniteOperationTestPackAssembly>$(MSBuildThisFileDirectory)..\finite-operation-test-pack\bin\$(Configuration)\net8.0\Devolutions.MultiPwsh.FiniteOperation.TestPack.dll</FiniteOperationTestPackAssembly>
     <IncompatibleLiveObjectTestPackProject>$(MSBuildThisFileDirectory)..\live-object-incompatible-test-pack\Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack.csproj</IncompatibleLiveObjectTestPackProject>
     <IncompatibleLiveObjectTestPackAssembly>$(MSBuildThisFileDirectory)..\live-object-incompatible-test-pack\bin\$(Configuration)\net8.0\Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack.dll</IncompatibleLiveObjectTestPackAssembly>
   </PropertyGroup>
@@ -43,6 +46,9 @@
              Targets="Restore;Build"
              Properties="Configuration=$(Configuration)" />
     <MSBuild Projects="$(BridgeContractTestPackProject)"
+             Targets="Restore;Build"
+             Properties="Configuration=$(Configuration)" />
+    <MSBuild Projects="$(FiniteOperationTestPackProject)"
              Targets="Restore;Build"
              Properties="Configuration=$(Configuration)" />
     <MSBuild Projects="$(IncompatibleLiveObjectTestPackProject)"
@@ -56,6 +62,8 @@
           DestinationFiles="$(PublishDir)Devolutions.MultiPwsh.LiveObject.TestPack.dll" />
     <Copy SourceFiles="$(BridgeContractTestPackAssembly)"
           DestinationFiles="$(PublishDir)Devolutions.MultiPwsh.BridgeContract.TestPack.dll" />
+    <Copy SourceFiles="$(FiniteOperationTestPackAssembly)"
+          DestinationFiles="$(PublishDir)Devolutions.MultiPwsh.FiniteOperation.TestPack.dll" />
     <Copy SourceFiles="$(IncompatibleLiveObjectTestPackAssembly)"
           DestinationFiles="$(PublishDir)Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack.dll" />
   </Target>

--- a/dotnet/nativeaot-sample/Program.cs
+++ b/dotnet/nativeaot-sample/Program.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Devolutions.MultiPwsh.BridgeTest;
+using Devolutions.MultiPwsh.FiniteOperationTest;
 using Devolutions.PowerShell.Ffi;
 using Devolutions.PowerShell.Ffi.LiveObjects;
 using NativeAotFfiSample;
@@ -18,6 +19,9 @@ string incompatibleContractPackPath = System.IO.Path.Combine(
 string bridgeContractPackPath = System.IO.Path.Combine(
     AppContext.BaseDirectory,
     "Devolutions.MultiPwsh.BridgeContract.TestPack.dll");
+string finiteOperationContractPackPath = System.IO.Path.Combine(
+    AppContext.BaseDirectory,
+    "Devolutions.MultiPwsh.FiniteOperation.TestPack.dll");
 if (!System.IO.File.Exists(contractPackPath))
 {
     Console.Error.WriteLine("NativeAOT facade did not publish the external live-object contract pack.");
@@ -31,6 +35,11 @@ if (!System.IO.File.Exists(incompatibleContractPackPath))
 if (!System.IO.File.Exists(bridgeContractPackPath))
 {
     Console.Error.WriteLine("NativeAOT facade did not publish the bridge contract test pack.");
+    return 1;
+}
+if (!System.IO.File.Exists(finiteOperationContractPackPath))
+{
+    Console.Error.WriteLine("NativeAOT facade did not publish the finite-operation test pack.");
     return 1;
 }
 
@@ -49,6 +58,9 @@ PowerShellLiveObjectContractPack[] contractPacks =
     new PowerShellLiveObjectContractPack(
         bridgeContractPackPath,
         "Devolutions.MultiPwsh.BridgeTest.BridgeContractTestPack, Devolutions.MultiPwsh.BridgeContract.TestPack"),
+    new PowerShellLiveObjectContractPack(
+        finiteOperationContractPackPath,
+        "Devolutions.MultiPwsh.FiniteOperationTest.FiniteOperationTestPack, Devolutions.MultiPwsh.FiniteOperation.TestPack"),
 ];
 
 if (args.Length == 2 && args[1].StartsWith("--expect-rejected-contract-pack:", StringComparison.Ordinal))
@@ -998,6 +1010,10 @@ if (!BrokerChannelSmoke.Run(runtime))
 }
 
 if (!BridgeAttachmentSmoke.Run(runtime))
+{
+    return 1;
+}
+if (!FiniteOperationAttachmentSmoke.Run(runtime))
 {
     return 1;
 }

--- a/dotnet/nativeaot-sample/Program.cs
+++ b/dotnet/nativeaot-sample/Program.cs
@@ -50,18 +50,17 @@ if (!FiniteOperationSmoke.Run())
 
 Console.WriteLine("NativeAOT finite operations: Success");
 
-PowerShellLiveObjectContractPack[] contractPacks =
-[
-    new PowerShellLiveObjectContractPack(
-        contractPackPath,
-        "Devolutions.MultiPwsh.LiveObject.TestPack.LiveObjectTestPack, Devolutions.MultiPwsh.LiveObject.TestPack"),
-    new PowerShellLiveObjectContractPack(
-        bridgeContractPackPath,
-        "Devolutions.MultiPwsh.BridgeTest.BridgeContractTestPack, Devolutions.MultiPwsh.BridgeContract.TestPack"),
-    new PowerShellLiveObjectContractPack(
-        finiteOperationContractPackPath,
-        "Devolutions.MultiPwsh.FiniteOperationTest.FiniteOperationTestPack, Devolutions.MultiPwsh.FiniteOperation.TestPack"),
-];
+var liveObjectContractPack = new PowerShellLiveObjectContractPack(
+    contractPackPath,
+    "Devolutions.MultiPwsh.LiveObject.TestPack.LiveObjectTestPack, Devolutions.MultiPwsh.LiveObject.TestPack");
+var bridgeContractPack = new PowerShellLiveObjectContractPack(
+    bridgeContractPackPath,
+    "Devolutions.MultiPwsh.BridgeTest.BridgeContractTestPack, Devolutions.MultiPwsh.BridgeContract.TestPack");
+var finiteOperationContractPack = new PowerShellLiveObjectContractPack(
+    finiteOperationContractPackPath,
+    "Devolutions.MultiPwsh.FiniteOperationTest.FiniteOperationTestPack, Devolutions.MultiPwsh.FiniteOperation.TestPack");
+PowerShellLiveObjectContractPack[] bridgeContractPacks = [liveObjectContractPack, bridgeContractPack];
+PowerShellLiveObjectContractPack[] finiteOperationContractPacks = [liveObjectContractPack, finiteOperationContractPack];
 
 if (args.Length == 2 && args[1].StartsWith("--expect-rejected-contract-pack:", StringComparison.Ordinal))
 {
@@ -100,7 +99,7 @@ if (args.Length == 2 && args[1].StartsWith("--expect-rejected-contract-pack:", S
     PowerShellLiveObjectContractPack[] rejectedPacks = fixtureName == "duplicate-across-packs"
         ?
         [
-            contractPacks[0],
+            liveObjectContractPack,
             new PowerShellLiveObjectContractPack(
                 incompatibleContractPackPath,
                 $"{scenario.Value.TypeName}, Devolutions.MultiPwsh.LiveObject.Incompatible.TestPack"),
@@ -136,23 +135,48 @@ if (args.Length == 2 && args[1].StartsWith("--expect-rejected-contract-pack:", S
 if (args.Length == 2 &&
     args[1].Equals("--expect-bridge-setup-failure-cleans-broker", StringComparison.Ordinal))
 {
-    PowerShellRuntime runtimeWithoutBridgePack = PowerShellRuntime.Activate(args[0], [contractPacks[0]]);
+    PowerShellRuntime runtimeWithoutBridgePack = PowerShellRuntime.Activate(args[0], [liveObjectContractPack]);
     return BridgeAttachmentSmoke.VerifyFailedBridgeSetupClearsBrokerContext(runtimeWithoutBridgePack)
         ? 0
         : 1;
 }
 
+if (args.Length == 2 &&
+    args[1].Equals("--expect-rejected-multiple-bridge-packs", StringComparison.Ordinal))
+{
+    try
+    {
+        _ = PowerShellRuntime.Activate(
+            args[0],
+            [liveObjectContractPack, bridgeContractPack, finiteOperationContractPack]);
+    }
+    catch (PowerShellFfiException exception) when (exception.Status == PowerShellFfiStatus.HostFailure &&
+        exception.Message.Contains("at most one bridge contract pack", StringComparison.Ordinal))
+    {
+        Console.WriteLine("Rejected multiple bridge contract packs.");
+        return 0;
+    }
+
+    Console.Error.WriteLine("NativeAOT facade accepted multiple bridge contract packs.");
+    return 1;
+}
+
+bool finiteOperationBridgeOnly = args.Length == 2 &&
+    args[1].Equals("--finite-operation-bridge-only", StringComparison.Ordinal);
 PowerShellRuntime runtime;
 switch (args.Length)
 {
     case 0:
-        runtime = PowerShellRuntime.Activate(contractPacks);
+        runtime = PowerShellRuntime.Activate(bridgeContractPacks);
         break;
     case 1:
-        runtime = PowerShellRuntime.Activate(args[0], contractPacks);
+        runtime = PowerShellRuntime.Activate(args[0], bridgeContractPacks);
+        break;
+    case 2 when finiteOperationBridgeOnly:
+        runtime = PowerShellRuntime.Activate(args[0], finiteOperationContractPacks);
         break;
     default:
-        Console.Error.WriteLine("Usage: NativeAotFfiSample [payload-directory]");
+        Console.Error.WriteLine("Usage: NativeAotFfiSample [payload-directory] [--finite-operation-bridge-only]");
         return 2;
 }
 
@@ -160,6 +184,17 @@ if (!System.IO.File.Exists(System.IO.Path.Combine(runtime.PayloadDirectory, "pws
 {
     Console.Error.WriteLine("NativeAOT facade did not report the selected PowerShell payload.");
     return 1;
+}
+
+if (finiteOperationBridgeOnly)
+{
+    if (!FiniteOperationAttachmentSmoke.Run(runtime))
+    {
+        return 1;
+    }
+
+    Console.WriteLine("NativeAOT in-process PowerShell FFI: Success");
+    return 0;
 }
 
 if (!ObservedPresentationSmoke.Run(runtime))
@@ -1010,10 +1045,6 @@ if (!BrokerChannelSmoke.Run(runtime))
 }
 
 if (!BridgeAttachmentSmoke.Run(runtime))
-{
-    return 1;
-}
-if (!FiniteOperationAttachmentSmoke.Run(runtime))
 {
     return 1;
 }

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Devolutions.MultiPwsh.Sdk</AssemblyName>
     <PackageId>Devolutions.MultiPwsh.Sdk</PackageId>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.18.0-bridge-v2.dbc.local.8</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.18.0-bridge-v2.dbc.local.6</PackageVersion>
     <Authors>Devolutions</Authors>
     <Description>Experimental dynamically selected PowerShell payload facade for the in-process NativeAOT Devolutions Rust FFI.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Devolutions.MultiPwsh.Sdk</AssemblyName>
     <PackageId>Devolutions.MultiPwsh.Sdk</PackageId>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.17.0</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.18.0-bridge-v2.dbc.local.3</PackageVersion>
     <Authors>Devolutions</Authors>
     <Description>Experimental dynamically selected PowerShell payload facade for the in-process NativeAOT Devolutions Rust FFI.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Devolutions.MultiPwsh.Sdk</AssemblyName>
     <PackageId>Devolutions.MultiPwsh.Sdk</PackageId>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.18.0-bridge-v2.dbc.local.3</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.18.0-bridge-v2.dbc.local.4</PackageVersion>
     <Authors>Devolutions</Authors>
     <Description>Experimental dynamically selected PowerShell payload facade for the in-process NativeAOT Devolutions Rust FFI.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Devolutions.MultiPwsh.Sdk</AssemblyName>
     <PackageId>Devolutions.MultiPwsh.Sdk</PackageId>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.18.0-bridge-v2.dbc.local.6</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.18.0-bridge-v2.dbc.local.8</PackageVersion>
     <Authors>Devolutions</Authors>
     <Description>Experimental dynamically selected PowerShell payload facade for the in-process NativeAOT Devolutions Rust FFI.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -76,6 +76,11 @@
           PackagePath="buildTransitive\Devolutions.MultiPwsh.LiveContracts\"
           Visible="false" />
     <None Include="..\interop\PowerShellLiveObjectContract.cs"
+          BuildAction="None"
+          Pack="true"
+          PackagePath="buildTransitive\Devolutions.MultiPwsh.LiveContracts\"
+          Visible="false" />
+    <None Include="..\live-contracts\PowerShellFiniteOperations.cs"
           BuildAction="None"
           Pack="true"
           PackagePath="buildTransitive\Devolutions.MultiPwsh.LiveContracts\"

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Devolutions.MultiPwsh.Sdk</AssemblyName>
     <PackageId>Devolutions.MultiPwsh.Sdk</PackageId>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.18.0-bridge-v2.dbc.local.4</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.18.0-bridge-v2.dbc.local.6</PackageVersion>
     <Authors>Devolutions</Authors>
     <Description>Experimental dynamically selected PowerShell payload facade for the in-process NativeAOT Devolutions Rust FFI.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/dotnet/sdk-ffi/README.md
+++ b/dotnet/sdk-ffi/README.md
@@ -249,7 +249,7 @@ failure, lease, authorization, and staged-mutation rules.
 ### Finite operation and typed report-page preview
 
 `PowerShellFiniteOperationRegistry<TPage>` in
-`Devolutions.PowerShell.Ffi.LiveObjects` is an opt-in host-only state machine
+`Devolutions.PowerShell.Ffi.LiveObjects.FiniteOperations` is an opt-in host-only state machine
 for an application-selected generated Bridge Contract v2 page type. It has no
 generic script or job dispatch surface: the application supplies a fixed schema
 ID, a direct detached-copy codec, snapshot/permission validator, and only the

--- a/dotnet/sdk-ffi/README.md
+++ b/dotnet/sdk-ffi/README.md
@@ -246,6 +246,31 @@ surface loses most of its value when an open one sits beside it.
 `docs/in-process-ffi.md` carries the normative wire, descriptor, dispatcher,
 failure, lease, authorization, and staged-mutation rules.
 
+### Finite operation and typed report-page preview
+
+`PowerShellFiniteOperationRegistry<TPage>` in
+`Devolutions.PowerShell.Ffi.LiveObjects` is an opt-in host-only state machine
+for an application-selected generated Bridge Contract v2 page type. It has no
+generic script or job dispatch surface: the application supplies a fixed schema
+ID, a direct detached-copy codec, snapshot/permission validator, and only the
+specific generated members it intends to expose.
+
+Each operation ID is a random opaque `Guid`, but access always also requires a
+host-only `PowerShellFiniteOperationOwner`; the ID alone cannot authorize or
+probe an operation. Active deadlines are capped at one hour and terminal
+retention at fifteen minutes. Deadline, cancellation, and already committed
+terminal outcomes have deterministic precedence; cancellation is idempotent.
+Terminal entries become explicit `Expired` tombstones after retention and keep
+their bounded slot until `TryRelease` or owner disposal.
+
+The supplied codec must make detached pages and report exact item and byte
+counts. The registry enforces hard page, item, and byte bounds and revalidates
+the original snapshot and permission revisions before every page read.
+Snapshot/permission invalidation, bounds failure, expiry, and release are
+deterministic terminal outcomes. It does not supply durable sessions or
+checkpoints, persistence, generic targets/schemas, reflection/JSON, remoting,
+credentials, UI, callbacks, pools, or staged mutation semantics.
+
 ## DTO projections and bounded paging
 
 `PowerShellDtoContractAttribute` and `PowerShellDtoMemberAttribute` opt an

--- a/dotnet/sdk-ffi/buildTransitive/Devolutions.MultiPwsh.Sdk.targets
+++ b/dotnet/sdk-ffi/buildTransitive/Devolutions.MultiPwsh.Sdk.targets
@@ -39,6 +39,9 @@
       <Compile Include="$(MSBuildThisFileDirectory)Devolutions.MultiPwsh.LiveContracts\PowerShellLiveObjectContract.cs"
                Link="Devolutions.MultiPwsh.LiveContracts\PowerShellLiveObjectContract.cs"
                Visible="false" />
+      <Compile Include="$(MSBuildThisFileDirectory)Devolutions.MultiPwsh.LiveContracts\PowerShellFiniteOperations.cs"
+               Link="Devolutions.MultiPwsh.LiveContracts\PowerShellFiniteOperations.cs"
+               Visible="false" />
       <ReferencePath Remove="@(ReferencePath)"
                      Condition="'%(ReferencePath.Filename)%(ReferencePath.Extension)' == 'Devolutions.MultiPwsh.LiveContracts.dll'" />
       <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)"

--- a/nuget/Devolutions.MultiPwsh.Cli/README.md
+++ b/nuget/Devolutions.MultiPwsh.Cli/README.md
@@ -6,7 +6,7 @@ The normal CLI payload is copied under `runtimes/<rid>/native/` for build and pu
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.16.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.3" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -28,7 +28,7 @@ AppHost mode is inert by default; set `MultiPwshAppHostEnabled=true` to copy the
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.16.0" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.3" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/nuget/Devolutions.MultiPwsh.Cli/README.md
+++ b/nuget/Devolutions.MultiPwsh.Cli/README.md
@@ -6,7 +6,7 @@ The normal CLI payload is copied under `runtimes/<rid>/native/` for build and pu
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.3" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.4" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -28,7 +28,7 @@ AppHost mode is inert by default; set `MultiPwshAppHostEnabled=true` to copy the
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.3" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.4" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/nuget/Devolutions.MultiPwsh.Cli/README.md
+++ b/nuget/Devolutions.MultiPwsh.Cli/README.md
@@ -6,7 +6,7 @@ The normal CLI payload is copied under `runtimes/<rid>/native/` for build and pu
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.4" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.6" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>
@@ -28,7 +28,7 @@ AppHost mode is inert by default; set `MultiPwshAppHostEnabled=true` to copy the
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.4" PrivateAssets="all" />
+  <PackageReference Include="Devolutions.MultiPwsh.Cli" Version="0.18.0-bridge-v2.dbc.local.6" PrivateAssets="all" />
 </ItemGroup>
 
 <PropertyGroup>

--- a/tests/Test-PwshFfiPackage.ps1
+++ b/tests/Test-PwshFfiPackage.ps1
@@ -275,6 +275,7 @@ try {
 "@ | Set-Content -Path $finitePayloadProject -Encoding utf8
     @"
 using Devolutions.PowerShell.Ffi.LiveObjects;
+using Devolutions.PowerShell.Ffi.LiveObjects.FiniteOperations;
 
 internal static class Program
 {

--- a/tests/Test-PwshFfiPackage.ps1
+++ b/tests/Test-PwshFfiPackage.ps1
@@ -161,6 +161,7 @@ try {
     $requiredPaths = @(
         'README.md',
         'buildTransitive/Devolutions.MultiPwsh.Sdk.targets',
+        'buildTransitive/Devolutions.MultiPwsh.LiveContracts/PowerShellFiniteOperations.cs',
         'lib/net10.0/Devolutions.MultiPwsh.Sdk.dll')
     foreach ($runtimeIdentifier in $ExpectedRuntimeIdentifiers) {
         $requiredPaths += "runtimes/$runtimeIdentifier/native/$($sdkNativeAssets[$runtimeIdentifier])"
@@ -254,6 +255,73 @@ try {
     if (Test-Path $inertNativeAsset -PathType Leaf) {
         throw "FFI native assets must be inert by default, but found $inertNativeAsset"
     }
+
+    $finitePayloadDirectory = Join-Path $workspace 'finite-payload'
+    New-Item -Path $finitePayloadDirectory -ItemType Directory -Force | Out-Null
+    $finitePayloadProject = Join-Path $finitePayloadDirectory 'FfiPackageFinitePayload.csproj'
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LiveContractMode>Payload</LiveContractMode>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="$packageId" Version="$PackageVersion" />
+  </ItemGroup>
+</Project>
+"@ | Set-Content -Path $finitePayloadProject -Encoding utf8
+    @"
+using Devolutions.PowerShell.Ffi.LiveObjects;
+
+internal static class Program
+{
+    private sealed class Codec : IPowerShellFinitePageCodec<int>
+    {
+        public bool TryCopy(int source, out int copy, out int itemCount, out int byteCount)
+        {
+            copy = source;
+            itemCount = 1;
+            byteCount = sizeof(int);
+            return true;
+        }
+    }
+
+    private sealed class Validator : IPowerShellFinitePageAccessValidator
+    {
+        public PowerShellFinitePageValidation Validate(in PowerShellFiniteOperationBinding binding) =>
+            PowerShellFinitePageValidation.Allowed;
+    }
+
+    private static void Main()
+    {
+        var contract = new PowerShellFinitePageContract<int>(
+            new Guid("59B43B9D-2D29-43EE-B25D-8706E3AA50C5"),
+            maximumPages: 1,
+            maximumItemsPerPage: 1,
+            maximumPageBytes: sizeof(int),
+            new Codec(),
+            new Validator());
+        using var registry = new PowerShellFiniteOperationRegistry<int>(contract, maximumOperations: 1);
+        using PowerShellFiniteOperationOwner owner = registry.CreateOwner();
+        PowerShellFiniteOperationResult result = registry.TryStart(
+            owner,
+            new PowerShellFiniteOperationBinding(contract.SchemaId, snapshotRevision: 1, permissionRevision: 1),
+            new PowerShellFiniteOperationOptions(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)),
+            out _);
+
+        if (result.Status != PowerShellFiniteOperationStatus.Active)
+        {
+            throw new InvalidOperationException("The finite payload source was not usable.");
+        }
+    }
+}
+"@ | Set-Content -Path (Join-Path $finitePayloadDirectory 'Program.cs') -Encoding utf8
+    Invoke-CheckedCommand -FilePath dotnet -ArgumentList @('restore', $finitePayloadProject, '--configfile', $nugetConfig)
+    Assert-RestoredPackageMatchesInspectedNupkg -NugetCache $nugetCache -PackageId $packageId -PackageVersion $PackageVersion -InspectedPackagePath $package.FullName
+    Invoke-CheckedCommand -FilePath dotnet -ArgumentList @('build', $finitePayloadProject, '--no-restore', '-c', $Configuration)
 
     $consumerDirectory = Join-Path $workspace 'consumer'
     New-Item -Path $consumerDirectory -ItemType Directory -Force | Out-Null


### PR DESCRIPTION
## Summary

- add the public, bounded finite-operation page registry and generated bridge contract fixture
- package finite payload contracts for external `LiveContractMode=Payload` consumers
- add finite NativeAOT attachment coverage and reject multiple independently compiled bridge contract packs before COM projection

## Validation

- `rustup toolchain install stable --profile minimal`
- `rustup default stable`
- `rustup component add rustfmt clippy --toolchain stable`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets`
- `dotnet build dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj -c Release`
- `dotnet test dotnet/bindings/Devolutions.PowerShell.SDK.Bindings.csproj -c Release --no-build`
- `dotnet run --project dotnet/live-contract-generator-tests/Devolutions.MultiPwsh.LiveContract.Generator.Tests.csproj -c Release --no-build`
- NativeAOT normal bridge, finite-only bridge, and multi-bridge-pack rejection modes against PowerShell 7.4.17