### PR TITLE
Add payload-local credential result sink

### DIFF
--- a/crates/pwsh-host/src/bindings/ffi.rs
+++ b/crates/pwsh-host/src/bindings/ffi.rs
@@ -33,6 +33,7 @@ const FFI_FEATURE_GENERATED_BRIDGE_ATTACHMENT: u64 = 1 << 26;
 const FFI_FEATURE_RELIABLE_BRIDGE_EVENTS: u64 = 1 << 28;
 const FFI_FEATURE_OBSERVED_PRESENTATION: u64 = 1 << 29;
 const FFI_FEATURE_SECRET_ADAPTERS: u64 = 1 << 30;
+const FFI_FEATURE_CREDENTIAL_RESULT_SINK: u64 = 1 << 31;
 const FFI_REQUIRED_FEATURES: u64 = FFI_FEATURE_ASYNC_OPERATION_PRIMITIVES
     | FFI_FEATURE_SESSION_PRIMITIVES
     | FFI_FEATURE_SESSION_POLLING
@@ -52,7 +53,8 @@ const FFI_REQUIRED_FEATURES: u64 = FFI_FEATURE_ASYNC_OPERATION_PRIMITIVES
     | FFI_FEATURE_GENERATED_BRIDGE_ATTACHMENT
     | FFI_FEATURE_RELIABLE_BRIDGE_EVENTS
     | FFI_FEATURE_OBSERVED_PRESENTATION
-    | FFI_FEATURE_SECRET_ADAPTERS;
+    | FFI_FEATURE_SECRET_ADAPTERS
+    | FFI_FEATURE_CREDENTIAL_RESULT_SINK;
 const STATUS_SUCCESS: i32 = 0;
 const STATUS_BUFFER_TOO_SMALL: i32 = 1;
 const VALUE_KIND_PROPERTY_BAG: u32 = 14;
@@ -181,6 +183,7 @@ struct FfiApiV1 {
     power_shell_set_bridge_context_fn: *const libc::c_void,
     observed_diagnostic_page_copy_record_value_fn: *const libc::c_void,
     power_shell_invoke_secret_result_fn: *const libc::c_void,
+    power_shell_invoke_credential_result_fn: *const libc::c_void,
 }
 
 type FnBindingsGetFfiApiV1 = unsafe extern "system" fn() -> *const FfiApiV1;
@@ -205,6 +208,16 @@ type FnFfiPowerShellInvokeToResult =
 type FnFfiPowerShellInvokeSecretResult = unsafe extern "system" fn(
     PowerShellHandle,
     u32,
+    *mut u8,
+    i32,
+    *mut i32,
+    *mut u16,
+    i32,
+    *mut i32,
+    *mut FfiCallResult,
+) -> i32;
+type FnFfiPowerShellInvokeCredentialResult = unsafe extern "system" fn(
+    PowerShellHandle,
     *mut u8,
     i32,
     *mut i32,
@@ -516,6 +529,7 @@ pub(crate) struct FfiBindings {
     power_shell_set_broker_context_fn: FnFfiPowerShellSetBrokerContext,
     power_shell_set_bridge_context_fn: FnFfiPowerShellSetBridgeContext,
     power_shell_invoke_secret_result_fn: FnFfiPowerShellInvokeSecretResult,
+    power_shell_invoke_credential_result_fn: FnFfiPowerShellInvokeCredentialResult,
 }
 
 pub struct FfiPayloadRuntimeDiagnostics {
@@ -738,6 +752,7 @@ impl FfiBindings {
             api.power_shell_set_bridge_context_fn,
             api.observed_diagnostic_page_copy_record_value_fn,
             api.power_shell_invoke_secret_result_fn,
+            api.power_shell_invoke_credential_result_fn,
         ];
         if fields.iter().any(|field| field.is_null()) {
             return Err(Error::IO(std::io::Error::new(
@@ -1066,6 +1081,11 @@ impl FfiBindings {
             power_shell_invoke_secret_result_fn: unsafe {
                 mem::transmute::<*const libc::c_void, FnFfiPowerShellInvokeSecretResult>(
                     api.power_shell_invoke_secret_result_fn,
+                )
+            },
+            power_shell_invoke_credential_result_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiPowerShellInvokeCredentialResult>(
+                    api.power_shell_invoke_credential_result_fn,
                 )
             },
             power_shell_set_capability_context_fn: unsafe {
@@ -1519,6 +1539,40 @@ impl FfiPowerShell {
             .filter(|length| *length <= secret.len())
             .ok_or_else(|| FfiBindingError::from_status(-6, "managed secret length is invalid".to_owned()))?;
         Ok((user_name_length, secret_length))
+    }
+
+    pub fn invoke_credential_result(
+        &self,
+        metadata: &mut [u8],
+        secret: &mut [u16],
+    ) -> Result<(usize, usize), FfiBindingError> {
+        let mut metadata_length = 0_i32;
+        let mut secret_length = 0_i32;
+        self.call(|handle, result| unsafe {
+            (self.bindings.power_shell_invoke_credential_result_fn)(
+                handle,
+                metadata.as_mut_ptr(),
+                i32::try_from(metadata.len()).unwrap_or(i32::MAX),
+                &mut metadata_length,
+                secret.as_mut_ptr(),
+                i32::try_from(secret.len()).unwrap_or(i32::MAX),
+                &mut secret_length,
+                result,
+            )
+        })?;
+        let metadata_length = usize::try_from(metadata_length)
+            .ok()
+            .filter(|length| *length <= metadata.len())
+            .ok_or_else(|| {
+                FfiBindingError::from_status(-6, "managed credential result metadata length is invalid".to_owned())
+            })?;
+        let secret_length = usize::try_from(secret_length)
+            .ok()
+            .filter(|length| *length <= secret.len())
+            .ok_or_else(|| {
+                FfiBindingError::from_status(-6, "managed credential result secret length is invalid".to_owned())
+            })?;
+        Ok((metadata_length, secret_length))
     }
 
     pub fn invoke_to_result(&self) -> Result<FfiInvocationResult, FfiBindingError> {

--- a/crates/pwsh-sdk-ffi/src/lib.rs
+++ b/crates/pwsh-sdk-ffi/src/lib.rs
@@ -55,6 +55,7 @@ const FEATURE_BROKER_TERMINAL_OBSERVATION: u64 = 1 << 27;
 const FEATURE_RELIABLE_BRIDGE_EVENTS: u64 = 1 << 28;
 const FEATURE_OBSERVED_PRESENTATION: u64 = 1 << 29;
 const FEATURE_SECRET_ADAPTERS: u64 = 1 << 30;
+const FEATURE_CREDENTIAL_RESULT_SINK: u64 = 1 << 31;
 const SECRET_VALUE_KIND_UTF16: u32 = 15;
 const SECRET_VALUE_KIND_CREDENTIAL: u32 = 16;
 const MAX_SECRET_UTF16_CODE_UNITS: usize = 4_096;
@@ -6300,6 +6301,7 @@ fn feature_flags() -> u64 {
         | FEATURE_RELIABLE_BRIDGE_EVENTS
         | FEATURE_OBSERVED_PRESENTATION
         | FEATURE_SECRET_ADAPTERS
+        | FEATURE_CREDENTIAL_RESULT_SINK
 }
 
 fn create_live_object_probe(initial_count: i64) -> Result<*mut std::ffi::c_void, (Status, String)> {
@@ -6902,6 +6904,55 @@ pub unsafe extern "C" fn multi_pwsh_invoke_secret_result(
                     )
                 })?;
             *user_name_length = returned_user_name_length;
+            *secret_length = returned_secret_length;
+            Ok(Status::Success)
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_invoke_credential_result(
+    handle: u64,
+    metadata_buffer: *mut u8,
+    metadata_capacity: usize,
+    metadata_length: *mut usize,
+    secret_buffer: *mut u16,
+    secret_capacity: usize,
+    secret_length: *mut usize,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || {
+        if metadata_length.is_null()
+            || secret_length.is_null()
+            || metadata_capacity > 16 * 1024
+            || (metadata_capacity != 0 && metadata_buffer.is_null())
+            || (secret_capacity != 0 && secret_buffer.is_null())
+        {
+            return Err((
+                Status::InvalidArgument,
+                "credential result arguments are invalid".to_owned(),
+            ));
+        }
+
+        let metadata = if metadata_capacity == 0 {
+            &mut []
+        } else {
+            slice::from_raw_parts_mut(metadata_buffer, metadata_capacity)
+        };
+        let secret = if secret_capacity == 0 {
+            &mut []
+        } else {
+            slice::from_raw_parts_mut(secret_buffer, secret_capacity)
+        };
+        with_session_result(handle, true, |session| {
+            let (returned_metadata_length, returned_secret_length) =
+                session.invoke_credential_result(metadata, secret).map_err(|_| {
+                    (
+                        Status::ManagedFailure,
+                        "credential result PowerShell operation failed".to_owned(),
+                    )
+                })?;
+            *metadata_length = returned_metadata_length;
             *secret_length = returned_secret_length;
             Ok(Status::Success)
         })
@@ -10312,7 +10363,8 @@ mod tests {
             | FEATURE_BROKER_TERMINAL_OBSERVATION
             | FEATURE_RELIABLE_BRIDGE_EVENTS
             | FEATURE_OBSERVED_PRESENTATION
-            | FEATURE_SECRET_ADAPTERS;
+            | FEATURE_SECRET_ADAPTERS
+            | FEATURE_CREDENTIAL_RESULT_SINK;
 
         assert_eq!(ABI_VERSION, 2);
         assert_eq!(MINIMUM_COMPATIBLE_ABI_VERSION, 2);

--- a/dotnet/bindings/FfiBindings.cs
+++ b/dotnet/bindings/FfiBindings.cs
@@ -4895,6 +4895,10 @@ namespace NativeHost
                 }
 
                 InitialSessionState initialState = InitialSessionState.CreateDefault2();
+                initialState.Commands.Add(new SessionStateCmdletEntry(
+                    "ConvertTo-SecureString",
+                    typeof(Microsoft.PowerShell.Commands.ConvertToSecureStringCommand),
+                    helpFileName: null));
                 if (initialConfiguration == ConstrainedLanguageConfiguration)
                 {
                     initialState.LanguageMode = PSLanguageMode.ConstrainedLanguage;

--- a/dotnet/bindings/FfiBindings.cs
+++ b/dotnet/bindings/FfiBindings.cs
@@ -74,8 +74,11 @@ namespace NativeHost
         private const ulong FfiFeatureReliableBridgeEvents = 1UL << 28;
         private const ulong FfiFeatureObservedPresentation = 1UL << 29;
         private const ulong FfiFeatureSecretAdapters = 1UL << 30;
+        private const ulong FfiFeatureCredentialResultSink = 1UL << 31;
         private const int FfiMaxSecretLength = 4_096;
         private const int FfiMaxSecretUserNameLength = 256;
+        private const int FfiMaxCredentialResultTextLength = 4_096;
+        private const int FfiMaxCredentialResultMetadataLength = 16 * 1024;
         private const uint FfiTypedResultPageTerminal = 1;
         private const uint FfiTypedResultPageTruncated = 1 << 1;
         private const uint FfiTypedResultPageComplete = 1 << 2;
@@ -213,6 +216,7 @@ namespace NativeHost
             public IntPtr PowerShell_SetBridgeContext;
             public IntPtr ObservedDiagnosticPage_CopyRecordValue;
             public IntPtr PowerShell_InvokeSecretResult;
+            public IntPtr PowerShell_InvokeCredentialResult;
         }
 
         private const int FfiPreflightMaximumTextLength = 128;
@@ -1145,7 +1149,7 @@ namespace NativeHost
                     FfiFeatureLiveStreamPolling | FfiFeatureTypedResultPaging | FfiFeatureObservedInvocation |
                     FfiFeatureSessionPreflight | FfiFeatureRuntimeDiagnostics | FfiFeatureDuplexBrokerChannel |
                     FfiFeatureGeneratedBridgeAttachment | FfiFeatureReliableBridgeEvents |
-                    FfiFeatureObservedPresentation | FfiFeatureSecretAdapters,
+                    FfiFeatureObservedPresentation | FfiFeatureSecretAdapters | FfiFeatureCredentialResultSink,
                 PowerShell_Create = (IntPtr)(delegate* unmanaged<IntPtr*, FfiCallResult*, int>)&FfiPowerShell_Create,
                 PowerShell_Release = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiPowerShell_Release,
                 PowerShell_AddArgumentUtf8 = (IntPtr)(delegate* unmanaged<IntPtr, byte*, int, FfiCallResult*, int>)&FfiPowerShell_AddArgumentUtf8,
@@ -1233,6 +1237,7 @@ namespace NativeHost
                 PowerShell_SetBridgeContext = (IntPtr)(delegate* unmanaged<IntPtr, ulong, ulong, ulong, ushort, ushort, uint, uint, byte*, int, FfiCallResult*, int>)&FfiPowerShell_SetBridgeContext,
                 ObservedDiagnosticPage_CopyRecordValue = (IntPtr)(delegate* unmanaged<IntPtr, int, uint*, byte*, int, int*, FfiCallResult*, int>)&FfiObservedDiagnosticPage_CopyRecordValue,
                 PowerShell_InvokeSecretResult = (IntPtr)(delegate* unmanaged<IntPtr, uint, byte*, int, int*, char*, int, int*, FfiCallResult*, int>)&FfiPowerShell_InvokeSecretResult,
+                PowerShell_InvokeCredentialResult = (IntPtr)(delegate* unmanaged<IntPtr, byte*, int, int*, char*, int, int*, FfiCallResult*, int>)&FfiPowerShell_InvokeCredentialResult,
             };
         }
 
@@ -2591,6 +2596,124 @@ namespace NativeHost
             });
         }
 
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiPowerShell_InvokeCredentialResult(
+            IntPtr ptrHandle,
+            byte* metadataBuffer,
+            int metadataCapacity,
+            int* metadataLength,
+            char* secretBuffer,
+            int secretCapacity,
+            int* secretLength,
+            FfiCallResult* result)
+        {
+            if (metadataLength == null ||
+                secretLength == null ||
+                metadataCapacity < 0 ||
+                metadataCapacity > FfiMaxCredentialResultMetadataLength ||
+                secretCapacity < 0 ||
+                (metadataCapacity != 0 && metadataBuffer == null) ||
+                (secretCapacity != 0 && secretBuffer == null))
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Credential result arguments are invalid.");
+            }
+
+            return ExecuteSecret(result, () =>
+            {
+                FfiPowerShellPipeline pipeline = GetPowerShellPipeline(ptrHandle);
+                pipeline.ThrowIfSecretBound();
+                FfiCredentialResultSnapshot snapshot = InvokeCredentialResultPipeline(
+                    pipeline,
+                    TakeCompletedInput(ptrHandle));
+                try
+                {
+                    int requiredMetadataLength = snapshot.GetMetadataLength();
+                    if (requiredMetadataLength > metadataCapacity ||
+                        (snapshot.Password is not null && snapshot.Password.Length > secretCapacity))
+                    {
+                        throw new InvalidOperationException("Credential result exceeds its bound.");
+                    }
+
+                    snapshot.WriteMetadata(new Span<byte>(metadataBuffer, requiredMetadataLength));
+                    *metadataLength = requiredMetadataLength;
+                    *secretLength = 0;
+                    if (snapshot.Password is not null)
+                    {
+                        IntPtr bstr = Marshal.SecureStringToBSTR(snapshot.Password);
+                        try
+                        {
+                            new ReadOnlySpan<char>((void*)bstr, snapshot.Password.Length)
+                                .CopyTo(new Span<char>(secretBuffer, snapshot.Password.Length));
+                            *secretLength = snapshot.Password.Length;
+                        }
+                        finally
+                        {
+                            Marshal.ZeroFreeBSTR(bstr);
+                        }
+                    }
+                }
+                finally
+                {
+                    snapshot.Dispose();
+                    pipeline.PowerShell.Commands.Clear();
+                }
+            });
+        }
+
+        private static FfiCredentialResultSnapshot InvokeCredentialResultPipeline(
+            FfiPowerShellPipeline pipeline,
+            object[] input)
+        {
+            FfiCredentialResultSink sink = new();
+            PowerShell powerShell = pipeline.PowerShell;
+            Runspace runspace = powerShell.Runspace;
+            bool ownsRunspace = false;
+            if (runspace is null)
+            {
+                runspace = RunspaceFactory.CreateRunspace();
+                runspace.Open();
+                powerShell.Runspace = runspace;
+                ownsRunspace = true;
+            }
+
+            PSVariable previous = runspace.SessionStateProxy.PSVariable.Get("Result");
+            runspace.SessionStateProxy.SetVariable("Result", sink);
+            try
+            {
+                FfiSecretInvocationOutput invocation = InvokeSecretPipeline(pipeline, input, captureOutput: true);
+                if (invocation.HadErrors || invocation.OutputCount != 0)
+                {
+                    throw new InvalidOperationException(
+                        "Credential result invocations must not produce pipeline output or diagnostics.");
+                }
+
+                return sink.TakeSnapshot();
+            }
+            finally
+            {
+                try
+                {
+                    if (previous is null)
+                    {
+                        runspace.SessionStateProxy.PSVariable.Remove("Result");
+                    }
+                    else
+                    {
+                        runspace.SessionStateProxy.PSVariable.Set(previous);
+                    }
+                }
+                finally
+                {
+                    sink.Dispose();
+                    if (ownsRunspace)
+                    {
+                        powerShell.Runspace = null;
+                        runspace.Dispose();
+                    }
+                }
+            }
+        }
+
         private static bool TryProjectCredentialResult(
             PSObject result,
             object value,
@@ -2748,6 +2871,338 @@ namespace NativeHost
             public int OutputCount { get; }
 
             public bool HadErrors { get; }
+        }
+
+        private sealed class FfiCredentialResultSink : IDisposable
+        {
+            private bool active = true;
+            private string username = string.Empty;
+            private string domain = string.Empty;
+            private string outputMessages = string.Empty;
+            private string errorMessages = string.Empty;
+            private string logMessage = string.Empty;
+            private SecureString password;
+            private bool cancel;
+
+            public string Username
+            {
+                get
+                {
+                    EnsureActive();
+                    return username;
+                }
+                set
+                {
+                    EnsureActive();
+                    username = ValidateText(value, FfiMaxSecretUserNameLength, "Username");
+                }
+            }
+
+            public string Domain
+            {
+                get
+                {
+                    EnsureActive();
+                    return domain;
+                }
+                set
+                {
+                    EnsureActive();
+                    domain = ValidateText(value, FfiMaxSecretUserNameLength, "Domain");
+                }
+            }
+
+            public string Password
+            {
+                get
+                {
+                    EnsureActive();
+                    return password is null ? string.Empty : CopyPasswordToString(password);
+                }
+                set
+                {
+                    EnsureActive();
+                    ReplacePassword(CreateSecureString(value));
+                }
+            }
+
+            public SecureString SecurePassword
+            {
+                get
+                {
+                    EnsureActive();
+                    return password is null ? CreateEmptySecureString() : CopySecureString(password);
+                }
+                set
+                {
+                    EnsureActive();
+                    ReplacePassword(CopySecureString(value));
+                }
+            }
+
+            public bool Cancel
+            {
+                get
+                {
+                    EnsureActive();
+                    return cancel;
+                }
+                set
+                {
+                    EnsureActive();
+                    cancel = value;
+                }
+            }
+
+            public string OutputMessages
+            {
+                get
+                {
+                    EnsureActive();
+                    return outputMessages;
+                }
+                set
+                {
+                    EnsureActive();
+                    outputMessages = ValidateText(value, FfiMaxCredentialResultTextLength, "OutputMessages");
+                }
+            }
+
+            public string ErrorMessages
+            {
+                get
+                {
+                    EnsureActive();
+                    return errorMessages;
+                }
+                set
+                {
+                    EnsureActive();
+                    errorMessages = ValidateText(value, FfiMaxCredentialResultTextLength, "ErrorMessages");
+                }
+            }
+
+            public string LogMessage
+            {
+                get
+                {
+                    EnsureActive();
+                    return logMessage;
+                }
+                set
+                {
+                    EnsureActive();
+                    logMessage = ValidateText(value, FfiMaxCredentialResultTextLength, "LogMessage");
+                }
+            }
+
+            public FfiCredentialResultSnapshot TakeSnapshot()
+            {
+                EnsureActive();
+                active = false;
+                SecureString resultPassword = password;
+                password = null;
+                FfiCredentialResultSnapshot snapshot = new(
+                    username,
+                    domain,
+                    resultPassword,
+                    cancel,
+                    outputMessages,
+                    errorMessages,
+                    logMessage);
+                username = string.Empty;
+                domain = string.Empty;
+                outputMessages = string.Empty;
+                errorMessages = string.Empty;
+                logMessage = string.Empty;
+                cancel = false;
+                return snapshot;
+            }
+
+            public void Dispose()
+            {
+                active = false;
+                SecureString value = password;
+                password = null;
+                value?.Dispose();
+                username = string.Empty;
+                domain = string.Empty;
+                outputMessages = string.Empty;
+                errorMessages = string.Empty;
+                logMessage = string.Empty;
+                cancel = false;
+            }
+
+            private static string ValidateText(string value, int maximumLength, string propertyName)
+            {
+                ArgumentNullException.ThrowIfNull(value);
+                if (value.IndexOf('\0') >= 0 ||
+                    value.Length > maximumLength ||
+                    Encoding.UTF8.GetByteCount(value) > FfiMaxCredentialResultTextLength)
+                {
+                    throw new ArgumentException(
+                        $"{propertyName} must be non-NUL text within its credential result bound.",
+                        propertyName);
+                }
+
+                return value;
+            }
+
+            private static SecureString CreateSecureString(string value)
+            {
+                ArgumentNullException.ThrowIfNull(value);
+                if (value.Length is < 1 or > FfiMaxSecretLength || value.IndexOf('\0') >= 0)
+                {
+                    throw new ArgumentException("Password must be bounded non-NUL text.", nameof(value));
+                }
+
+                var result = new SecureString();
+                foreach (char character in value)
+                {
+                    result.AppendChar(character);
+                }
+                result.MakeReadOnly();
+                return result;
+            }
+
+            private static SecureString CreateEmptySecureString()
+            {
+                var result = new SecureString();
+                result.MakeReadOnly();
+                return result;
+            }
+
+            private static unsafe SecureString CopySecureString(SecureString value)
+            {
+                ArgumentNullException.ThrowIfNull(value);
+                if (value.Length is < 1 or > FfiMaxSecretLength)
+                {
+                    throw new ArgumentException("SecurePassword must be bounded non-empty text.", nameof(value));
+                }
+
+                IntPtr bstr = Marshal.SecureStringToBSTR(value);
+                try
+                {
+                    var result = new SecureString();
+                    foreach (char character in new ReadOnlySpan<char>((void*)bstr, value.Length))
+                    {
+                        if (character == '\0')
+                        {
+                            result.Dispose();
+                            throw new ArgumentException("SecurePassword must not contain NUL.", nameof(value));
+                        }
+                        result.AppendChar(character);
+                    }
+                    result.MakeReadOnly();
+                    return result;
+                }
+                finally
+                {
+                    Marshal.ZeroFreeBSTR(bstr);
+                }
+            }
+
+            private static string CopyPasswordToString(SecureString value)
+            {
+                IntPtr bstr = Marshal.SecureStringToBSTR(value);
+                try
+                {
+                    return Marshal.PtrToStringBSTR(bstr);
+                }
+                finally
+                {
+                    Marshal.ZeroFreeBSTR(bstr);
+                }
+            }
+
+            private void ReplacePassword(SecureString value)
+            {
+                SecureString previous = password;
+                password = value;
+                previous?.Dispose();
+            }
+
+            private void EnsureActive()
+            {
+                if (!active)
+                {
+                    throw new InvalidOperationException("The credential result sink is no longer active.");
+                }
+            }
+        }
+
+        private sealed class FfiCredentialResultSnapshot : IDisposable
+        {
+            private const uint HasPassword = 1;
+            private const uint Cancelled = 1 << 1;
+
+            public FfiCredentialResultSnapshot(
+                string username,
+                string domain,
+                SecureString password,
+                bool cancel,
+                string outputMessages,
+                string errorMessages,
+                string logMessage)
+            {
+                Username = username;
+                Domain = domain;
+                Password = password;
+                Cancel = cancel;
+                OutputMessages = outputMessages;
+                ErrorMessages = errorMessages;
+                LogMessage = logMessage;
+            }
+
+            public string Username { get; }
+            public string Domain { get; }
+            public SecureString Password { get; }
+            public bool Cancel { get; }
+            public string OutputMessages { get; }
+            public string ErrorMessages { get; }
+            public string LogMessage { get; }
+
+            public int GetMetadataLength()
+            {
+                return checked(
+                    sizeof(uint) +
+                    (sizeof(int) * 5) +
+                    Encoding.UTF8.GetByteCount(Username) +
+                    Encoding.UTF8.GetByteCount(Domain) +
+                    Encoding.UTF8.GetByteCount(OutputMessages) +
+                    Encoding.UTF8.GetByteCount(ErrorMessages) +
+                    Encoding.UTF8.GetByteCount(LogMessage));
+            }
+
+            public void WriteMetadata(Span<byte> destination)
+            {
+                if (destination.Length != GetMetadataLength())
+                {
+                    throw new ArgumentException("Credential result metadata buffer length is invalid.", nameof(destination));
+                }
+
+                uint flags = (Password is null ? 0U : HasPassword) | (Cancel ? Cancelled : 0U);
+                BinaryPrimitives.WriteUInt32LittleEndian(destination, flags);
+                int offset = sizeof(uint);
+                WriteField(destination, ref offset, Username);
+                WriteField(destination, ref offset, Domain);
+                WriteField(destination, ref offset, OutputMessages);
+                WriteField(destination, ref offset, ErrorMessages);
+                WriteField(destination, ref offset, LogMessage);
+            }
+
+            public void Dispose()
+            {
+                Password?.Dispose();
+            }
+
+            private static void WriteField(Span<byte> destination, ref int offset, string value)
+            {
+                int byteLength = Encoding.UTF8.GetByteCount(value);
+                BinaryPrimitives.WriteInt32LittleEndian(destination.Slice(offset, sizeof(int)), byteLength);
+                offset += sizeof(int);
+                offset += Encoding.UTF8.GetBytes(value, destination[offset..]);
+            }
         }
 
         [UnmanagedCallersOnly]

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -142,6 +142,9 @@
   <Target Name="BuildPwshFfiNativeAsset"
           BeforeTargets="GenerateNuspec"
           Condition="'$(BuildPwshFfiNativeAsset)' != 'false' and '$(PwshFfiNativeStagingRoot)' == ''">
+    <MSBuild Projects="$(RepositoryRoot)\dotnet\bindings\Devolutions.PowerShell.SDK.Bindings.csproj"
+             Targets="Build"
+             Properties="Configuration=$(Configuration);PwshExePath=$(PwshExePath)" />
     <Exec Command="cargo build --profile $(PwshFfiCargoProfile) -p pwsh-sdk-ffi"
           WorkingDirectory="$(RepositoryRoot)"
           EnvironmentVariables="RUSTFLAGS=$(PwshFfiRustFlags)" />

--- a/dotnet/sdk-ffi/NativeMethods.cs
+++ b/dotnet/sdk-ffi/NativeMethods.cs
@@ -353,6 +353,18 @@ internal static unsafe partial class NativeMethods
         nuint* secretLength,
         NativeCallResult* result);
 
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_invoke_credential_result")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int InvokeCredentialResult(
+        ulong handle,
+        byte* metadataBuffer,
+        nuint metadataCapacity,
+        nuint* metadataLength,
+        char* secretBuffer,
+        nuint secretCapacity,
+        nuint* secretLength,
+        NativeCallResult* result);
+
     [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_add_parameter_switch")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial int AddParameterSwitch(

--- a/dotnet/sdk-ffi/PowerShell.cs
+++ b/dotnet/sdk-ffi/PowerShell.cs
@@ -35,6 +35,7 @@ public sealed unsafe class PowerShell : IDisposable
     private const ulong ReliableBridgeEventsFeature = 1UL << 28;
     private const ulong ObservedPresentationFeature = 1UL << 29;
     private const ulong SecretAdaptersFeature = 1UL << 30;
+    private const ulong CredentialResultSinkFeature = 1UL << 31;
     private const ulong LiveObjectProbeFeature = 1UL << 17;
     private const ulong LiveSessionObjectProbeFeature = 1UL << 18;
     private const ulong LiveObjectContractsFeature = 1UL << 19;
@@ -728,6 +729,58 @@ public sealed unsafe class PowerShell : IDisposable
         }
     }
 
+    /// <summary>
+    /// Invokes a mutation-only script with a payload-local <c>$Result</c> sink.
+    /// Normal pipeline output and diagnostics are rejected so credentials remain
+    /// available only through the disposable, redacted result.
+    /// </summary>
+    public PowerShellCredentialResult InvokeCredentialResult()
+    {
+        EnsureCredentialResultSinkSupported();
+        byte[] metadata = new byte[16 * 1024];
+        char[] secret = new char[PowerShellSecret.MaximumLength];
+        try
+        {
+            using PowerShellHandle.HandleLease lease = handle.Borrow();
+            byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+            NativeCallResult result = NativeCall.CreateResult(diagnostic);
+            nuint metadataLength = 0;
+            nuint secretLength = 0;
+            fixed (byte* metadataPointer = metadata)
+            fixed (char* secretPointer = secret)
+            {
+                int status = NativeMethods.InvokeCredentialResult(
+                    lease.Value,
+                    metadataPointer,
+                    (nuint)metadata.Length,
+                    &metadataLength,
+                    secretPointer,
+                    (nuint)secret.Length,
+                    &secretLength,
+                    &result);
+                NativeCall.ThrowIfFailed(status, result, diagnostic);
+            }
+
+            if (metadataLength > (nuint)metadata.Length ||
+                secretLength > (nuint)secret.Length)
+            {
+                throw new PowerShellFfiException(
+                    PowerShellFfiStatus.ManagedFailure,
+                    "Native PowerShell FFI returned invalid credential result lengths.");
+            }
+
+            return ReadCredentialResult(
+                metadata.AsSpan(0, checked((int)metadataLength)),
+                secret,
+                checked((int)secretLength));
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(metadata);
+            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(secret.AsSpan()));
+        }
+    }
+
     public PowerShellInvocationResult InvokeWithDiagnostics()
     {
         using PowerShellHandle.HandleLease lease = handle.Borrow();
@@ -980,6 +1033,105 @@ public sealed unsafe class PowerShell : IDisposable
                 PowerShellFfiStatus.UnsupportedCapability,
                 "The selected PowerShell payload does not support explicit secret adapters.");
         }
+    }
+
+    internal static void EnsureCredentialResultSinkSupported()
+    {
+        EnsureSupportedAbi();
+        if ((FeatureFlags & CredentialResultSinkFeature) == 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.UnsupportedCapability,
+                "The selected PowerShell payload does not support an invocation-owned credential result sink.");
+        }
+    }
+
+    private static PowerShellCredentialResult ReadCredentialResult(
+        ReadOnlySpan<byte> metadata,
+        char[] secret,
+        int secretLength)
+    {
+        const int HeaderLength = sizeof(uint) + (sizeof(int) * 5);
+        const uint HasPassword = 1;
+        const uint Cancelled = 1 << 1;
+        if (metadata.Length < HeaderLength)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned invalid credential result metadata.");
+        }
+
+        uint flags = BitConverter.ToUInt32(metadata[..sizeof(uint)]);
+        if ((flags & ~(HasPassword | Cancelled)) != 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned unsupported credential result flags.");
+        }
+
+        int offset = sizeof(uint);
+        string username = ReadCredentialResultField(metadata, ref offset);
+        string domain = ReadCredentialResultField(metadata, ref offset);
+        string outputMessages = ReadCredentialResultField(metadata, ref offset);
+        string errorMessages = ReadCredentialResultField(metadata, ref offset);
+        string logMessage = ReadCredentialResultField(metadata, ref offset);
+        if (offset != metadata.Length ||
+            username.Length > 256 ||
+            domain.Length > 256 ||
+            ((flags & HasPassword) == 0 && secretLength != 0) ||
+            ((flags & HasPassword) != 0 && secretLength is < 1 or > PowerShellSecret.MaximumLength))
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned an invalid credential result.");
+        }
+
+        PowerShellSecret? password = null;
+        if ((flags & HasPassword) != 0)
+        {
+            char[] ownedSecret = secret[..secretLength];
+            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(secret.AsSpan()));
+            password = PowerShellSecret.TakeOwnership(ownedSecret);
+        }
+
+        return new PowerShellCredentialResult(
+            username,
+            domain,
+            password,
+            (flags & Cancelled) != 0,
+            outputMessages,
+            errorMessages,
+            logMessage);
+    }
+
+    private static string ReadCredentialResultField(ReadOnlySpan<byte> metadata, ref int offset)
+    {
+        if (offset > metadata.Length - sizeof(int))
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned invalid credential result metadata.");
+        }
+
+        int length = BitConverter.ToInt32(metadata.Slice(offset, sizeof(int)));
+        offset += sizeof(int);
+        if (length < 0 || length > 4_096 || length > metadata.Length - offset)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned invalid credential result metadata.");
+        }
+
+        string value = Encoding.UTF8.GetString(metadata.Slice(offset, length));
+        offset += length;
+        if (value.IndexOf('\0') >= 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned invalid credential result text.");
+        }
+
+        return value;
     }
 
     internal static void EnsureTypedResultPagingSupported(NativeAbiInfo info)

--- a/dotnet/sdk-ffi/PowerShellCredentialResult.cs
+++ b/dotnet/sdk-ffi/PowerShellCredentialResult.cs
@@ -1,0 +1,50 @@
+namespace Devolutions.PowerShell.Ffi;
+
+/// <summary>
+/// A redacted, disposable result from a payload-local credential result sink.
+/// </summary>
+public sealed class PowerShellCredentialResult : IDisposable
+{
+    internal PowerShellCredentialResult(
+        string username,
+        string domain,
+        PowerShellSecret? password,
+        bool isCancelled,
+        string outputMessages,
+        string errorMessages,
+        string logMessage)
+    {
+        Username = username;
+        Domain = domain;
+        Password = password;
+        IsCancelled = isCancelled;
+        OutputMessages = outputMessages;
+        ErrorMessages = errorMessages;
+        LogMessage = logMessage;
+    }
+
+    public string Username { get; }
+
+    public string Domain { get; }
+
+    /// <summary>
+    /// The payload-local password, when the script assigned either Password or SecurePassword.
+    /// </summary>
+    public PowerShellSecret? Password { get; }
+
+    public bool IsCancelled { get; }
+
+    public string OutputMessages { get; }
+
+    public string ErrorMessages { get; }
+
+    public string LogMessage { get; }
+
+    public override string ToString() =>
+        $"<redacted PowerShell credential result: cancelled={IsCancelled}, password={(Password is null ? "absent" : "present")}>";
+
+    public void Dispose()
+    {
+        Password?.Dispose();
+    }
+}

--- a/dotnet/sdk-ffi/PowerShellSecret.cs
+++ b/dotnet/sdk-ffi/PowerShellSecret.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Security.Cryptography;
 
 namespace Devolutions.PowerShell.Ffi;
@@ -43,7 +44,19 @@ public sealed class PowerShellSecret : IDisposable
         return new PowerShellSecret(value);
     }
 
-    internal void CopyTo(Span<char> destination)
+    /// <summary>
+    /// Gets the number of UTF-16 code units in this secret.
+    /// </summary>
+    public int Length => (value ?? throw new ObjectDisposedException(nameof(PowerShellSecret))).Length;
+
+    /// <summary>
+    /// Copies the secret into a caller-owned buffer.
+    /// </summary>
+    /// <remarks>
+    /// The destination must have exactly <see cref="Length"/> elements. Callers
+    /// must clear the destination immediately after use.
+    /// </remarks>
+    public void CopyTo(Span<char> destination)
     {
         char[] source = value ?? throw new ObjectDisposedException(nameof(PowerShellSecret));
         if (destination.Length != source.Length)
@@ -54,7 +67,25 @@ public sealed class PowerShellSecret : IDisposable
         source.AsSpan().CopyTo(destination);
     }
 
-    internal int Length => (value ?? throw new ObjectDisposedException(nameof(PowerShellSecret))).Length;
+    /// <summary>
+    /// Copies this secret into a read-only <see cref="SecureString"/>.
+    /// </summary>
+    /// <remarks>
+    /// The returned value is independently owned and must be disposed by the
+    /// caller after it has been passed to the secure credential sink.
+    /// </remarks>
+    public SecureString ToSecureString()
+    {
+        char[] source = value ?? throw new ObjectDisposedException(nameof(PowerShellSecret));
+        var secureString = new SecureString();
+        foreach (char character in source)
+        {
+            secureString.AppendChar(character);
+        }
+
+        secureString.MakeReadOnly();
+        return secureString;
+    }
 
     public override string ToString() => "<redacted PowerShell secret>";
 

--- a/tests/PwshFfiApiBaseline.txt
+++ b/tests/PwshFfiApiBaseline.txt
@@ -1137,6 +1137,19 @@ facade:type:Devolutions.PowerShell.Ffi.PowerShellBridgeReliableEventStreamIdenti
 facade:type:Devolutions.PowerShell.Ffi.PowerShellBridgeReliableEventStreamInfo
 facade:type:Devolutions.PowerShell.Ffi.PowerShellBridgeReliableEventTerminalState
 bindings:FfiPowerShell_InvokeSecretResult
+bindings:FfiPowerShell_InvokeCredentialResult
+facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShellCredentialResult InvokeCredentialResult()
+facade:type:Devolutions.PowerShell.Ffi.PowerShellCredentialResult
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.String Domain
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.String ErrorMessages
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::Boolean IsCancelled
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.String LogMessage
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.String OutputMessages
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::Devolutions.PowerShell.Ffi.PowerShellSecret Password
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.String Username
+facade:method:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.String ToString()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::Void Dispose()
+native:multi_pwsh_invoke_credential_result
 facade:ctor:Devolutions.PowerShell.Ffi.PowerShellCredential::Void .ctor(System.String, Devolutions.PowerShell.Ffi.PowerShellSecret)
 facade:ctor:Devolutions.PowerShell.Ffi.PowerShellModuleImport::Void .ctor(System.String, System.Version, Devolutions.PowerShell.Ffi.PowerShellModuleImportOptions)
 facade:ctor:Devolutions.PowerShell.Ffi.PowerShellRemoteSessionOptions::Void .ctor(System.String, Devolutions.PowerShell.Ffi.PowerShellCredential, Boolean, Int32)

--- a/tests/PwshFfiApiBaseline.txt
+++ b/tests/PwshFfiApiBaseline.txt
@@ -1175,8 +1175,11 @@ facade:method:Devolutions.PowerShell.Ffi.PowerShellRemoteSession::Devolutions.Po
 facade:method:Devolutions.PowerShell.Ffi.PowerShellRemoteSession::Devolutions.PowerShell.Ffi.PowerShellRemoteSessionMetadata GetMetadata()
 facade:method:Devolutions.PowerShell.Ffi.PowerShellRemoteSession::Void Dispose()
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSecret::Devolutions.PowerShell.Ffi.PowerShellSecret Create(System.ReadOnlySpan`1[System.Char])
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSecret::System.Security.SecureString ToSecureString()
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSecret::System.String ToString()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSecret::Void CopyTo(System.Span`1[System.Char])
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSecret::Void Dispose()
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSecret::Int32 Length
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSecretResult::System.String ToString()
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSecretResult::Void Dispose()
 facade:method:Devolutions.PowerShell.Ffi.PowerShellSession::Void ImportModule(Devolutions.PowerShell.Ffi.PowerShellModuleImport)

--- a/tests/Test-PwshFfiPackage.ps1
+++ b/tests/Test-PwshFfiPackage.ps1
@@ -3476,6 +3476,102 @@ static void VerifySecretBindings(PowerShellRuntime runtime)
             result.Credential?.UserName == "fixture-user",
             "The contract-pack PSCredential result binding failed.");
     }
+
+    using (PowerShell pipeline = session.CreatePowerShell())
+    using (PowerShellCredentialResult result = pipeline
+        .AddScript(
+            "`$Result.Username = 'secure-user'; " +
+            "`$Result.Domain = 'secure-domain'; " +
+            "`$securePassword = [System.Security.SecureString]::new(); " +
+            "foreach (`$character in 'secure-fixture'.ToCharArray()) { `$securePassword.AppendChar(`$character) }; " +
+            "`$Result.SecurePassword = `$securePassword")
+        .InvokeCredentialResult())
+    {
+        Require(
+            result.Username == "secure-user" &&
+            result.Domain == "secure-domain" &&
+            result.Password is not null &&
+            !result.ToString().Contains("secure-fixture", StringComparison.Ordinal) &&
+            !result.Password.ToString().Contains("secure-fixture", StringComparison.Ordinal),
+            "The payload-local SecurePassword credential result sink did not return a redacted typed result.");
+    }
+
+    using (PowerShell pipeline = session.CreatePowerShell())
+    using (PowerShellCredentialResult result = pipeline
+        .AddScript("`$Result.Username = 'plain-user'; `$Result.Password = 'plain-fixture'")
+        .InvokeCredentialResult())
+    {
+        Require(
+            result.Username == "plain-user" &&
+            result.Password is not null &&
+            !result.ToString().Contains("plain-fixture", StringComparison.Ordinal),
+            "The payload-local Password credential result sink did not convert a legacy password assignment.");
+    }
+
+    using (PowerShell pipeline = session.CreatePowerShell())
+    using (PowerShellCredentialResult result = pipeline
+        .AddScript(
+            "`$Result.Cancel = `$true; " +
+            "`$Result.OutputMessages = 'output message'; " +
+            "`$Result.ErrorMessages = 'error message'; " +
+            "`$Result.LogMessage = 'log message'")
+        .InvokeCredentialResult())
+    {
+        Require(
+            result.IsCancelled &&
+            result.OutputMessages == "output message" &&
+            result.ErrorMessages == "error message" &&
+            result.LogMessage == "log message" &&
+            result.Password is null,
+            "The payload-local credential result sink did not return cancellation and bounded messages.");
+    }
+
+    try
+    {
+        using PowerShell pipeline = session.CreatePowerShell();
+        _ = pipeline
+            .AddScript("`$Result.Password = 'output-fixture'; `$Result.Password")
+            .InvokeCredentialResult();
+        throw new InvalidOperationException("Credential result output was accepted by an ordinary result path.");
+    }
+    catch (PowerShellFfiException exception)
+    {
+        Require(
+            !exception.Message.Contains("output-fixture", StringComparison.Ordinal),
+            "Credential result output leaked a secret through diagnostics.");
+    }
+
+    using (PowerShell pipeline = session.CreatePowerShell())
+    using (PowerShellCredentialResult result = pipeline
+        .AddScript("`$global:RetainedCredentialResult = `$Result; `$Result.Password = 'retained-fixture'")
+        .InvokeCredentialResult())
+    {
+        Require(result.Password is not null, "Credential result retention fixture did not produce a typed secret.");
+    }
+
+    try
+    {
+        using (PowerShell pipeline = session.CreatePowerShell())
+        {
+            PowerShellInvocationResult retainedResult = pipeline
+                .AddScript(
+                    "`$rejected = `$false; " +
+                    "try { `$global:RetainedCredentialResult.Username = 'must-not-set' } " +
+                    "catch { `$rejected = `$true }; " +
+                    "`$rejected")
+                .InvokeWithDiagnostics();
+            Require(
+                retainedResult.Output.Records.Count == 1 &&
+                retainedResult.Output.Records[0].DisplayText == "True" &&
+                retainedResult.Errors.Records.Count == 0,
+                "A retained credential result sink remained usable after its invocation.");
+        }
+    }
+    finally
+    {
+        using PowerShell cleanup = session.CreatePowerShell();
+        _ = cleanup.AddScript("Remove-Variable -Name RetainedCredentialResult -Scope Global -ErrorAction SilentlyContinue").Invoke();
+    }
 }
 
 if (args.Length != 1)

--- a/tests/Test-PwshFfiPackage.ps1
+++ b/tests/Test-PwshFfiPackage.ps1
@@ -3487,6 +3487,21 @@ static void VerifySecretBindings(PowerShellRuntime runtime)
             "`$Result.SecurePassword = `$securePassword")
         .InvokeCredentialResult())
     {
+        char[] transferredPassword = new char[result.Password!.Length];
+        try
+        {
+            result.Password.CopyTo(transferredPassword);
+            using var securePassword = result.Password.ToSecureString();
+            Require(
+                transferredPassword.AsSpan().SequenceEqual("secure-fixture".AsSpan()) &&
+                securePassword.Length == result.Password.Length,
+                "The credential result password did not support explicit secure transfer.");
+        }
+        finally
+        {
+            Array.Clear(transferredPassword);
+        }
+
         Require(
             result.Username == "secure-user" &&
             result.Domain == "secure-domain" &&

--- a/tests/Test-PwshFfiPackage.ps1
+++ b/tests/Test-PwshFfiPackage.ps1
@@ -3482,9 +3482,7 @@ static void VerifySecretBindings(PowerShellRuntime runtime)
         .AddScript(
             "`$Result.Username = 'secure-user'; " +
             "`$Result.Domain = 'secure-domain'; " +
-            "`$securePassword = [System.Security.SecureString]::new(); " +
-            "foreach (`$character in 'secure-fixture'.ToCharArray()) { `$securePassword.AppendChar(`$character) }; " +
-            "`$Result.SecurePassword = `$securePassword")
+            "`$Result.SecurePassword = ConvertTo-SecureString 'secure-fixture' -AsPlainText -Force")
         .InvokeCredentialResult())
     {
         char[] transferredPassword = new char[result.Password!.Length];

--- a/tests/Verify-PwshFfiApiBaseline.ps1
+++ b/tests/Verify-PwshFfiApiBaseline.ps1
@@ -359,10 +359,13 @@ $expectedObservedPresentationTableSlots = @(
 $expectedSecretAdapterTableSlots = @(
     @{ Field = 'PowerShell_InvokeSecretResult'; Rust = 'power_shell_invoke_secret_result_fn'; Alias = 'FnFfiPowerShellInvokeSecretResult'; Method = 'FfiPowerShell_InvokeSecretResult'; Signature = 'IntPtr,uint,byte*,int,int*,char*,int,int*,FfiCallResult*,int' }
 )
+$expectedCredentialResultTableSlots = @(
+    @{ Field = 'PowerShell_InvokeCredentialResult'; Rust = 'power_shell_invoke_credential_result_fn'; Alias = 'FnFfiPowerShellInvokeCredentialResult'; Method = 'FfiPowerShell_InvokeCredentialResult'; Signature = 'IntPtr,byte*,int,int*,char*,int,int*,FfiCallResult*,int' }
+)
 $compactFfiBindingsSource = $ffiBindingsSource -replace '\s+', ''
-$allTableSlots = @($expectedTableSlots) + @($expectedLiveTableSlots) + @($expectedTypedResultTableSlots) + @($expectedObservedInvocationTableSlots) + @($expectedSessionPreflightTableSlots) + @($expectedRuntimeDiagnosticsTableSlots) + @($expectedBrokerTableSlots) + @($expectedObservedPresentationTableSlots) + @($expectedSecretAdapterTableSlots)
+$allTableSlots = @($expectedTableSlots) + @($expectedLiveTableSlots) + @($expectedTypedResultTableSlots) + @($expectedObservedInvocationTableSlots) + @($expectedSessionPreflightTableSlots) + @($expectedRuntimeDiagnosticsTableSlots) + @($expectedBrokerTableSlots) + @($expectedObservedPresentationTableSlots) + @($expectedSecretAdapterTableSlots) + @($expectedCredentialResultTableSlots)
 $ffiApiType = $bindingsAssemblyObject.GetType('NativeHost.Bindings+FfiApiV1', $true)
-Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiType)) -Expected 720 -Description 'Managed FfiApiV1 size'
+Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiType)) -Expected 728 -Description 'Managed FfiApiV1 size'
 $ffiApiFields = @($ffiApiType.GetFields($instanceFields) | Sort-Object MetadataToken)
 $expectedFfiApiFieldNames = @('Size', 'AbiVersion', 'FeatureFlags') + @($allTableSlots | ForEach-Object { $_.Field })
 Assert-Sequence -Actual @($ffiApiFields | ForEach-Object Name) -Expected $expectedFfiApiFieldNames -Description 'Managed FfiApiV1 slot order'
@@ -374,7 +377,7 @@ for ($index = 0; $index -lt $ffiApiFields.Count; $index++) {
     Assert-Equal -Actual (Get-ManagedTypeName $field.FieldType) -Expected $expectedType -Description "Managed FfiApiV1 '$($field.Name)' type"
 }
 
-$expectedBridgeFeatures = 'FeatureFlags=(1UL<<4)|(1UL<<5)|(1UL<<6)|FfiFeatureAsyncOperationPrimitives|FfiFeatureSessionPrimitives|FfiFeatureSessionPolling|FfiFeatureSnapshotProjections|FfiFeatureSessionConfiguration|FfiFeatureSessionVariables|FfiFeatureCapabilityRpc|FfiFeatureLiveObjectProbe|FfiFeatureLiveSessionObjectProbe|FfiFeatureLiveObjectContracts|FfiFeatureLiveStreamPolling|FfiFeatureTypedResultPaging|FfiFeatureObservedInvocation|FfiFeatureSessionPreflight|FfiFeatureRuntimeDiagnostics|FfiFeatureDuplexBrokerChannel|FfiFeatureGeneratedBridgeAttachment|FfiFeatureReliableBridgeEvents|FfiFeatureObservedPresentation|FfiFeatureSecretAdapters'
+$expectedBridgeFeatures = 'FeatureFlags=(1UL<<4)|(1UL<<5)|(1UL<<6)|FfiFeatureAsyncOperationPrimitives|FfiFeatureSessionPrimitives|FfiFeatureSessionPolling|FfiFeatureSnapshotProjections|FfiFeatureSessionConfiguration|FfiFeatureSessionVariables|FfiFeatureCapabilityRpc|FfiFeatureLiveObjectProbe|FfiFeatureLiveSessionObjectProbe|FfiFeatureLiveObjectContracts|FfiFeatureLiveStreamPolling|FfiFeatureTypedResultPaging|FfiFeatureObservedInvocation|FfiFeatureSessionPreflight|FfiFeatureRuntimeDiagnostics|FfiFeatureDuplexBrokerChannel|FfiFeatureGeneratedBridgeAttachment|FfiFeatureReliableBridgeEvents|FfiFeatureObservedPresentation|FfiFeatureSecretAdapters|FfiFeatureCredentialResultSink'
 if (-not $compactFfiBindingsSource.Contains($expectedBridgeFeatures)) {
     throw 'Managed FfiApiV1 feature flags no longer advertise the checked bridge capabilities.'
 }
@@ -413,7 +416,8 @@ $expectedRustApiTableFields = @('size', 'abi_version', 'feature_flags') +
     @($expectedRuntimeDiagnosticsTableSlots | ForEach-Object Rust) +
     @($expectedBrokerTableSlots | ForEach-Object Rust) +
     @($expectedObservedPresentationTableSlots | ForEach-Object Rust) +
-    @($expectedSecretAdapterTableSlots | ForEach-Object Rust)
+    @($expectedSecretAdapterTableSlots | ForEach-Object Rust) +
+    @($expectedCredentialResultTableSlots | ForEach-Object Rust)
 Assert-Sequence -Actual $rustApiTableFields -Expected $expectedRustApiTableFields -Description 'Rust FfiApiV1 slot order'
 
 $rustBindingsTableMatch = [regex]::Match($rustBindingsSource, '(?s)pub\(crate\)\s+struct\s+FfiBindings\s*\{(?<body>.*?)\n\s*\}')
@@ -438,7 +442,8 @@ Assert-Sequence -Actual $rustBindingsFields -Expected (
         'runtime_diagnostics_copy_power_shell_file_version_utf8_fn|FnFfiRuntimeDiagnosticsCopyPowerShellFileVersionUtf8',
         'power_shell_set_broker_context_fn|FnFfiPowerShellSetBrokerContext',
         'power_shell_set_bridge_context_fn|FnFfiPowerShellSetBridgeContext',
-        'power_shell_invoke_secret_result_fn|FnFfiPowerShellInvokeSecretResult'
+        'power_shell_invoke_secret_result_fn|FnFfiPowerShellInvokeSecretResult',
+        'power_shell_invoke_credential_result_fn|FnFfiPowerShellInvokeCredentialResult'
     )
 ) -Description 'Rust FfiBindings slot order and aliases'
 if (-not $rustFfiSource.Contains('const FEATURE_TYPED_RESULT_PAGING: u64 = 1 << 21;')) {
@@ -465,6 +470,9 @@ if (-not $rustFfiSource.Contains('const FEATURE_OBSERVED_PRESENTATION: u64 = 1 <
 if (-not $rustFfiSource.Contains('const FEATURE_SECRET_ADAPTERS: u64 = 1 << 30;')) {
     throw 'Rust native ABI must advertise secret adapter feature bit 30.'
 }
+if (-not $rustFfiSource.Contains('const FEATURE_CREDENTIAL_RESULT_SINK: u64 = 1 << 31;')) {
+    throw 'Rust native ABI must advertise credential result sink feature bit 31.'
+}
 
 $expectedRustFunctionAliases = @'
 FnBindingsGetFfiApiV1|unsafeextern"system"fn()->*constFfiApiV1
@@ -481,6 +489,7 @@ FnFfiPowerShellClear|unsafeextern"system"fn(PowerShellHandle,*mutFfiCallResult)-
 FnFfiPowerShellStop|unsafeextern"system"fn(PowerShellHandle,*mutFfiCallResult)->i32
 FnFfiPowerShellInvokeToResult|unsafeextern"system"fn(PowerShellHandle,*mutPowerShellHandle,*mutFfiCallResult)->i32
 FnFfiPowerShellInvokeSecretResult|unsafeextern"system"fn(PowerShellHandle,u32,*mutu8,i32,*muti32,*mutu16,i32,*muti32,*mutFfiCallResult)->i32
+FnFfiPowerShellInvokeCredentialResult|unsafeextern"system"fn(PowerShellHandle,*mutu8,i32,*muti32,*mutu16,i32,*muti32,*mutFfiCallResult)->i32
 FnFfiInvocationResultRelease|unsafeextern"system"fn(PowerShellHandle,*mutFfiCallResult)->i32
 FnFfiInvocationResultGetInfo|unsafeextern"system"fn(PowerShellHandle,*mutu32,*muti32,*mutFfiCallResult)->i32
 FnFfiInvocationResultGetStreamInfo|unsafeextern"system"fn(PowerShellHandle,i32,*muti32,*mutu32,*mutFfiCallResult)->i32


### PR DESCRIPTION
## Summary
- add an invocation-owned payload-local `$Result` credential sink for mutation-only resolver scripts
- return redacted, disposable credential results and expose secure `PowerShellSecret` transfer APIs
- enable the built-in `ConvertTo-SecureString` cmdlet for new generic sessions without importing arbitrary modules

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets` (existing warnings only)
- `cargo build --all-targets`
- `cargo test --all-targets`
- bindings build/tests and public API baseline verification
- restored-NuGet NativeAOT package smoke, including the generated bridge-contract pack and credential result cases

Note: the required Rustup default-setting command could not run because the local Rustup installation reports an invalid `C:\Users\mamoreau\.cargo` location; the installed stable toolchain ran the formatter and Clippy checks successfully.