### PR TITLE
Add NativeAOT credential result sink

### DIFF
--- a/crates/pwsh-host/src/bindings.rs
+++ b/crates/pwsh-host/src/bindings.rs
@@ -12,10 +12,11 @@ pub(crate) use self::bindings_generated::Bindings;
 use self::bindings_generated::PowerShellHandle;
 pub(crate) use self::ffi::FfiBindings;
 pub use self::ffi::{
-    FfiBindingError, FfiBridgeContext, FfiInvocationResult, FfiLiveInvocation, FfiLiveObjectContractDescriptor,
-    FfiLiveStreamBatch, FfiLiveStreamRecord, FfiObservedDiagnosticPage, FfiObservedDiagnosticRecord,
-    FfiObservedInvocation, FfiPayloadRuntimeDiagnostics, FfiPowerShell, FfiPowerShellSession, FfiSessionEvent,
-    FfiSessionSnapshot, FfiSnapshotValue, FfiTypedResultInvocation, FfiTypedResultPage, FfiTypedResultRecord,
+    FfiBindingError, FfiBridgeContext, FfiCredentialResult, FfiInvocationResult, FfiLiveInvocation,
+    FfiLiveObjectContractDescriptor, FfiLiveStreamBatch, FfiLiveStreamRecord, FfiObservedDiagnosticPage,
+    FfiObservedDiagnosticRecord, FfiObservedInvocation, FfiPayloadRuntimeDiagnostics, FfiPowerShell,
+    FfiPowerShellSession, FfiSessionEvent, FfiSessionSnapshot, FfiSnapshotValue, FfiTypedResultInvocation,
+    FfiTypedResultPage, FfiTypedResultRecord,
 };
 use crate::loader::HostedRuntime;
 

--- a/crates/pwsh-host/src/bindings/ffi.rs
+++ b/crates/pwsh-host/src/bindings/ffi.rs
@@ -1556,7 +1556,14 @@ impl FfiPowerShell {
         Ok((user_name_length, secret_length))
     }
 
-    pub fn invoke_credential_result(&self, credential_result: &mut FfiCredentialResult) -> Result<(), FfiBindingError> {
+    /// # Safety
+    ///
+    /// Every non-null buffer in `credential_result` must be writable for its
+    /// declared capacity and remain valid for the duration of the call.
+    pub unsafe fn invoke_credential_result(
+        &self,
+        credential_result: &mut FfiCredentialResult,
+    ) -> Result<(), FfiBindingError> {
         self.call(|handle, result| unsafe {
             (self.bindings.power_shell_invoke_credential_result_fn)(handle, credential_result, result)
         })?;

--- a/crates/pwsh-host/src/bindings/ffi.rs
+++ b/crates/pwsh-host/src/bindings/ffi.rs
@@ -33,6 +33,7 @@ const FFI_FEATURE_GENERATED_BRIDGE_ATTACHMENT: u64 = 1 << 26;
 const FFI_FEATURE_RELIABLE_BRIDGE_EVENTS: u64 = 1 << 28;
 const FFI_FEATURE_OBSERVED_PRESENTATION: u64 = 1 << 29;
 const FFI_FEATURE_SECRET_ADAPTERS: u64 = 1 << 30;
+const FFI_FEATURE_CREDENTIAL_RESULT: u64 = 1 << 31;
 const FFI_REQUIRED_FEATURES: u64 = FFI_FEATURE_ASYNC_OPERATION_PRIMITIVES
     | FFI_FEATURE_SESSION_PRIMITIVES
     | FFI_FEATURE_SESSION_POLLING
@@ -52,7 +53,8 @@ const FFI_REQUIRED_FEATURES: u64 = FFI_FEATURE_ASYNC_OPERATION_PRIMITIVES
     | FFI_FEATURE_GENERATED_BRIDGE_ATTACHMENT
     | FFI_FEATURE_RELIABLE_BRIDGE_EVENTS
     | FFI_FEATURE_OBSERVED_PRESENTATION
-    | FFI_FEATURE_SECRET_ADAPTERS;
+    | FFI_FEATURE_SECRET_ADAPTERS
+    | FFI_FEATURE_CREDENTIAL_RESULT;
 const STATUS_SUCCESS: i32 = 0;
 const STATUS_BUFFER_TOO_SMALL: i32 = 1;
 const VALUE_KIND_PROPERTY_BAG: u32 = 14;
@@ -66,6 +68,30 @@ struct FfiCallResult {
     diagnostic_capacity: i32,
     diagnostic_required_length: i32,
     diagnostic_written_length: i32,
+}
+
+#[repr(C)]
+pub struct FfiCredentialResult {
+    pub size: u32,
+    pub is_cancelled: u32,
+    pub username: *mut u8,
+    pub username_capacity: i32,
+    pub username_length: i32,
+    pub domain: *mut u8,
+    pub domain_capacity: i32,
+    pub domain_length: i32,
+    pub password: *mut u16,
+    pub password_capacity: i32,
+    pub password_length: i32,
+    pub output_messages: *mut u8,
+    pub output_messages_capacity: i32,
+    pub output_messages_length: i32,
+    pub error_messages: *mut u8,
+    pub error_messages_capacity: i32,
+    pub error_messages_length: i32,
+    pub log_message: *mut u8,
+    pub log_message_capacity: i32,
+    pub log_message_length: i32,
 }
 
 #[repr(C)]
@@ -181,6 +207,7 @@ struct FfiApiV1 {
     power_shell_set_bridge_context_fn: *const libc::c_void,
     observed_diagnostic_page_copy_record_value_fn: *const libc::c_void,
     power_shell_invoke_secret_result_fn: *const libc::c_void,
+    power_shell_invoke_credential_result_fn: *const libc::c_void,
 }
 
 type FnBindingsGetFfiApiV1 = unsafe extern "system" fn() -> *const FfiApiV1;
@@ -213,6 +240,8 @@ type FnFfiPowerShellInvokeSecretResult = unsafe extern "system" fn(
     *mut i32,
     *mut FfiCallResult,
 ) -> i32;
+type FnFfiPowerShellInvokeCredentialResult =
+    unsafe extern "system" fn(PowerShellHandle, *mut FfiCredentialResult, *mut FfiCallResult) -> i32;
 type FnFfiPowerShellBeginLiveInvocation =
     unsafe extern "system" fn(PowerShellHandle, *mut PowerShellHandle, *mut FfiCallResult) -> i32;
 type FnFfiLiveInvocationPoll = unsafe extern "system" fn(PowerShellHandle, *mut i32, *mut FfiCallResult) -> i32;
@@ -516,6 +545,7 @@ pub(crate) struct FfiBindings {
     power_shell_set_broker_context_fn: FnFfiPowerShellSetBrokerContext,
     power_shell_set_bridge_context_fn: FnFfiPowerShellSetBridgeContext,
     power_shell_invoke_secret_result_fn: FnFfiPowerShellInvokeSecretResult,
+    power_shell_invoke_credential_result_fn: FnFfiPowerShellInvokeCredentialResult,
 }
 
 pub struct FfiPayloadRuntimeDiagnostics {
@@ -649,7 +679,6 @@ impl FfiBindings {
         };
 
         let api = unsafe { load_ffi_api_v1(get_api_fn)? };
-
         let fields = [
             api.create_fn,
             api.release_fn,
@@ -738,6 +767,7 @@ impl FfiBindings {
             api.power_shell_set_bridge_context_fn,
             api.observed_diagnostic_page_copy_record_value_fn,
             api.power_shell_invoke_secret_result_fn,
+            api.power_shell_invoke_credential_result_fn,
         ];
         if fields.iter().any(|field| field.is_null()) {
             return Err(Error::IO(std::io::Error::new(
@@ -1066,6 +1096,11 @@ impl FfiBindings {
             power_shell_invoke_secret_result_fn: unsafe {
                 mem::transmute::<*const libc::c_void, FnFfiPowerShellInvokeSecretResult>(
                     api.power_shell_invoke_secret_result_fn,
+                )
+            },
+            power_shell_invoke_credential_result_fn: unsafe {
+                mem::transmute::<*const libc::c_void, FnFfiPowerShellInvokeCredentialResult>(
+                    api.power_shell_invoke_credential_result_fn,
                 )
             },
             power_shell_set_capability_context_fn: unsafe {
@@ -1519,6 +1554,13 @@ impl FfiPowerShell {
             .filter(|length| *length <= secret.len())
             .ok_or_else(|| FfiBindingError::from_status(-6, "managed secret length is invalid".to_owned()))?;
         Ok((user_name_length, secret_length))
+    }
+
+    pub fn invoke_credential_result(&self, credential_result: &mut FfiCredentialResult) -> Result<(), FfiBindingError> {
+        self.call(|handle, result| unsafe {
+            (self.bindings.power_shell_invoke_credential_result_fn)(handle, credential_result, result)
+        })?;
+        Ok(())
     }
 
     pub fn invoke_to_result(&self) -> Result<FfiInvocationResult, FfiBindingError> {

--- a/crates/pwsh-host/src/lib.rs
+++ b/crates/pwsh-host/src/lib.rs
@@ -25,11 +25,11 @@ extern crate quick_error;
 mod pdcstring;
 
 pub use bindings::{
-    FfiBindingError, FfiBridgeContext, FfiInvocationResult, FfiLiveInvocation, FfiLiveObjectContractDescriptor,
-    FfiLiveStreamBatch, FfiLiveStreamRecord, FfiObservedDiagnosticPage, FfiObservedDiagnosticRecord,
-    FfiObservedInvocation, FfiPayloadRuntimeDiagnostics, FfiPowerShell, FfiPowerShellSession, FfiSessionEvent,
-    FfiSessionSnapshot, FfiSnapshotValue, FfiTypedResultInvocation, FfiTypedResultPage, FfiTypedResultRecord,
-    PowerShell,
+    FfiBindingError, FfiBridgeContext, FfiCredentialResult, FfiInvocationResult, FfiLiveInvocation,
+    FfiLiveObjectContractDescriptor, FfiLiveStreamBatch, FfiLiveStreamRecord, FfiObservedDiagnosticPage,
+    FfiObservedDiagnosticRecord, FfiObservedInvocation, FfiPayloadRuntimeDiagnostics, FfiPowerShell,
+    FfiPowerShellSession, FfiSessionEvent, FfiSessionSnapshot, FfiSnapshotValue, FfiTypedResultInvocation,
+    FfiTypedResultPage, FfiTypedResultRecord, PowerShell,
 };
 pub use host_detect::find_pwsh_dir;
 pub use loader::{get_assembly_delegate_loader_for_pwsh_dir, HostedRuntime, LiveObjectContractPack};

--- a/crates/pwsh-sdk-ffi/src/lib.rs
+++ b/crates/pwsh-sdk-ffi/src/lib.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 #[cfg(test)]
 use pwsh_host::FfiLiveStreamRecord;
 use pwsh_host::{
-    find_pwsh_dir, FfiBindingError, FfiBridgeContext, FfiInvocationResult, FfiLiveInvocation,
+    find_pwsh_dir, FfiBindingError, FfiBridgeContext, FfiCredentialResult, FfiInvocationResult, FfiLiveInvocation,
     FfiLiveObjectContractDescriptor, FfiLiveStreamBatch, FfiObservedDiagnosticPage, FfiObservedInvocation,
     FfiPowerShell, FfiPowerShellSession, FfiSessionEvent, FfiSessionSnapshot, FfiSnapshotValue,
     FfiTypedResultInvocation, FfiTypedResultPage, FfiTypedResultRecord, HostedRuntime, LiveObjectContractPack,
@@ -55,10 +55,16 @@ const FEATURE_BROKER_TERMINAL_OBSERVATION: u64 = 1 << 27;
 const FEATURE_RELIABLE_BRIDGE_EVENTS: u64 = 1 << 28;
 const FEATURE_OBSERVED_PRESENTATION: u64 = 1 << 29;
 const FEATURE_SECRET_ADAPTERS: u64 = 1 << 30;
+const FEATURE_CREDENTIAL_RESULT: u64 = 1 << 31;
 const SECRET_VALUE_KIND_UTF16: u32 = 15;
 const SECRET_VALUE_KIND_CREDENTIAL: u32 = 16;
 const MAX_SECRET_UTF16_CODE_UNITS: usize = 4_096;
 const MAX_SECRET_USER_NAME_UTF8_BYTES: usize = 1_024;
+const MAX_CREDENTIAL_TEXT_UTF8_BYTES: usize = 4 * 1024;
+const MAX_CREDENTIAL_MESSAGE_COUNT: usize = 16;
+const MAX_CREDENTIAL_MESSAGE_UTF8_BYTES: usize = 4 * 1024;
+const MAX_CREDENTIAL_MESSAGE_BUFFER_BYTES: usize = std::mem::size_of::<u32>()
+    + MAX_CREDENTIAL_MESSAGE_COUNT * (std::mem::size_of::<u32>() + MAX_CREDENTIAL_MESSAGE_UTF8_BYTES);
 const CALL_RESULT_DIAGNOSTIC_TRUNCATED: u32 = 1;
 #[cfg(test)]
 const RESULT_RECORD_SCALAR_VALUE_PRESENT: u32 = 1 << 1;
@@ -6300,6 +6306,7 @@ fn feature_flags() -> u64 {
         | FEATURE_RELIABLE_BRIDGE_EVENTS
         | FEATURE_OBSERVED_PRESENTATION
         | FEATURE_SECRET_ADAPTERS
+        | FEATURE_CREDENTIAL_RESULT
 }
 
 fn create_live_object_probe(initial_count: i64) -> Result<*mut std::ffi::c_void, (Status, String)> {
@@ -6904,6 +6911,58 @@ pub unsafe extern "C" fn multi_pwsh_invoke_secret_result(
             *user_name_length = returned_user_name_length;
             *secret_length = returned_secret_length;
             Ok(Status::Success)
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn multi_pwsh_invoke_credential_result(
+    handle: u64,
+    credential_result: *mut FfiCredentialResult,
+    result: *mut CallResult,
+) -> i32 {
+    v2_call(result, || {
+        if credential_result.is_null() {
+            return Err((Status::InvalidArgument, "credential result output is null".to_owned()));
+        }
+
+        let credential_result = &mut *credential_result;
+        if credential_result.size < std::mem::size_of::<FfiCredentialResult>() as u32
+            || credential_result.username_capacity < 0
+            || credential_result.username_capacity as usize > MAX_CREDENTIAL_TEXT_UTF8_BYTES
+            || credential_result.domain_capacity < 0
+            || credential_result.domain_capacity as usize > MAX_CREDENTIAL_TEXT_UTF8_BYTES
+            || credential_result.password_capacity < 0
+            || credential_result.password_capacity as usize > MAX_SECRET_UTF16_CODE_UNITS
+            || credential_result.output_messages_capacity < 0
+            || credential_result.output_messages_capacity as usize > MAX_CREDENTIAL_MESSAGE_BUFFER_BYTES
+            || credential_result.error_messages_capacity < 0
+            || credential_result.error_messages_capacity as usize > MAX_CREDENTIAL_MESSAGE_BUFFER_BYTES
+            || credential_result.log_message_capacity < 0
+            || credential_result.log_message_capacity as usize > MAX_CREDENTIAL_TEXT_UTF8_BYTES
+            || (credential_result.username_capacity != 0 && credential_result.username.is_null())
+            || (credential_result.domain_capacity != 0 && credential_result.domain.is_null())
+            || (credential_result.password_capacity != 0 && credential_result.password.is_null())
+            || (credential_result.output_messages_capacity != 0 && credential_result.output_messages.is_null())
+            || (credential_result.error_messages_capacity != 0 && credential_result.error_messages.is_null())
+            || (credential_result.log_message_capacity != 0 && credential_result.log_message.is_null())
+        {
+            return Err((
+                Status::InvalidArgument,
+                "credential result output is invalid".to_owned(),
+            ));
+        }
+
+        with_session_result(handle, true, |session| {
+            session
+                .invoke_credential_result(credential_result)
+                .map(|_| Status::Success)
+                .map_err(|_| {
+                    (
+                        Status::ManagedFailure,
+                        "credential result PowerShell operation failed".to_owned(),
+                    )
+                })
         })
     })
 }
@@ -10312,7 +10371,8 @@ mod tests {
             | FEATURE_BROKER_TERMINAL_OBSERVATION
             | FEATURE_RELIABLE_BRIDGE_EVENTS
             | FEATURE_OBSERVED_PRESENTATION
-            | FEATURE_SECRET_ADAPTERS;
+            | FEATURE_SECRET_ADAPTERS
+            | FEATURE_CREDENTIAL_RESULT;
 
         assert_eq!(ABI_VERSION, 2);
         assert_eq!(MINIMUM_COMPATIBLE_ABI_VERSION, 2);

--- a/crates/pwsh-sdk-ffi/src/lib.rs
+++ b/crates/pwsh-sdk-ffi/src/lib.rs
@@ -6954,8 +6954,7 @@ pub unsafe extern "C" fn multi_pwsh_invoke_credential_result(
         }
 
         with_session_result(handle, true, |session| {
-            session
-                .invoke_credential_result(credential_result)
+            unsafe { session.invoke_credential_result(credential_result) }
                 .map(|_| Status::Success)
                 .map_err(|_| {
                     (

--- a/docs/in-process-ffi.md
+++ b/docs/in-process-ffi.md
@@ -774,6 +774,31 @@ The payload clears its secure-string copies when the builder is cleared,
 released, or finishes the dedicated invocation. The public lease zeroes its
 managed character buffer on disposal.
 
+`PowerShellSecret.Length`, `CopyTo(Span<char>)`, and `ToSecureString()` are
+the only public transfer operations. `CopyTo` requires an exactly sized,
+caller-owned buffer which the caller must clear. `ToSecureString()` returns a
+separately owned, read-only `SecureString` which the caller must dispose.
+Neither operation creates a plaintext string getter, and `ToString()` is
+always redacted.
+
+`InvokeCredentialResult()` is the separate credential-resolver sink. For one
+invocation only, the payload injects `$Result` with setter-only `Username`,
+`Domain`, `Password`, `SecurePassword`, `OutputMessages`, `ErrorMessages`,
+`LogMessage`, and `Cancel` properties. `Password` accepts a string only long
+enough to copy it into an internal `SecureString`; `SecurePassword` accepts a
+`SecureString` only. Text and messages have fixed bounds, and the returned
+`PowerShellCredentialResult` contains only copied username/domain/log text,
+bounded output/error messages, cancellation state, and an optional disposable
+redacted `PowerShellSecret` password. Normal pipeline output, error records,
+or unsupported setter shapes reject the invocation rather than becoming a
+generic result.
+
+Sessions created from `InitialSessionState.CreateDefault2()` explicitly add
+only `Microsoft.PowerShell.Commands.ConvertToSecureStringCommand` for this
+sink, so `$Result.SecurePassword = ConvertTo-SecureString ... -AsPlainText
+-Force` is supported without importing a module. No other module or
+application-specific command surface is added.
+
 This limits accidental FFI, logging, and DTO disclosure. It does **not** make
 an arbitrary script, module, or remoting endpoint trustworthy: any code that
 receives a credential can deliberately emit or retain it. General strings are

--- a/dotnet/bindings/FfiBindings.cs
+++ b/dotnet/bindings/FfiBindings.cs
@@ -74,8 +74,12 @@ namespace NativeHost
         private const ulong FfiFeatureReliableBridgeEvents = 1UL << 28;
         private const ulong FfiFeatureObservedPresentation = 1UL << 29;
         private const ulong FfiFeatureSecretAdapters = 1UL << 30;
+        private const ulong FfiFeatureCredentialResult = 1UL << 31;
         private const int FfiMaxSecretLength = 4_096;
         private const int FfiMaxSecretUserNameLength = 256;
+        private const int FfiMaxCredentialTextUtf8Bytes = 4 * 1024;
+        private const int FfiMaxCredentialMessages = 16;
+        private const int FfiMaxCredentialMessageUtf8Bytes = 4 * 1024;
         private const uint FfiTypedResultPageTerminal = 1;
         private const uint FfiTypedResultPageTruncated = 1 << 1;
         private const uint FfiTypedResultPageComplete = 1 << 2;
@@ -91,6 +95,31 @@ namespace NativeHost
             public int DiagnosticCapacity;
             public int DiagnosticRequiredLength;
             public int DiagnosticWrittenLength;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct FfiCredentialResult
+        {
+            public uint Size;
+            public uint IsCancelled;
+            public byte* Username;
+            public int UsernameCapacity;
+            public int UsernameLength;
+            public byte* Domain;
+            public int DomainCapacity;
+            public int DomainLength;
+            public char* Password;
+            public int PasswordCapacity;
+            public int PasswordLength;
+            public byte* OutputMessages;
+            public int OutputMessagesCapacity;
+            public int OutputMessagesLength;
+            public byte* ErrorMessages;
+            public int ErrorMessagesCapacity;
+            public int ErrorMessagesLength;
+            public byte* LogMessage;
+            public int LogMessageCapacity;
+            public int LogMessageLength;
         }
 
         private static bool TryGetConfigurationStrings(object[] values, out string[] result)
@@ -213,6 +242,7 @@ namespace NativeHost
             public IntPtr PowerShell_SetBridgeContext;
             public IntPtr ObservedDiagnosticPage_CopyRecordValue;
             public IntPtr PowerShell_InvokeSecretResult;
+            public IntPtr PowerShell_InvokeCredentialResult;
         }
 
         private const int FfiPreflightMaximumTextLength = 128;
@@ -1145,7 +1175,7 @@ namespace NativeHost
                     FfiFeatureLiveStreamPolling | FfiFeatureTypedResultPaging | FfiFeatureObservedInvocation |
                     FfiFeatureSessionPreflight | FfiFeatureRuntimeDiagnostics | FfiFeatureDuplexBrokerChannel |
                     FfiFeatureGeneratedBridgeAttachment | FfiFeatureReliableBridgeEvents |
-                    FfiFeatureObservedPresentation | FfiFeatureSecretAdapters,
+                    FfiFeatureObservedPresentation | FfiFeatureSecretAdapters | FfiFeatureCredentialResult,
                 PowerShell_Create = (IntPtr)(delegate* unmanaged<IntPtr*, FfiCallResult*, int>)&FfiPowerShell_Create,
                 PowerShell_Release = (IntPtr)(delegate* unmanaged<IntPtr, FfiCallResult*, int>)&FfiPowerShell_Release,
                 PowerShell_AddArgumentUtf8 = (IntPtr)(delegate* unmanaged<IntPtr, byte*, int, FfiCallResult*, int>)&FfiPowerShell_AddArgumentUtf8,
@@ -1233,6 +1263,7 @@ namespace NativeHost
                 PowerShell_SetBridgeContext = (IntPtr)(delegate* unmanaged<IntPtr, ulong, ulong, ulong, ushort, ushort, uint, uint, byte*, int, FfiCallResult*, int>)&FfiPowerShell_SetBridgeContext,
                 ObservedDiagnosticPage_CopyRecordValue = (IntPtr)(delegate* unmanaged<IntPtr, int, uint*, byte*, int, int*, FfiCallResult*, int>)&FfiObservedDiagnosticPage_CopyRecordValue,
                 PowerShell_InvokeSecretResult = (IntPtr)(delegate* unmanaged<IntPtr, uint, byte*, int, int*, char*, int, int*, FfiCallResult*, int>)&FfiPowerShell_InvokeSecretResult,
+                PowerShell_InvokeCredentialResult = (IntPtr)(delegate* unmanaged<IntPtr, FfiCredentialResult*, FfiCallResult*, int>)&FfiPowerShell_InvokeCredentialResult,
             };
         }
 
@@ -2589,6 +2620,488 @@ namespace NativeHost
                     pipeline.PowerShell.Commands.Clear();
                 }
             });
+        }
+
+        [UnmanagedCallersOnly]
+        public static unsafe int FfiPowerShell_InvokeCredentialResult(
+            IntPtr ptrHandle,
+            FfiCredentialResult* credentialResult,
+            FfiCallResult* result)
+        {
+            if (credentialResult == null ||
+                credentialResult->Size < (uint)sizeof(FfiCredentialResult) ||
+                !HasValidCredentialBuffer(credentialResult->Username, credentialResult->UsernameCapacity) ||
+                !HasValidCredentialBuffer(credentialResult->Domain, credentialResult->DomainCapacity) ||
+                !HasValidCredentialSecretBuffer(credentialResult->Password, credentialResult->PasswordCapacity) ||
+                !HasValidCredentialBuffer(credentialResult->OutputMessages, credentialResult->OutputMessagesCapacity) ||
+                !HasValidCredentialBuffer(credentialResult->ErrorMessages, credentialResult->ErrorMessagesCapacity) ||
+                !HasValidCredentialBuffer(credentialResult->LogMessage, credentialResult->LogMessageCapacity))
+            {
+                return WriteFailure(result, FfiStatusInvalidArgument, "Credential result arguments are invalid.");
+            }
+
+            return ExecuteSecret(result, () =>
+            {
+                FfiPowerShellPipeline pipeline = GetPowerShellPipeline(ptrHandle);
+                pipeline.ThrowIfSecretBound();
+                FfiInvocationResults.TryRemove(ptrHandle, out _);
+                var sink = new FfiCredentialResultSink();
+                FfiPowerShellSession session = pipeline.Session;
+                bool sessionInvocationStarted = false;
+                Exception terminatingException = null;
+                Runspace runspace = null;
+                PSVariable previousResult = null;
+                bool resultVariableRead = false;
+                try
+                {
+                    if (session is not null)
+                    {
+                        session.BeginInvocation();
+                        sessionInvocationStarted = true;
+                    }
+
+                    runspace = pipeline.PowerShell.Runspace ?? Runspace.DefaultRunspace
+                        ?? throw new InvalidOperationException("Credential result invocation requires an opened runspace.");
+                    previousResult = runspace.SessionStateProxy.PSVariable.Get("Result");
+                    resultVariableRead = true;
+                    runspace.SessionStateProxy.PSVariable.Set(new PSVariable("Result", sink));
+                    FfiCredentialInvocationOutput invocation = InvokeCredentialPipeline(
+                        pipeline,
+                        TakeCompletedInput(ptrHandle));
+                    if (invocation.OutputCount != 0 || invocation.HadErrors)
+                    {
+                        throw new InvalidOperationException("Credential result invocation emitted output or errors.");
+                    }
+
+                    WriteCredentialResult(credentialResult, sink);
+                }
+                catch (Exception exception)
+                {
+                    terminatingException = exception;
+                    throw;
+                }
+                finally
+                {
+                    try
+                    {
+                        if (resultVariableRead && runspace is not null && previousResult is null)
+                        {
+                            runspace.SessionStateProxy.PSVariable.Remove("Result");
+                        }
+                        else if (resultVariableRead && runspace is not null)
+                        {
+                            runspace.SessionStateProxy.PSVariable.Set(previousResult);
+                        }
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            sink.Dispose();
+                            pipeline.PowerShell.Commands.Clear();
+                        }
+                        finally
+                        {
+                            if (sessionInvocationStarted)
+                            {
+                                session.EndInvocation(terminatingException is not null);
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        private static unsafe bool HasValidCredentialBuffer(byte* buffer, int capacity)
+        {
+            return capacity >= 0 && (capacity == 0 || buffer != null);
+        }
+
+        private static unsafe bool HasValidCredentialSecretBuffer(char* buffer, int capacity)
+        {
+            return capacity >= 0 && (capacity == 0 || buffer != null);
+        }
+
+        private static unsafe void WriteCredentialResult(
+            FfiCredentialResult* result,
+            FfiCredentialResultSink sink)
+        {
+            result->IsCancelled = sink.IsCancelled ? 1U : 0U;
+            result->UsernameLength = WriteCredentialText(
+                sink.UsernameValue,
+                result->Username,
+                result->UsernameCapacity);
+            result->DomainLength = WriteCredentialText(
+                sink.DomainValue,
+                result->Domain,
+                result->DomainCapacity);
+            result->LogMessageLength = WriteCredentialText(
+                sink.LogMessageValue,
+                result->LogMessage,
+                result->LogMessageCapacity);
+            result->OutputMessagesLength = WriteCredentialMessages(
+                sink.OutputMessageValues,
+                result->OutputMessages,
+                result->OutputMessagesCapacity);
+            result->ErrorMessagesLength = WriteCredentialMessages(
+                sink.ErrorMessageValues,
+                result->ErrorMessages,
+                result->ErrorMessagesCapacity);
+            result->PasswordLength = sink.IsCancelled
+                ? 0
+                : sink.CopyPassword(result->Password, result->PasswordCapacity);
+        }
+
+        private static unsafe int WriteCredentialText(string value, byte* destination, int capacity)
+        {
+            if (value is null)
+            {
+                return 0;
+            }
+
+            int required = Encoding.UTF8.GetByteCount(value);
+            if (required > capacity)
+            {
+                throw new InvalidOperationException("Credential result exceeds its bound.");
+            }
+
+            Encoding.UTF8.GetBytes(value, new Span<byte>(destination, required));
+            return required;
+        }
+
+        private static unsafe int WriteCredentialMessages(
+            IReadOnlyList<string> messages,
+            byte* destination,
+            int capacity)
+        {
+            int required = sizeof(uint);
+            foreach (string message in messages)
+            {
+                required = checked(required + sizeof(uint) + Encoding.UTF8.GetByteCount(message));
+            }
+            if (required > capacity)
+            {
+                throw new InvalidOperationException("Credential result messages exceed their bound.");
+            }
+
+            Span<byte> target = new(destination, required);
+            BinaryPrimitives.WriteUInt32LittleEndian(target, checked((uint)messages.Count));
+            int offset = sizeof(uint);
+            foreach (string message in messages)
+            {
+                int length = Encoding.UTF8.GetByteCount(message);
+                BinaryPrimitives.WriteUInt32LittleEndian(target[offset..], checked((uint)length));
+                offset += sizeof(uint);
+                Encoding.UTF8.GetBytes(message, target[offset..(offset + length)]);
+                offset += length;
+            }
+
+            return required;
+        }
+
+        private static FfiCredentialInvocationOutput InvokeCredentialPipeline(
+            FfiPowerShellPipeline pipeline,
+            object[] input)
+        {
+            PowerShell powerShell = pipeline.PowerShell;
+            FfiPowerShellSession session = pipeline.Session;
+            var output = new PSDataCollection<PSObject> { DataAddedCount = 1 };
+            int outputCount = 0;
+            bool hadErrors = false;
+            PSDataCollection<object> inputCollection = null;
+
+            EventHandler<DataAddedEventArgs> outputAdded = (_, _) =>
+            {
+                outputCount++;
+                output.Clear();
+            };
+            EventHandler<DataAddedEventArgs> errorAdded = (_, _) =>
+            {
+                hadErrors = true;
+                powerShell.Streams.Error.Clear();
+            };
+            EventHandler<DataAddedEventArgs> warningAdded = (_, _) => powerShell.Streams.Warning.Clear();
+            EventHandler<DataAddedEventArgs> verboseAdded = (_, _) => powerShell.Streams.Verbose.Clear();
+            EventHandler<DataAddedEventArgs> debugAdded = (_, _) => powerShell.Streams.Debug.Clear();
+            EventHandler<DataAddedEventArgs> informationAdded = (_, _) => powerShell.Streams.Information.Clear();
+            EventHandler<DataAddedEventArgs> progressAdded = (_, _) => powerShell.Streams.Progress.Clear();
+
+            ClearStreamBuffers(powerShell);
+            output.DataAdded += outputAdded;
+            powerShell.Streams.Error.DataAdded += errorAdded;
+            powerShell.Streams.Warning.DataAdded += warningAdded;
+            powerShell.Streams.Verbose.DataAdded += verboseAdded;
+            powerShell.Streams.Debug.DataAdded += debugAdded;
+            powerShell.Streams.Information.DataAdded += informationAdded;
+            powerShell.Streams.Progress.DataAdded += progressAdded;
+            try
+            {
+                PSInvocationSettings invocationSettings = session?.CreateInvocationSettings();
+                if (input is null)
+                {
+                    powerShell.Invoke<PSObject, PSObject>(null, output, invocationSettings);
+                }
+                else
+                {
+                    inputCollection = new PSDataCollection<object>();
+                    foreach (object value in input)
+                    {
+                        inputCollection.Add(value);
+                    }
+
+                    inputCollection.Complete();
+                    powerShell.Invoke<object, PSObject>(inputCollection, output, invocationSettings);
+                }
+
+                hadErrors |= powerShell.HadErrors;
+                return new FfiCredentialInvocationOutput(outputCount, hadErrors);
+            }
+            finally
+            {
+                output.DataAdded -= outputAdded;
+                powerShell.Streams.Error.DataAdded -= errorAdded;
+                powerShell.Streams.Warning.DataAdded -= warningAdded;
+                powerShell.Streams.Verbose.DataAdded -= verboseAdded;
+                powerShell.Streams.Debug.DataAdded -= debugAdded;
+                powerShell.Streams.Information.DataAdded -= informationAdded;
+                powerShell.Streams.Progress.DataAdded -= progressAdded;
+                inputCollection?.Clear();
+                output.Clear();
+                ClearStreamBuffers(powerShell);
+            }
+        }
+
+        private sealed class FfiCredentialInvocationOutput
+        {
+            public FfiCredentialInvocationOutput(int outputCount, bool hadErrors)
+            {
+                OutputCount = outputCount;
+                HadErrors = hadErrors;
+            }
+
+            public int OutputCount { get; }
+
+            public bool HadErrors { get; }
+        }
+
+        private sealed unsafe class FfiCredentialResultSink : IDisposable
+        {
+            private SecureString password;
+            private string[] outputMessages = Array.Empty<string>();
+            private string[] errorMessages = Array.Empty<string>();
+
+            public object Username
+            {
+                set => username = ValidateCredentialText(value, "Username", allowNull: true);
+            }
+
+            public object Domain
+            {
+                set => domain = ValidateCredentialText(value, "Domain", allowNull: true);
+            }
+
+            public object Password
+            {
+                set => SetPassword(value, secure: false);
+            }
+
+            public object SecurePassword
+            {
+                set => SetPassword(value, secure: true);
+            }
+
+            public object OutputMessages
+            {
+                set => outputMessages = ValidateCredentialMessages(value, "OutputMessages");
+            }
+
+            public object ErrorMessages
+            {
+                set => errorMessages = ValidateCredentialMessages(value, "ErrorMessages");
+            }
+
+            public object LogMessage
+            {
+                set => logMessage = ValidateCredentialText(value, "LogMessage", allowNull: true);
+            }
+
+            public object Cancel
+            {
+                set
+                {
+                    if (value is not bool cancelled)
+                    {
+                        throw new InvalidOperationException("Credential result Cancel must be Boolean.");
+                    }
+
+                    isCancelled = cancelled;
+                }
+            }
+
+            private string username;
+            private string domain;
+            private string logMessage;
+            private bool isCancelled;
+
+            internal string UsernameValue => username;
+            internal string DomainValue => domain;
+            internal string LogMessageValue => logMessage;
+            internal IReadOnlyList<string> OutputMessageValues => outputMessages;
+            internal IReadOnlyList<string> ErrorMessageValues => errorMessages;
+            internal bool IsCancelled => isCancelled;
+
+            internal int CopyPassword(char* destination, int capacity)
+            {
+                if (password is null)
+                {
+                    return 0;
+                }
+
+                int length = password.Length;
+                if (length > capacity)
+                {
+                    throw new InvalidOperationException("Credential password exceeds its bound.");
+                }
+
+                IntPtr bstr = Marshal.SecureStringToBSTR(password);
+                try
+                {
+                    new ReadOnlySpan<char>((void*)bstr, length).CopyTo(new Span<char>(destination, length));
+                    return length;
+                }
+                finally
+                {
+                    Marshal.ZeroFreeBSTR(bstr);
+                }
+            }
+
+            public void Dispose()
+            {
+                SecureString value = Interlocked.Exchange(ref password, null);
+                value?.Dispose();
+            }
+
+            private void SetPassword(object value, bool secure)
+            {
+                SecureString next = null;
+                if (value is null)
+                {
+                    ReplacePassword(null);
+                    return;
+                }
+
+                if (secure)
+                {
+                    if (value is not SecureString secureString)
+                    {
+                        throw new InvalidOperationException("Credential result SecurePassword must be a SecureString.");
+                    }
+
+                    next = CopySecureString(secureString);
+                }
+                else
+                {
+                    if (value is not string text)
+                    {
+                        throw new InvalidOperationException("Credential result Password must be a string.");
+                    }
+
+                    next = CreateSecureString(text);
+                }
+
+                ReplacePassword(next);
+            }
+
+            private void ReplacePassword(SecureString next)
+            {
+                SecureString previous = Interlocked.Exchange(ref password, next);
+                previous?.Dispose();
+            }
+
+            private static string ValidateCredentialText(object value, string name, bool allowNull)
+            {
+                if (value is null && allowNull)
+                {
+                    return null;
+                }
+                if (value is not string text ||
+                    text.IndexOf('\0') >= 0 ||
+                    Encoding.UTF8.GetByteCount(text) > FfiMaxCredentialTextUtf8Bytes)
+                {
+                    throw new InvalidOperationException($"Credential result {name} is invalid.");
+                }
+
+                return text;
+            }
+
+            private static string[] ValidateCredentialMessages(object value, string name)
+            {
+                if (value is not object[] values || values.Length > FfiMaxCredentialMessages)
+                {
+                    throw new InvalidOperationException($"Credential result {name} must be a bounded string array.");
+                }
+
+                var result = new string[values.Length];
+                for (int index = 0; index < values.Length; index++)
+                {
+                    if (values[index] is not string text ||
+                        text.Length == 0 ||
+                        text.IndexOf('\0') >= 0 ||
+                        Encoding.UTF8.GetByteCount(text) > FfiMaxCredentialMessageUtf8Bytes)
+                    {
+                        throw new InvalidOperationException($"Credential result {name} is invalid.");
+                    }
+
+                    result[index] = text;
+                }
+
+                return result;
+            }
+
+            private static SecureString CreateSecureString(string text)
+            {
+                if (text.Length is < 1 or > FfiMaxSecretLength || text.IndexOf('\0') >= 0)
+                {
+                    throw new InvalidOperationException("Credential password is invalid.");
+                }
+
+                var result = new SecureString();
+                foreach (char character in text)
+                {
+                    result.AppendChar(character);
+                }
+                result.MakeReadOnly();
+                return result;
+            }
+
+            private static SecureString CopySecureString(SecureString source)
+            {
+                if (source.Length is < 1 or > FfiMaxSecretLength)
+                {
+                    throw new InvalidOperationException("Credential password is invalid.");
+                }
+
+                IntPtr bstr = Marshal.SecureStringToBSTR(source);
+                try
+                {
+                    var result = new SecureString();
+                    foreach (char character in new ReadOnlySpan<char>((void*)bstr, source.Length))
+                    {
+                        if (character == '\0')
+                        {
+                            result.Dispose();
+                            throw new InvalidOperationException("Credential password is invalid.");
+                        }
+                        result.AppendChar(character);
+                    }
+                    result.MakeReadOnly();
+                    return result;
+                }
+                finally
+                {
+                    Marshal.ZeroFreeBSTR(bstr);
+                }
+            }
         }
 
         private static bool TryProjectCredentialResult(
@@ -4440,6 +4953,10 @@ namespace NativeHost
                 }
 
                 InitialSessionState initialState = InitialSessionState.CreateDefault2();
+                initialState.Commands.Add(new SessionStateCmdletEntry(
+                    "ConvertTo-SecureString",
+                    typeof(Microsoft.PowerShell.Commands.ConvertToSecureStringCommand),
+                    null));
                 if (initialConfiguration == ConstrainedLanguageConfiguration)
                 {
                     initialState.LanguageMode = PSLanguageMode.ConstrainedLanguage;

--- a/dotnet/bindings/FfiBindings.cs
+++ b/dotnet/bindings/FfiBindings.cs
@@ -2650,6 +2650,7 @@ namespace NativeHost
                 bool sessionInvocationStarted = false;
                 Exception terminatingException = null;
                 Runspace runspace = null;
+                Runspace ownedCredentialRunspace = null;
                 PSVariable previousResult = null;
                 bool resultVariableRead = false;
                 try
@@ -2660,8 +2661,15 @@ namespace NativeHost
                         sessionInvocationStarted = true;
                     }
 
-                    runspace = pipeline.PowerShell.Runspace ?? Runspace.DefaultRunspace
-                        ?? throw new InvalidOperationException("Credential result invocation requires an opened runspace.");
+                    runspace = pipeline.PowerShell.Runspace;
+                    if (runspace is null)
+                    {
+                        ownedCredentialRunspace = RunspaceFactory.CreateRunspace();
+                        ownedCredentialRunspace.Open();
+                        pipeline.PowerShell.Runspace = ownedCredentialRunspace;
+                        runspace = ownedCredentialRunspace;
+                    }
+
                     previousResult = runspace.SessionStateProxy.PSVariable.Get("Result");
                     resultVariableRead = true;
                     runspace.SessionStateProxy.PSVariable.Set(new PSVariable("Result", sink));
@@ -2697,8 +2705,25 @@ namespace NativeHost
                     {
                         try
                         {
-                            sink.Dispose();
-                            pipeline.PowerShell.Commands.Clear();
+                            try
+                            {
+                                sink.Dispose();
+                                pipeline.PowerShell.Commands.Clear();
+                            }
+                            finally
+                            {
+                                if (ownedCredentialRunspace is not null)
+                                {
+                                    try
+                                    {
+                                        pipeline.PowerShell.Runspace = null;
+                                    }
+                                    finally
+                                    {
+                                        ownedCredentialRunspace.Dispose();
+                                    }
+                                }
+                            }
                         }
                         finally
                         {

--- a/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
+++ b/dotnet/sdk-ffi/Devolutions.MultiPwsh.Sdk.csproj
@@ -12,7 +12,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>PowerShell;NativeAOT;FFI;experimental</PackageTags>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>
-    <PackageReleaseNotes>Native deployment is opt-in. PowerShell is not included; activation selects pwsh from PATH by default or accepts an explicit payload directory. ABI v2 adds explicit lease-only SecureString and PSCredential parameter adapters, typed secret results, bounded module declarations, and payload-owned PSSession helpers. Windows x64 is the current end-to-end validated runtime.</PackageReleaseNotes>
+    <PackageReleaseNotes>Native deployment is opt-in. PowerShell is not included; activation selects pwsh from PATH by default or accepts an explicit payload directory. ABI v2 adds explicit lease-only SecureString and PSCredential parameter adapters, typed secret results, bounded credential-result sinks, safe PowerShellSecret transfer APIs, bounded module declarations, and payload-owned PSSession helpers. Windows x64 is the current end-to-end validated runtime.</PackageReleaseNotes>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>

--- a/dotnet/sdk-ffi/NativeMethods.cs
+++ b/dotnet/sdk-ffi/NativeMethods.cs
@@ -33,6 +33,31 @@ internal unsafe struct NativeDataValue
 }
 
 [StructLayout(LayoutKind.Sequential)]
+internal unsafe struct NativeCredentialResult
+{
+    internal uint Size;
+    internal uint IsCancelled;
+    internal byte* Username;
+    internal int UsernameCapacity;
+    internal int UsernameLength;
+    internal byte* Domain;
+    internal int DomainCapacity;
+    internal int DomainLength;
+    internal char* Password;
+    internal int PasswordCapacity;
+    internal int PasswordLength;
+    internal byte* OutputMessages;
+    internal int OutputMessagesCapacity;
+    internal int OutputMessagesLength;
+    internal byte* ErrorMessages;
+    internal int ErrorMessagesCapacity;
+    internal int ErrorMessagesLength;
+    internal byte* LogMessage;
+    internal int LogMessageCapacity;
+    internal int LogMessageLength;
+}
+
+[StructLayout(LayoutKind.Sequential)]
 internal struct NativeBrokerChannelOptions
 {
     internal uint Size;
@@ -351,6 +376,13 @@ internal static unsafe partial class NativeMethods
         char* secretBuffer,
         nuint secretCapacity,
         nuint* secretLength,
+        NativeCallResult* result);
+
+    [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_invoke_credential_result")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int InvokeCredentialResult(
+        ulong handle,
+        NativeCredentialResult* credentialResult,
         NativeCallResult* result);
 
     [LibraryImport(LibraryName, EntryPoint = "multi_pwsh_add_parameter_switch")]

--- a/dotnet/sdk-ffi/PowerShell.cs
+++ b/dotnet/sdk-ffi/PowerShell.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -35,6 +36,7 @@ public sealed unsafe class PowerShell : IDisposable
     private const ulong ReliableBridgeEventsFeature = 1UL << 28;
     private const ulong ObservedPresentationFeature = 1UL << 29;
     private const ulong SecretAdaptersFeature = 1UL << 30;
+    private const ulong CredentialResultFeature = 1UL << 31;
     private const ulong LiveObjectProbeFeature = 1UL << 17;
     private const ulong LiveSessionObjectProbeFeature = 1UL << 18;
     private const ulong LiveObjectContractsFeature = 1UL << 19;
@@ -51,7 +53,8 @@ public sealed unsafe class PowerShell : IDisposable
         SessionConfigurationFeature | SessionVariablesFeature | CapabilityRpcFeature |
         LiveObjectProbeFeature | LiveSessionObjectProbeFeature | LiveObjectContractsFeature |
         LiveStreamPollingFeature | TypedResultPagingFeature | ObservedInvocationFeature |
-        SessionPreflightFeature | RuntimeDiagnosticsFeature;
+        SessionPreflightFeature | RuntimeDiagnosticsFeature | SecretAdaptersFeature |
+        CredentialResultFeature;
     private const uint ResultTerminatingFailure = 1;
     private const uint ResultSequenceTruncated = 1 << 1;
     private const uint StreamTruncated = 1;
@@ -68,6 +71,12 @@ public sealed unsafe class PowerShell : IDisposable
     private const nuint MaxResultFieldUtf8Bytes = 16 * 1024;
     private const nuint MaxResultValueBytes = 16 * 1024;
     private const nuint MaxPayloadPathUtf8Bytes = 32 * 1024;
+    private const int MaxCredentialTextUtf8Bytes = 4 * 1024;
+    private const int MaxCredentialMessages = 16;
+    private const int MaxCredentialMessageBytes = 4 * 1024;
+    private const int MaxCredentialMessageBufferBytes =
+        sizeof(uint) + (MaxCredentialMessages * (sizeof(uint) + MaxCredentialMessageBytes));
+    private static readonly UTF8Encoding StrictUtf8 = new(false, true);
 
     private readonly PowerShellHandle handle;
 
@@ -728,6 +737,194 @@ public sealed unsafe class PowerShell : IDisposable
         }
     }
 
+    /// <summary>
+    /// Invokes a credential resolver pipeline. The script must assign the
+    /// supported values to <c>$Result</c> and must not emit pipeline output.
+    /// </summary>
+    public PowerShellCredentialResult InvokeCredentialResult()
+    {
+        EnsureCredentialResultSupported();
+        byte[] username = new byte[MaxCredentialTextUtf8Bytes];
+        byte[] domain = new byte[MaxCredentialTextUtf8Bytes];
+        byte[] outputMessages = new byte[MaxCredentialMessageBufferBytes];
+        byte[] errorMessages = new byte[MaxCredentialMessageBufferBytes];
+        byte[] logMessage = new byte[MaxCredentialTextUtf8Bytes];
+        char[] password = new char[PowerShellSecret.MaximumLength];
+        try
+        {
+            using PowerShellHandle.HandleLease lease = handle.Borrow();
+            byte* diagnostic = stackalloc byte[NativeCall.DiagnosticCapacity];
+            NativeCallResult callResult = NativeCall.CreateResult(diagnostic);
+            fixed (byte* usernamePointer = username)
+            fixed (byte* domainPointer = domain)
+            fixed (byte* outputMessagesPointer = outputMessages)
+            fixed (byte* errorMessagesPointer = errorMessages)
+            fixed (byte* logMessagePointer = logMessage)
+            fixed (char* passwordPointer = password)
+            {
+                var nativeResult = new NativeCredentialResult
+                {
+                    Size = checked((uint)sizeof(NativeCredentialResult)),
+                    Username = usernamePointer,
+                    UsernameCapacity = username.Length,
+                    Domain = domainPointer,
+                    DomainCapacity = domain.Length,
+                    Password = passwordPointer,
+                    PasswordCapacity = password.Length,
+                    OutputMessages = outputMessagesPointer,
+                    OutputMessagesCapacity = outputMessages.Length,
+                    ErrorMessages = errorMessagesPointer,
+                    ErrorMessagesCapacity = errorMessages.Length,
+                    LogMessage = logMessagePointer,
+                    LogMessageCapacity = logMessage.Length,
+                };
+                int status = NativeMethods.InvokeCredentialResult(lease.Value, &nativeResult, &callResult);
+                NativeCall.ThrowIfFailed(status, callResult, diagnostic);
+
+                if (nativeResult.IsCancelled > 1 ||
+                    nativeResult.UsernameLength is < 0 or > MaxCredentialTextUtf8Bytes ||
+                    nativeResult.DomainLength is < 0 or > MaxCredentialTextUtf8Bytes ||
+                    nativeResult.LogMessageLength is < 0 or > MaxCredentialTextUtf8Bytes ||
+                    nativeResult.PasswordLength is < 0 or > PowerShellSecret.MaximumLength ||
+                    nativeResult.OutputMessagesLength is < 0 or > MaxCredentialMessageBufferBytes ||
+                    nativeResult.ErrorMessagesLength is < 0 or > MaxCredentialMessageBufferBytes)
+                {
+                    throw new PowerShellFfiException(
+                        PowerShellFfiStatus.ManagedFailure,
+                        "Native PowerShell FFI returned an invalid credential result.");
+                }
+
+                PowerShellSecret? secret = null;
+                if (nativeResult.PasswordLength != 0)
+                {
+                    if (nativeResult.IsCancelled != 0)
+                    {
+                        throw new PowerShellFfiException(
+                            PowerShellFfiStatus.ManagedFailure,
+                            "Native PowerShell FFI returned a password for a cancelled credential result.");
+                    }
+
+                    char[] ownedSecret = password[..nativeResult.PasswordLength];
+                    CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(password.AsSpan()));
+                    password = Array.Empty<char>();
+                    secret = PowerShellSecret.TakeOwnership(ownedSecret);
+                }
+
+                try
+                {
+                    return new PowerShellCredentialResult(
+                        DecodeCredentialText(username.AsSpan(0, nativeResult.UsernameLength)),
+                        DecodeCredentialText(domain.AsSpan(0, nativeResult.DomainLength)),
+                        secret,
+                        DecodeCredentialMessages(outputMessages, nativeResult.OutputMessagesLength),
+                        DecodeCredentialMessages(errorMessages, nativeResult.ErrorMessagesLength),
+                        DecodeCredentialText(logMessage.AsSpan(0, nativeResult.LogMessageLength)),
+                        nativeResult.IsCancelled != 0);
+                }
+                catch
+                {
+                    secret?.Dispose();
+                    throw;
+                }
+            }
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(username);
+            CryptographicOperations.ZeroMemory(domain);
+            CryptographicOperations.ZeroMemory(outputMessages);
+            CryptographicOperations.ZeroMemory(errorMessages);
+            CryptographicOperations.ZeroMemory(logMessage);
+            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(password.AsSpan()));
+        }
+    }
+
+    private static string? DecodeCredentialText(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.IsEmpty)
+        {
+            return null;
+        }
+
+        string value;
+        try
+        {
+            value = StrictUtf8.GetString(buffer);
+        }
+        catch (DecoderFallbackException)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned invalid credential text.");
+        }
+
+        if (value.IndexOf('\0') >= 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned invalid credential text.");
+        }
+
+        return value;
+    }
+
+    private static IReadOnlyList<string> DecodeCredentialMessages(byte[] buffer, int length)
+    {
+        if (length < sizeof(uint))
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned invalid credential messages.");
+        }
+
+        ReadOnlySpan<byte> source = buffer.AsSpan(0, length);
+        int offset = 0;
+        uint count = BinaryPrimitives.ReadUInt32LittleEndian(source);
+        offset += sizeof(uint);
+        if (count > MaxCredentialMessages)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned an unbounded credential message count.");
+        }
+
+        var messages = new string[checked((int)count)];
+        for (int index = 0; index < messages.Length; index++)
+        {
+            if (source.Length - offset < sizeof(uint))
+            {
+                throw new PowerShellFfiException(
+                    PowerShellFfiStatus.ManagedFailure,
+                    "Native PowerShell FFI returned invalid credential messages.");
+            }
+
+            uint messageLength = BinaryPrimitives.ReadUInt32LittleEndian(source[offset..]);
+            offset += sizeof(uint);
+            if (messageLength is 0 or > MaxCredentialMessageBytes ||
+                messageLength > source.Length - offset)
+            {
+                throw new PowerShellFfiException(
+                    PowerShellFfiStatus.ManagedFailure,
+                    "Native PowerShell FFI returned invalid credential messages.");
+            }
+
+            string? message = DecodeCredentialText(source.Slice(offset, checked((int)messageLength)));
+            messages[index] = message ?? throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned invalid credential messages.");
+            offset += checked((int)messageLength);
+        }
+
+        if (offset != source.Length)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.ManagedFailure,
+                "Native PowerShell FFI returned invalid credential messages.");
+        }
+
+        return Array.AsReadOnly(messages);
+    }
+
     public PowerShellInvocationResult InvokeWithDiagnostics()
     {
         using PowerShellHandle.HandleLease lease = handle.Borrow();
@@ -982,6 +1179,17 @@ public sealed unsafe class PowerShell : IDisposable
         }
     }
 
+    private static void EnsureCredentialResultSupported()
+    {
+        EnsureSecretAdaptersSupported();
+        if ((FeatureFlags & CredentialResultFeature) == 0)
+        {
+            throw new PowerShellFfiException(
+                PowerShellFfiStatus.UnsupportedCapability,
+                "The selected PowerShell payload does not support bounded credential results.");
+        }
+    }
+
     internal static void EnsureTypedResultPagingSupported(NativeAbiInfo info)
     {
         EnsureSupportedAbi(info);
@@ -1035,7 +1243,7 @@ public sealed unsafe class PowerShell : IDisposable
             (info.FeatureFlags & RequiredFeatures) != RequiredFeatures)
         {
             throw new NotSupportedException(
-                $"Native PowerShell FFI ABI {info.AbiVersion} does not support facade ABI {RequiredAbiVersion} structured errors, diagnostics, UTF-8, value, command, input, result, async operation, and session features.");
+                $"Native PowerShell FFI ABI {info.AbiVersion} does not support facade ABI {RequiredAbiVersion} structured errors, diagnostics, UTF-8, value, command, input, result, async operation, session, and credential-result features.");
         }
     }
 

--- a/dotnet/sdk-ffi/PowerShellCredentialResult.cs
+++ b/dotnet/sdk-ffi/PowerShellCredentialResult.cs
@@ -1,0 +1,46 @@
+namespace Devolutions.PowerShell.Ffi;
+
+/// <summary>
+/// A bounded, redacted credential resolver result.
+/// </summary>
+public sealed class PowerShellCredentialResult : IDisposable
+{
+    internal PowerShellCredentialResult(
+        string? username,
+        string? domain,
+        PowerShellSecret? password,
+        IReadOnlyList<string> outputMessages,
+        IReadOnlyList<string> errorMessages,
+        string? logMessage,
+        bool isCancelled)
+    {
+        Username = username;
+        Domain = domain;
+        Password = password;
+        OutputMessages = outputMessages;
+        ErrorMessages = errorMessages;
+        LogMessage = logMessage;
+        IsCancelled = isCancelled;
+    }
+
+    public string? Username { get; }
+
+    public string? Domain { get; }
+
+    public PowerShellSecret? Password { get; }
+
+    public IReadOnlyList<string> OutputMessages { get; }
+
+    public IReadOnlyList<string> ErrorMessages { get; }
+
+    public string? LogMessage { get; }
+
+    public bool IsCancelled { get; }
+
+    public override string ToString() => "<redacted PowerShell credential result>";
+
+    public void Dispose()
+    {
+        Password?.Dispose();
+    }
+}

--- a/dotnet/sdk-ffi/PowerShellSecret.cs
+++ b/dotnet/sdk-ffi/PowerShellSecret.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Security.Cryptography;
 
 namespace Devolutions.PowerShell.Ffi;
@@ -43,7 +44,16 @@ public sealed class PowerShellSecret : IDisposable
         return new PowerShellSecret(value);
     }
 
-    internal void CopyTo(Span<char> destination)
+    /// <summary>
+    /// Gets the number of UTF-16 code units in this secret.
+    /// </summary>
+    public int Length => (value ?? throw new ObjectDisposedException(nameof(PowerShellSecret))).Length;
+
+    /// <summary>
+    /// Copies the secret to a caller-owned buffer. The caller must clear the
+    /// buffer after use.
+    /// </summary>
+    public void CopyTo(Span<char> destination)
     {
         char[] source = value ?? throw new ObjectDisposedException(nameof(PowerShellSecret));
         if (destination.Length != source.Length)
@@ -54,7 +64,22 @@ public sealed class PowerShellSecret : IDisposable
         source.AsSpan().CopyTo(destination);
     }
 
-    internal int Length => (value ?? throw new ObjectDisposedException(nameof(PowerShellSecret))).Length;
+    /// <summary>
+    /// Creates an independently owned, read-only <see cref="SecureString"/>.
+    /// The caller must dispose the returned value.
+    /// </summary>
+    public SecureString ToSecureString()
+    {
+        char[] source = value ?? throw new ObjectDisposedException(nameof(PowerShellSecret));
+        var secureString = new SecureString();
+        foreach (char character in source)
+        {
+            secureString.AppendChar(character);
+        }
+
+        secureString.MakeReadOnly();
+        return secureString;
+    }
 
     public override string ToString() => "<redacted PowerShell secret>";
 

--- a/tests/PwshFfiApiBaseline.txt
+++ b/tests/PwshFfiApiBaseline.txt
@@ -1193,3 +1193,19 @@ facade:type:Devolutions.PowerShell.Ffi.PowerShellSecret
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSecretResult
 facade:type:Devolutions.PowerShell.Ffi.PowerShellSecretResultKind
 native:multi_pwsh_invoke_secret_result
+bindings:FfiPowerShell_InvokeCredentialResult
+facade:method:Devolutions.PowerShell.Ffi.PowerShell::Devolutions.PowerShell.Ffi.PowerShellCredentialResult InvokeCredentialResult()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.String ToString()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::Void Dispose()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSecret::System.Security.SecureString ToSecureString()
+facade:method:Devolutions.PowerShell.Ffi.PowerShellSecret::Void CopyTo(System.Span`1[System.Char])
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::Boolean IsCancelled
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::Devolutions.PowerShell.Ffi.PowerShellSecret Password
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.Collections.Generic.IReadOnlyList`1[System.String] ErrorMessages
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.Collections.Generic.IReadOnlyList`1[System.String] OutputMessages
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.String Domain
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.String LogMessage
+facade:property:Devolutions.PowerShell.Ffi.PowerShellCredentialResult::System.String Username
+facade:property:Devolutions.PowerShell.Ffi.PowerShellSecret::Int32 Length
+facade:type:Devolutions.PowerShell.Ffi.PowerShellCredentialResult
+native:multi_pwsh_invoke_credential_result

--- a/tests/PwshFfiApiBaselineInspector/Program.cs
+++ b/tests/PwshFfiApiBaselineInspector/Program.cs
@@ -112,9 +112,9 @@ static void ValidateAbiCompatibility(Assembly facadeAssembly, BindingFlags stati
         throw new InvalidOperationException("The facade must retain an ABI validation overload that accepts NativeAbiInfo.");
     }
 
-    const ulong allRequiredFeatures = 0x1FFFDFF;
+    const ulong allRequiredFeatures = 0xC1FFFDFF;
     ensureSupportedAbi.Invoke(null, [CreateAbiInfo(abiInfoType, allRequiredFeatures, abiVersion: 2, minimumCompatibleAbiVersion: 2)]);
-    for (int bit = 0; bit <= 24; bit++)
+    foreach (int bit in Enumerable.Range(0, 25).Concat([30, 31]))
     {
         if ((allRequiredFeatures & (1UL << bit)) == 0)
         {

--- a/tests/Test-PwshFfiPackage.ps1
+++ b/tests/Test-PwshFfiPackage.ps1
@@ -3476,6 +3476,122 @@ static void VerifySecretBindings(PowerShellRuntime runtime)
             result.Credential?.UserName == "fixture-user",
             "The contract-pack PSCredential result binding failed.");
     }
+
+    using (PowerShell pipeline = session.CreatePowerShell())
+    using (PowerShellCredentialResult result = pipeline
+        .AddScript(
+            "`$Result.Username = 'fixture-user'; " +
+            "`$Result.Domain = 'fixture-domain'; " +
+            "`$Result.Password = 'plain-fixture'; " +
+            "`$Result.OutputMessages = @('output-one', 'output-two'); " +
+            "`$Result.ErrorMessages = @('error-one'); " +
+            "`$Result.LogMessage = 'fixture-log'")
+        .InvokeCredentialResult())
+    {
+        Require(
+            result.Username == "fixture-user" &&
+            result.Domain == "fixture-domain" &&
+            result.OutputMessages.SequenceEqual(["output-one", "output-two"]) &&
+            result.ErrorMessages.SequenceEqual(["error-one"]) &&
+            result.LogMessage == "fixture-log" &&
+            !result.IsCancelled &&
+            result.Password is not null,
+            "The bounded plaintext credential result projection failed.");
+        Require(
+            !result.ToString().Contains("plain-fixture", StringComparison.Ordinal) &&
+            !result.Password.ToString().Contains("plain-fixture", StringComparison.Ordinal),
+            "The plaintext credential result leaked through diagnostics.");
+
+        char[] password = new char[result.Password.Length];
+        try
+        {
+            result.Password.CopyTo(password);
+            Require(
+                password.AsSpan().SequenceEqual("plain-fixture".AsSpan()),
+                "PowerShellSecret.CopyTo did not transfer the credential result.");
+
+            using var securePassword = result.Password.ToSecureString();
+            Require(
+                securePassword.IsReadOnly() &&
+                securePassword.Length == password.Length,
+                "PowerShellSecret.ToSecureString did not return an independent read-only copy.");
+        }
+        finally
+        {
+            Array.Clear(password);
+        }
+    }
+
+    using (PowerShell pipeline = session.CreatePowerShell())
+    using (PowerShellCredentialResult result = pipeline
+        .AddScript(
+            "`$Result.Username = 'secure-user'; " +
+            "`$Result.SecurePassword = ConvertTo-SecureString 'secure-fixture' -AsPlainText -Force")
+        .InvokeCredentialResult())
+    {
+        Require(
+            result.Username == "secure-user" &&
+            result.Password is not null &&
+            result.Password.Length == "secure-fixture".Length,
+            "CreateDefault2 did not expose the controlled ConvertTo-SecureString credential result path.");
+
+        char[] password = new char[result.Password.Length];
+        try
+        {
+            result.Password.CopyTo(password);
+            Require(
+                password.AsSpan().SequenceEqual("secure-fixture".AsSpan()),
+                "The SecureString credential result did not preserve its contents.");
+        }
+        finally
+        {
+            Array.Clear(password);
+        }
+    }
+
+    using (PowerShell pipeline = session.CreatePowerShell())
+    using (PowerShellCredentialResult result = pipeline
+        .AddScript("`$Result.Cancel = `$true; `$Result.Password = 'discarded-fixture'")
+        .InvokeCredentialResult())
+    {
+        Require(
+            result.IsCancelled && result.Password is null,
+            "A cancelled credential result retained password material.");
+    }
+
+    using (PowerShell pipeline = session.CreatePowerShell())
+    {
+        try
+        {
+            pipeline
+                .AddScript("`$Result.Username = 'fixture-user'; 'ordinary-output'")
+                .InvokeCredentialResult();
+            throw new InvalidOperationException("Credential result invocation accepted ordinary pipeline output.");
+        }
+        catch (PowerShellFfiException exception)
+        {
+            Require(
+                !exception.Message.Contains("ordinary-output", StringComparison.Ordinal),
+                "Rejected credential-result output leaked through diagnostics.");
+        }
+    }
+
+    using (PowerShell pipeline = session.CreatePowerShell())
+    {
+        try
+        {
+            pipeline
+                .AddScript("`$Result.Password = 7")
+                .InvokeCredentialResult();
+            throw new InvalidOperationException("Credential result invocation accepted an unsafe password value.");
+        }
+        catch (PowerShellFfiException exception)
+        {
+            Require(
+                !exception.Message.Contains("Password", StringComparison.Ordinal),
+                "Rejected credential-result values leaked sink details through diagnostics.");
+        }
+    }
 }
 
 if (args.Length != 1)

--- a/tests/Test-PwshFfiPackage.ps1
+++ b/tests/Test-PwshFfiPackage.ps1
@@ -3522,6 +3522,20 @@ static void VerifySecretBindings(PowerShellRuntime runtime)
         }
     }
 
+    using (PowerShell pipeline = PowerShell.Create())
+    using (PowerShellCredentialResult result = pipeline
+        .AddScript(
+            "`$Result.Username = 'standalone-user'; " +
+            "`$Result.Password = 'standalone-fixture'")
+        .InvokeCredentialResult())
+    {
+        Require(
+            result.Username == "standalone-user" &&
+            result.Password is not null &&
+            result.Password.Length == "standalone-fixture".Length,
+            "The standalone credential result invocation did not create an isolated runspace.");
+    }
+
     using (PowerShell pipeline = session.CreatePowerShell())
     using (PowerShellCredentialResult result = pipeline
         .AddScript(

--- a/tests/Verify-PwshFfiApiBaseline.ps1
+++ b/tests/Verify-PwshFfiApiBaseline.ps1
@@ -147,6 +147,7 @@ $expectedManagedStructs = [ordered]@{
     'NativeAbiInfo' = @{ Size = 24; Fields = @('Size|0|System.UInt32', 'AbiVersion|4|System.UInt32', 'FeatureFlags|8|System.UInt64', 'MinimumCompatibleAbiVersion|16|System.UInt32', 'Reserved|20|System.UInt32') }
     'NativeUtf8Span' = @{ Size = 16; Fields = @('Data|0|System.Byte*', 'Length|8|System.UIntPtr') }
     'NativeDataValue' = @{ Size = 32; Fields = @('Size|0|System.UInt32', 'Kind|4|System.UInt32', 'Flags|8|System.UInt32', 'Reserved|12|System.UInt32', 'Data|16|System.Byte*', 'DataLength|24|System.UIntPtr') }
+    'NativeCredentialResult' = @{ Size = 104; Fields = @('Size|0|System.UInt32', 'IsCancelled|4|System.UInt32', 'Username|8|System.Byte*', 'UsernameCapacity|16|System.Int32', 'UsernameLength|20|System.Int32', 'Domain|24|System.Byte*', 'DomainCapacity|32|System.Int32', 'DomainLength|36|System.Int32', 'Password|40|System.Char*', 'PasswordCapacity|48|System.Int32', 'PasswordLength|52|System.Int32', 'OutputMessages|56|System.Byte*', 'OutputMessagesCapacity|64|System.Int32', 'OutputMessagesLength|68|System.Int32', 'ErrorMessages|72|System.Byte*', 'ErrorMessagesCapacity|80|System.Int32', 'ErrorMessagesLength|84|System.Int32', 'LogMessage|88|System.Byte*', 'LogMessageCapacity|96|System.Int32', 'LogMessageLength|100|System.Int32') }
     'NativeCallResult' = @{ Size = 48; Fields = @('Size|0|System.UInt32', 'Status|4|System.Int32', 'Flags|8|System.UInt32', 'Reserved|12|System.UInt32', 'Diagnostic|16|System.Byte*', 'DiagnosticCapacity|24|System.UIntPtr', 'DiagnosticRequired|32|System.UIntPtr', 'DiagnosticWritten|40|System.UIntPtr') }
     'NativeCapabilityRegistration' = @{ Size = 32; Fields = @('Size|0|System.UInt32', 'Flags|4|System.UInt32', 'Definitions|8|Devolutions.PowerShell.Ffi.NativeDataValue*', 'DispatchCallback|16|System.IntPtr', 'CancelCallback|24|System.IntPtr') }
     'NativeLiveObjectContractPack' = @{ Size = 40; Fields = @('Size|0|System.UInt32', 'Flags|4|System.UInt32', 'PayloadAdapterAssemblyPath|8|Devolutions.PowerShell.Ffi.NativeUtf8Span', 'PayloadAdapterTypeName|24|Devolutions.PowerShell.Ffi.NativeUtf8Span') }
@@ -359,10 +360,13 @@ $expectedObservedPresentationTableSlots = @(
 $expectedSecretAdapterTableSlots = @(
     @{ Field = 'PowerShell_InvokeSecretResult'; Rust = 'power_shell_invoke_secret_result_fn'; Alias = 'FnFfiPowerShellInvokeSecretResult'; Method = 'FfiPowerShell_InvokeSecretResult'; Signature = 'IntPtr,uint,byte*,int,int*,char*,int,int*,FfiCallResult*,int' }
 )
+$expectedCredentialResultTableSlots = @(
+    @{ Field = 'PowerShell_InvokeCredentialResult'; Rust = 'power_shell_invoke_credential_result_fn'; Alias = 'FnFfiPowerShellInvokeCredentialResult'; Method = 'FfiPowerShell_InvokeCredentialResult'; Signature = 'IntPtr,FfiCredentialResult*,FfiCallResult*,int' }
+)
 $compactFfiBindingsSource = $ffiBindingsSource -replace '\s+', ''
-$allTableSlots = @($expectedTableSlots) + @($expectedLiveTableSlots) + @($expectedTypedResultTableSlots) + @($expectedObservedInvocationTableSlots) + @($expectedSessionPreflightTableSlots) + @($expectedRuntimeDiagnosticsTableSlots) + @($expectedBrokerTableSlots) + @($expectedObservedPresentationTableSlots) + @($expectedSecretAdapterTableSlots)
+$allTableSlots = @($expectedTableSlots) + @($expectedLiveTableSlots) + @($expectedTypedResultTableSlots) + @($expectedObservedInvocationTableSlots) + @($expectedSessionPreflightTableSlots) + @($expectedRuntimeDiagnosticsTableSlots) + @($expectedBrokerTableSlots) + @($expectedObservedPresentationTableSlots) + @($expectedSecretAdapterTableSlots) + @($expectedCredentialResultTableSlots)
 $ffiApiType = $bindingsAssemblyObject.GetType('NativeHost.Bindings+FfiApiV1', $true)
-Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiType)) -Expected 720 -Description 'Managed FfiApiV1 size'
+Assert-Equal -Actual ([System.Runtime.InteropServices.Marshal]::SizeOf([Type]$ffiApiType)) -Expected 728 -Description 'Managed FfiApiV1 size'
 $ffiApiFields = @($ffiApiType.GetFields($instanceFields) | Sort-Object MetadataToken)
 $expectedFfiApiFieldNames = @('Size', 'AbiVersion', 'FeatureFlags') + @($allTableSlots | ForEach-Object { $_.Field })
 Assert-Sequence -Actual @($ffiApiFields | ForEach-Object Name) -Expected $expectedFfiApiFieldNames -Description 'Managed FfiApiV1 slot order'
@@ -374,7 +378,7 @@ for ($index = 0; $index -lt $ffiApiFields.Count; $index++) {
     Assert-Equal -Actual (Get-ManagedTypeName $field.FieldType) -Expected $expectedType -Description "Managed FfiApiV1 '$($field.Name)' type"
 }
 
-$expectedBridgeFeatures = 'FeatureFlags=(1UL<<4)|(1UL<<5)|(1UL<<6)|FfiFeatureAsyncOperationPrimitives|FfiFeatureSessionPrimitives|FfiFeatureSessionPolling|FfiFeatureSnapshotProjections|FfiFeatureSessionConfiguration|FfiFeatureSessionVariables|FfiFeatureCapabilityRpc|FfiFeatureLiveObjectProbe|FfiFeatureLiveSessionObjectProbe|FfiFeatureLiveObjectContracts|FfiFeatureLiveStreamPolling|FfiFeatureTypedResultPaging|FfiFeatureObservedInvocation|FfiFeatureSessionPreflight|FfiFeatureRuntimeDiagnostics|FfiFeatureDuplexBrokerChannel|FfiFeatureGeneratedBridgeAttachment|FfiFeatureReliableBridgeEvents|FfiFeatureObservedPresentation|FfiFeatureSecretAdapters'
+$expectedBridgeFeatures = 'FeatureFlags=(1UL<<4)|(1UL<<5)|(1UL<<6)|FfiFeatureAsyncOperationPrimitives|FfiFeatureSessionPrimitives|FfiFeatureSessionPolling|FfiFeatureSnapshotProjections|FfiFeatureSessionConfiguration|FfiFeatureSessionVariables|FfiFeatureCapabilityRpc|FfiFeatureLiveObjectProbe|FfiFeatureLiveSessionObjectProbe|FfiFeatureLiveObjectContracts|FfiFeatureLiveStreamPolling|FfiFeatureTypedResultPaging|FfiFeatureObservedInvocation|FfiFeatureSessionPreflight|FfiFeatureRuntimeDiagnostics|FfiFeatureDuplexBrokerChannel|FfiFeatureGeneratedBridgeAttachment|FfiFeatureReliableBridgeEvents|FfiFeatureObservedPresentation|FfiFeatureSecretAdapters|FfiFeatureCredentialResult'
 if (-not $compactFfiBindingsSource.Contains($expectedBridgeFeatures)) {
     throw 'Managed FfiApiV1 feature flags no longer advertise the checked bridge capabilities.'
 }
@@ -413,7 +417,8 @@ $expectedRustApiTableFields = @('size', 'abi_version', 'feature_flags') +
     @($expectedRuntimeDiagnosticsTableSlots | ForEach-Object Rust) +
     @($expectedBrokerTableSlots | ForEach-Object Rust) +
     @($expectedObservedPresentationTableSlots | ForEach-Object Rust) +
-    @($expectedSecretAdapterTableSlots | ForEach-Object Rust)
+    @($expectedSecretAdapterTableSlots | ForEach-Object Rust) +
+    @($expectedCredentialResultTableSlots | ForEach-Object Rust)
 Assert-Sequence -Actual $rustApiTableFields -Expected $expectedRustApiTableFields -Description 'Rust FfiApiV1 slot order'
 
 $rustBindingsTableMatch = [regex]::Match($rustBindingsSource, '(?s)pub\(crate\)\s+struct\s+FfiBindings\s*\{(?<body>.*?)\n\s*\}')
@@ -438,7 +443,8 @@ Assert-Sequence -Actual $rustBindingsFields -Expected (
         'runtime_diagnostics_copy_power_shell_file_version_utf8_fn|FnFfiRuntimeDiagnosticsCopyPowerShellFileVersionUtf8',
         'power_shell_set_broker_context_fn|FnFfiPowerShellSetBrokerContext',
         'power_shell_set_bridge_context_fn|FnFfiPowerShellSetBridgeContext',
-        'power_shell_invoke_secret_result_fn|FnFfiPowerShellInvokeSecretResult'
+        'power_shell_invoke_secret_result_fn|FnFfiPowerShellInvokeSecretResult',
+        'power_shell_invoke_credential_result_fn|FnFfiPowerShellInvokeCredentialResult'
     )
 ) -Description 'Rust FfiBindings slot order and aliases'
 if (-not $rustFfiSource.Contains('const FEATURE_TYPED_RESULT_PAGING: u64 = 1 << 21;')) {
@@ -465,6 +471,9 @@ if (-not $rustFfiSource.Contains('const FEATURE_OBSERVED_PRESENTATION: u64 = 1 <
 if (-not $rustFfiSource.Contains('const FEATURE_SECRET_ADAPTERS: u64 = 1 << 30;')) {
     throw 'Rust native ABI must advertise secret adapter feature bit 30.'
 }
+if (-not $rustFfiSource.Contains('const FEATURE_CREDENTIAL_RESULT: u64 = 1 << 31;')) {
+    throw 'Rust native ABI must advertise credential result feature bit 31.'
+}
 
 $expectedRustFunctionAliases = @'
 FnBindingsGetFfiApiV1|unsafeextern"system"fn()->*constFfiApiV1
@@ -481,6 +490,7 @@ FnFfiPowerShellClear|unsafeextern"system"fn(PowerShellHandle,*mutFfiCallResult)-
 FnFfiPowerShellStop|unsafeextern"system"fn(PowerShellHandle,*mutFfiCallResult)->i32
 FnFfiPowerShellInvokeToResult|unsafeextern"system"fn(PowerShellHandle,*mutPowerShellHandle,*mutFfiCallResult)->i32
 FnFfiPowerShellInvokeSecretResult|unsafeextern"system"fn(PowerShellHandle,u32,*mutu8,i32,*muti32,*mutu16,i32,*muti32,*mutFfiCallResult)->i32
+FnFfiPowerShellInvokeCredentialResult|unsafeextern"system"fn(PowerShellHandle,*mutFfiCredentialResult,*mutFfiCallResult)->i32
 FnFfiInvocationResultRelease|unsafeextern"system"fn(PowerShellHandle,*mutFfiCallResult)->i32
 FnFfiInvocationResultGetInfo|unsafeextern"system"fn(PowerShellHandle,*mutu32,*muti32,*mutFfiCallResult)->i32
 FnFfiInvocationResultGetStreamInfo|unsafeextern"system"fn(PowerShellHandle,i32,*muti32,*mutu32,*mutFfiCallResult)->i32


### PR DESCRIPTION
## Summary
- add the bounded, redacted `PowerShellCredentialResult` sink and `PowerShell.InvokeCredentialResult()` API required by the RDM NativeAOT credential resolver
- restore safe `PowerShellSecret` transfer APIs and explicitly register `ConvertToSecureStringCommand` for controlled default sessions
- extend the required V1 C#/Rust binding table, update baselines/docs, and cover NativeAOT package consumption

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo build --all-targets`
- `cargo test --all-targets`
- binding/SDK builds and binding tests
- FFI API baseline verification
- staged NativeAOT package-consumer smoke

The local installed PowerShell payload has stale bindings; package smoke used a disposable staged payload overlay without modifying it.